### PR TITLE
fix tests and update pytest to latest 2.x-compatible version

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,3 +1,3 @@
-pytest==3.0.6
-pytest-cov==2.4.0
+pytest==4.6.*
+pytest-cov==2.8.1
 pytz

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -3,6 +3,7 @@
 import easypost
 from time import sleep
 
+
 def test_batch_create_and_buy():
     # We create Address and Parcel objects. We then try to create a Batch containing a shipment.
     # Finally, we assert on saved and returned data.
@@ -72,7 +73,7 @@ def test_batch_create_and_buy():
     assert batch.shipments[0].buyer_address.street1 == '388 Townsend St'
 
     # Assert on fees
-    assert batch.shipments[0].fees[0].amount == '0.01000'
+    assert batch.shipments[0].fees[0].amount == '0.00000'
     assert batch.shipments[0].fees[1].amount == '7.68000'
     assert batch.shipments[0].fees[2].amount == '1.00000'
 

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -1,6 +1,9 @@
 # Unit tests related to 'Shipments' (https://www.easypost.com/docs/api#shipments).
 
+import time
+
 import easypost
+import pytest
 
 
 def test_shipment_creation():
@@ -67,12 +70,6 @@ def test_shipment_creation():
     rate_id = shipment.rates[0].id
     assert rate_id is not None
 
-    shipment.get_rates()
-
-    new_rate_id = shipment.rates[0].id
-    assert new_rate_id is not None
-    assert new_rate_id != rate_id
-
     # Assert address values match
     assert shipment.buyer_address.country == to_address.country
     assert shipment.buyer_address.phone == to_address.phone
@@ -98,3 +95,78 @@ def test_shipment_creation():
     assert shipment.insurance == '100.00'
 
     assert 'https://easypost-files.s3-us-west-2.amazonaws.com' in shipment.postage_label.label_url
+
+
+@pytest.mark.slow
+def test_rerate():
+    # We create a shipment and assert on values saved.
+
+    # create a to address and a from address
+    to_address = easypost.Address.create(
+        name="Sawyer Bateman",
+        street1="1A Larkspur Cres.",
+        street2="",
+        city="St. Albert",
+        state="AB",
+        zip="t8n2m4",
+        country="CA",
+        phone="780-283-9384"
+    )
+    from_address = easypost.Address.create(
+        company="EasyPost",
+        street1="118 2nd St",
+        street2="4th Fl",
+        city="San Francisco",
+        state="CA",
+        zip="94105",
+        phone="415-456-7890"
+    )
+
+    # create a parcel
+    parcel = easypost.Parcel.create(
+        length=10.2,
+        width=7.8,
+        height=4.3,
+        weight=21.2
+    )
+
+    # create customs_info form for intl shipping
+    customs_item = easypost.CustomsItem.create(
+        description="EasyPost t-shirts",
+        hs_tariff_number=123456,
+        origin_country="US",
+        quantity=2,
+        value=96.27,
+        weight=21.1
+    )
+    customs_info = easypost.CustomsInfo.create(
+        customs_certify=1,
+        customs_signer="Hector Hammerfall",
+        contents_type="gift",
+        contents_explanation="",
+        eel_pfc="NOEEI 30.37(a)",
+        non_delivery_option="return",
+        restriction_type="none",
+        restriction_comments="",
+        customs_items=[customs_item]
+    )
+
+    # create shipment
+    shipment = easypost.Shipment.create(
+        to_address=to_address,
+        from_address=from_address,
+        parcel=parcel,
+        customs_info=customs_info
+    )
+
+    rate_id = shipment.rates[0].id
+    assert rate_id is not None
+
+    # we only rerate on get_rates calls for shipments made at least 60 seconds ago
+    time.sleep(61)
+
+    shipment.get_rates()
+
+    new_rate_id = shipment.rates[0].id
+    assert new_rate_id is not None
+    assert new_rate_id != rate_id


### PR DESCRIPTION
Fixes an issue with 1¢ rates (see https://www.easypost.com/pricing for current pricing).

Fixes an issue with rerating. Amusingly, while we didn't have any backend tests on the bizarro write-on-GET `/rates` behavior, we _did_ test it in this client library. What a weird world.