### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EasyPost Python Client Library
 
-[![Build Status](https://travis-ci.org/EasyPost/easypost-python.svg?branch=master)](https://travis-ci.org/EasyPost/easypost-python)
+[![Build Status](https://travis-ci.org/EasyPost/easypost-python.svg?branch=master)](https://travis-ci.org/EasyPost/easypost-python) [![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/EasyPostTracking/functions?utm_source=EasyPostGithub&utm_medium=button&utm_content=Vender_GitHub)
 
 EasyPost is the simple shipping API. You can sign up for an account at <https://easypost.com>.
 


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out EasyPost API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!