### PR TITLE
attempt to add python 3.7 and pypy3.5 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "pypy"
+matrix:
+  include:
+    - python: "2.7"
+    - python: "3.4"
+    - python: "3.5"
+    - python: "3.6"
+    - python: "pypy"
+    - python: "pypy3.5"
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   - "pip install six requests"
   - "pip install -r requirements-tests.txt"


### PR DESCRIPTION
replaces #73 