### PR TITLE
Add language classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,10 @@ setup(
     packages=['easypost'],
     package_data={'easypost': ['../VERSION']},
     install_requires=install_requires,
-    test_suite='test'
+    test_suite='test',
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3"
+    ]
 )


### PR DESCRIPTION
Without a Python3 classifier the tool `caniusepython3` will erroneously flag this package as not supporting Python 3.

You probably want to add more classifiers (see [PayPal-Python-SDK](https://github.com/paypal/PayPal-Python-SDK/blob/master/setup.py) for examples) to help make the package easier to find on PyPI.