### PR TITLE
Support using a custom timeout for requests

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -18,9 +18,13 @@ version_info = tuple(int(v) for v in VERSION.split('.'))
 
 # use urlfetch as request_lib on google app engine, otherwise use requests
 request_lib = None
+# use a max timeout equal to that of all customer-facing backend operations
+_max_timeout = 90
 try:
     from google.appengine.api import urlfetch
     request_lib = 'urlfetch'
+    # use the GAE application-wide "deadline" (or its default) if it's less than our existing max timeout
+    _max_timeout = min(urlfetch.get_default_fetch_deadline() or 60, _max_timeout)
 except ImportError:
     try:
         import requests
@@ -47,7 +51,8 @@ except ImportError:
 # config
 api_key = None
 api_base = 'https://api.easypost.com/v2'
-timeout = 60
+# use our default timeout, or our max timeout if that is less
+timeout = min(60, _max_timeout)
 
 
 USER_AGENT = 'EasyPost/v2 PythonClient/{0}'.format(VERSION)
@@ -294,6 +299,9 @@ class Requestor(object):
             'Content-type': 'application/x-www-form-urlencoded'
         }
 
+        if timeout > _max_timeout:
+            raise Error("`timeout` must not exceed %d; it is %d" % (_max_timeout, timeout))
+
         if request_lib == 'urlfetch':
             http_body, http_status = self.urlfetch_request(method, abs_url, headers, params)
         elif request_lib == 'requests':
@@ -355,7 +363,7 @@ class Requestor(object):
         args['method'] = method
         args['headers'] = headers
         args['validate_certificate'] = False
-        args['deadline'] = 55  # GAE times out after 60
+        args['deadline'] = timeout
 
         try:
             result = urlfetch.fetch(**args)

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -47,6 +47,7 @@ except ImportError:
 # config
 api_key = None
 api_base = 'https://api.easypost.com/v2'
+timeout = 60
 
 
 USER_AGENT = 'EasyPost/v2 PythonClient/{0}'.format(VERSION)
@@ -330,7 +331,7 @@ class Requestor(object):
                 abs_url,
                 headers=headers,
                 data=data,
-                timeout=60,
+                timeout=timeout,
                 verify=True,
             )
             http_body = result.text


### PR DESCRIPTION
This change adds support for using a custom timeout. It can be set similar to how `api_key` is set.

```
import easypost
easypost.api_key = '<YOUR API KEY>'
easypost.timeout = 30
```