### PR TITLE
Closes #95 - Closes the VERSION file

### DIFF
--- a/easypost/version.py
+++ b/easypost/version.py
@@ -1,7 +1,8 @@
 import pkg_resources
 
-
-VERSION = pkg_resources.resource_stream('easypost', '../VERSION').read().decode('utf-8').strip()
+VERSION_FILE = pkg_resources.resource_stream('easypost', '../VERSION')
+VERSION = VERSION_FILE.read().decode('utf-8').strip()
+VERSION_FILE.close()
 
 if '-' in VERSION:
     VERSION_INFO = tuple([int(v) for v in VERSION.split('-')[0].split('.')] + VERSION.split('-')[1:])


### PR DESCRIPTION
An issue was reported about how the VERSION file stays open and is not closed. For best practice sake and to correct the warning, I put a fix in place that closes the file after we access the contents and assign to a variable. Closes #95 .