### PR TITLE
handle attempts to retrieve a resource with an easypost_id string containing 'id' substring

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -455,7 +455,10 @@ class Resource(EasyPostObject):
 
     @classmethod
     def retrieve(cls, easypost_id, api_key=None, **params):
-        easypost_id = easypost_id["id"] if "id" in easypost_id else easypost_id
+        try:
+            easypost_id = easypost_id['id']
+        except (KeyError, TypeError):
+            pass
 
         instance = cls(easypost_id, api_key, **params)
         instance.refresh()


### PR DESCRIPTION
If the easypost_id is passed as a string and that string includes "id" as a substring, then the if will return True but the string will raise a TypeError when accessed with the nonnumeric index of "id".

This PR attempts to account for that without reverting all the way back to catching a naked exception.