### PR TITLE
Fix unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ test
 virtualenv
 .virtualenv
 .idea
+.coverage

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,12 +1,10 @@
 # Unit tests related to 'Batch' (https://www.easypost.com/docs/api#batches).
 
 import easypost
-
 from time import sleep
 
-
 def test_batch_create_and_buy():
-    # We create Address and Parcel objects. We then try to create a Batch containing a shipment. Finally,
+    # We create Address and Parcel objects. We then try to create a Batch containing a shipment.
     # Finally, we assert on saved and returned data.
 
     # from address and parcel don't change
@@ -75,7 +73,7 @@ def test_batch_create_and_buy():
 
     # Assert on fees
     assert batch.shipments[0].fees[0].amount == '0.01000'
-    assert batch.shipments[0].fees[1].amount == '7.65000'
+    assert batch.shipments[0].fees[1].amount == '7.68000'
     assert batch.shipments[0].fees[2].amount == '1.00000'
 
     # Assert on parcel

--- a/tests/test_pickup.py
+++ b/tests/test_pickup.py
@@ -2,14 +2,11 @@
 
 import time
 import datetime
-
 import easypost
 import pytest
 import pytz
 
-
 ONE_DAY = datetime.timedelta(days=1)
-
 
 @pytest.fixture
 def noon_on_next_monday():
@@ -18,18 +15,19 @@ def noon_on_next_monday():
     noon_est = datetime.time(12, 0, tzinfo=pytz.timezone('America/New_York'))
     return datetime.datetime.combine(next_monday, noon_est)
 
-
 def test_pickup_batch(noon_on_next_monday):
     # Create a Batch containing multiple Shipments. Then we try to buy a Pickup and assert if it was bought.
 
     pickup_address = easypost.Address.create(
         verify=['delivery'],
-        name='Jarrett Streebin',
+        name='TAKASHI KOVACS',
         company='EasyPost',
-        street1='1 MONTGOMERY ST STE 400',
-        city='San Francisco',
-        state='CA',
-        zip='94104',
+        street1='2889 W ASHTON BLVD',
+        street2='SUITE 325',
+        city='Lehi',
+        state='UT',
+        zip='84042',
+        country='US',
         phone='415-456-7890'
     )
 
@@ -102,18 +100,19 @@ def test_pickup_batch(noon_on_next_monday):
         service=pickup.pickup_rates[0].service
     )
 
-
 def test_single_pickup(noon_on_next_monday):
     """Create a Shipment, buy it, and then buy a pickup for it"""
 
     pickup_address = easypost.Address.create(
         verify=['delivery'],
-        name='Jarrett Streebin',
+        name='TAKASHI KOVACS',
         company='EasyPost',
-        street1='1 MONTGOMERY ST STE 400',
-        city='San Francisco',
-        state='CA',
-        zip='94104',
+        street1='2889 W ASHTON BLVD',
+        street2='SUITE 325',
+        city='Lehi',
+        state='UT',
+        zip='84042',
+        country='US',
         phone='415-456-7890'
     )
 
@@ -144,7 +143,7 @@ def test_single_pickup(noon_on_next_monday):
         instructions='Special pickup instructions'
     )
 
-    assert pickup.pickup_rates != []
+    assert pickup.pickup_rates != [], pickup.messages
 
     pickup.buy(
         carrier=pickup.pickup_rates[0].carrier,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,13 +1,17 @@
 # Unit tests related to 'Report's (https://www.easypost.com/docs/api.html#reports).
 
 import easypost
+from datetime import date
 
+# Use the current date to avoid needing to define a new date manually on each test
+today = date.today()
+testdate = today.strftime("%Y/%m/%d")
 
 def test_shipment_report():
     report = easypost.Report.create(
         type="shipment",
-        start_date="2012-12-01",
-        end_date="2013-01-01",
+        start_date=testdate,
+        end_date=testdate,
     )
 
     assert report.object == "ShipmentReport"


### PR DESCRIPTION
It's been some time since unit tests were run and some items have changed making a few fail. The following changes are fixes to bring unit tests into the current state of the EasyPost API and carrier requirements so unit tests will pass once again.