### PR TITLE
Change docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ print shipment.postage_label.label_url
 Documentation
 -------------
 
-Up-to-date documentation at: https://www.geteasypost.com/docs
+Up-to-date documentation at: https://www.easypost.com/docs
 
 Tests
 -----


### PR DESCRIPTION
I think that this URL has possibly changed? If not then the SSL certificate is broken / invalid. The URL provided here seems to be working.
