### PR TITLE
Swap GET to POST on Refund method

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -734,7 +734,7 @@ class Shipment(AllResource, CreateResource):
         requestor = Requestor(self._api_key)
         url = "%s/%s" % (self.instance_url(), "refund")
 
-        response, api_key = requestor.request('get', url, params)
+        response, api_key = requestor.request('post', url, params)
         self.refresh_from(response, api_key)
         return self
 


### PR DESCRIPTION
Our docs say to use POST for refunds but the CL uses GET. It works as there are not params to pass but it should probably match for clarity and uniformity.

Closes #105 
