### PR TITLE
Make no rates found error optional

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -753,13 +753,13 @@ class Shipment(AllResource, CreateResource):
             carriers = carriers.split(',')
         except AttributeError:
             pass
-        carriers = [c.lower() for c in carriers]
+        carriers = set([c.lower() for c in carriers])
 
         try:
             services = services.split(',')
         except AttributeError:
             pass
-        services = [service.lower() for service in services]
+        services = set([service.lower() for service in services])
 
         for rate in self.rates:
             rate_carrier = rate.carrier.lower()

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -743,7 +743,7 @@ class Shipment(AllResource, CreateResource):
         self.refresh_from(response, api_key)
         return self
 
-    def lowest_rate(self, carriers=None, services=None):
+    def lowest_rate(self, carriers=None, services=None, raise_error=True):
         carriers = carriers or []
         services = services or []
 
@@ -773,7 +773,7 @@ class Shipment(AllResource, CreateResource):
             if lowest_rate is None or float(rate.rate) < float(lowest_rate.rate):
                 lowest_rate = rate
 
-        if lowest_rate is None:
+        if lowest_rate is None and raise_error:
             raise Error('No rates found.')
 
         return lowest_rate


### PR DESCRIPTION
It is unnecessary to always raise error if no rates could be found.  Raising error made it inconvenient to use as you were required to have a redundant wrapper around the possible error.