### PR TITLE
fix install_requires typo that prevented 'six' from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ except ImportError:
     from distutils.core import setup
 
 install_requires = [
-    'requests >= 1.0.0'
+    'requests >= 1.0.0',
     'six'
 ]
 


### PR DESCRIPTION
The 'setup.py' didn't separate the install_requires list arguments with a comma. I believe that is what was preventing the 'six' library from being installed by pip