### PR TITLE
Fix encoding errors with non-ASCII characters.

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -123,8 +123,8 @@ class Requestor(object):
 
     @classmethod
     def _utf8(cls, value):
-        if hasattr(value, 'decode'):
-            return value.decode('utf-8').encode('utf-8')
+        if isinstance(value, six.text_type):
+            return value.encode('utf-8')
         else:
             return value
 


### PR DESCRIPTION
When creating an address with fields that contain extended latin characters, I was getting a UnicodeEncodeError at this spot.  This fix correctly encodes unicode text to UTF-8.  