### PR TITLE
issue #7 Fixed params for Requestor.encode_none()

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -142,7 +142,7 @@ class Requestor(object):
     out.append((key, utc_timestamp))
 
   @classmethod
-  def encode_none(cls, out, key):
+  def encode_none(cls, out, key, none_value):
     pass # do not include None-valued params in request
 
   @classmethod


### PR DESCRIPTION
Requestor.encode_none() now takes a value since the value is passed in when it is called.
