### PR TITLE
add new regenerate_rates method corresponding to the new rerate api

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -721,6 +721,13 @@ class Shipment(AllResource, CreateResource):
         response, api_key = requestor.request('get', url, params)
         return response
 
+    def regenerate_rates(self):
+        requestor = Requestor(self._api_key)
+        url = "%s/%s" % (self.instance_url(), "rerate")
+        response, api_key = requestor.request('post', url)
+        self.refresh_from(response, api_key)
+        return self
+
     def get_rates(self):
         requestor = Requestor(self._api_key)
         url = "%s/%s" % (self.instance_url(), "rates")

--- a/tests/cassettes/test_rerate.yaml
+++ b/tests/cassettes/test_rerate.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode address%5Bcity%5D=St.+Albert&address%5Bcountry%5D=CA&address%5Bname%5D=Sawyer+Bateman&address%5Bphone%5D=780-283-9384&address%5Bstate%5D=AB&address%5Bstreet1%5D=1A+Larkspur+Cres.&address%5Bstreet2%5D=&address%5Bzip%5D=t8n2m4
+    body: address%5Bcity%5D=St.+Albert&address%5Bcountry%5D=CA&address%5Bname%5D=Sawyer+Bateman&address%5Bphone%5D=780-283-9384&address%5Bstate%5D=AB&address%5Bstreet1%5D=1A+Larkspur+Cres.&address%5Bstreet2%5D=&address%5Bzip%5D=t8n2m4
     headers:
       Accept:
       - '*/*'
@@ -23,12 +23,12 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4SQMXODMAyF/wrnOcmBgeCwkazd2qkLJ2zl6hYMJ0Rbmst/r5xeOnTpZul9enry
-        RXmnagWO2rzQXb6Hau8qU2iddsbuc3dILWau6rpCbdTYvaJl4RvnCOdZWpYQGF0Lsa1TnW7Tcptl
-        Tzqry6ouzbMwy+T+ZQIMKOojfKxIyVH4AUL0H4cJwqrqsPT9Rs1MiJwJmTXJA9DbPC2UnCTMTt1V
-        LWqc9LxGR94lTd8h8Q0Q45j/KMWXn+TJJuihuG1aAlMcOTVSTi9jiGhlUm3yQ24iI6F8f88yjC4C
-        jHO0tkDkkdozWN/fVv9QEs07DOzhd/CMDgn6luGzjd9/P02y/em9I/mzt8B+DLOqL9frNwAAAP//
-        AwBjEXDXsQEAAA==
+        H4sIAAAAAAAAA4yRPVPDMAyG/0rOK21PdvqRZEu7ssGeU2z1MCROTnGA0ut/Rw5XBiY2fTyv9Op0
+        Vd6pSqHjRu/Blrok0+a7Le2g3Lc7agFbKFGD1WqlhvaVbBS+do5pmqRkmTCSazCVDRi9BrOG/Bmg
+        0ocKtg8SAAg4j+5/YMCeBHnCjwtxdhRRjyFtGvoRw0VVYe66lZoiE0UtpK6zR+S3aZw5O4mtjbp3
+        jXST0sdLmhg3Wd21xHEBZHC65CjJlx8ljEUw/XbZNIfISXKqJR1fhpDQQwGmyMu8SIyY8t3dSz+4
+        BESa0miLzJ64OaP13bL6hxJr3lGIHn+FZ3LE2DURP5v0iPtp4u1P7Z3Yn73F6Icwqep6u30DAAD/
+        /wMAqVIfpbsBAAA=
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -39,7 +39,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/addresses/adr_342b36a76d784220b8c63d90ce1d7bb4
+      - /api/v2/addresses/adr_160c919e2b354e5096b5eb0ab09a10c1
       pragma:
       - no-cache
       strict-transport-security:
@@ -51,26 +51,26 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - c805095b5eb9ca66fb56ed6a00084369
+      - 2ebf75b86019eb80ee4cfaf400001f2f
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6sj
+      - bigweb1nuq
       x-proxied:
-      - intlb2sj 5834894b53
-      - intlb2wdc 5834894b53
-      - extlb1wdc 5834894b53
+      - intlb1nuq 9cd9455ca9
+      - intlb2wdc 9cd9455ca9
+      - extlb2wdc 9cd9455ca9
       x-runtime:
-      - '0.040120'
+      - '0.026269'
       x-version-label:
-      - easypost-202005112100-59b664a857-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode address%5Bcity%5D=San+Francisco&address%5Bcompany%5D=EasyPost&address%5Bphone%5D=415-456-7890&address%5Bstate%5D=CA&address%5Bstreet1%5D=118+2nd+St&address%5Bstreet2%5D=4th+Fl&address%5Bzip%5D=94105
+    body: address%5Bcity%5D=San+Francisco&address%5Bcompany%5D=EasyPost&address%5Bphone%5D=415-456-7890&address%5Bstate%5D=CA&address%5Bstreet1%5D=118+2nd+St&address%5Bstreet2%5D=4th+Fl&address%5Bzip%5D=94105
     headers:
       Accept:
       - '*/*'
@@ -93,12 +93,12 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4SQwU7DMAyGX6XKmUlJl2xtbxNiZ6TBhUvlxa4W1CZVkiHGtHfHKQIkLtziT9/v
-        /PJVOBSdAIw91K1stG6PZt3ojUZA1GDo2NAwyGG9EXciHF/JZvZ3iJFSYmQjQSbsoeBa1nIlzUqp
-        p1p1ZtuZ5oWd84z/Oh4mEp0/jyPvDNMM/sLyA6TLY0iZhZQjUVYMlWqq2mN1+MU1Y51P1X4slVwu
-        2QP4ah/BW5dsWEwuwfx+x8OHm/nZaiVNSYSzz7GEng88zqfgi6mV0WazbVrJkCZw43fDKWARMi3V
-        LMToKPYDWDcun39ZfCKH5LODn+BASBHGPsN7Xy7/RZdqf9gbRTc4C9kFn0R3vd0+AQAA//8DAB08
-        CBysAQAA
+        H4sIAAAAAAAAA4yRy2rDMBBFf8Vo2wZGjhw/dqE060LatRlLE6JgS0ZSStOQf+/IoS101d3M4Vzp
+        Il2FNaITaEJfNThIvWlrA4Oqm6GVVQPSrFuAWlW6FI/CDyfSif2tMYFiZKQDYSLTY8YllHIF5QrW
+        rwCdrDtQDzwAsHiezf9EhxOJzp3HkU/304zuwolnjJcXHxMLMQWiJBlK2RSlM8X+F5eMVToWuzGX
+        syln9+iKXUCnbdR+MbkJ86ctL5925rFVEqqc8GeXQg697Xmdj95lU8lKVZu6aXNBmtCO3w0nb7KQ
+        aKmmMQRLoT+gtuNy+d3ix7KGXLL4EzyQoYBjn/Cjz39wp0u1P+ydgj1Yjcl6F0V3vd2+AAAA//8D
+        AGigh1O2AQAA
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -109,7 +109,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/addresses/adr_a2908449b538464dadd4a5eb8eff0f36
+      - /api/v2/addresses/adr_58ab1c697d0b478b915801d3900745c2
       pragma:
       - no-cache
       strict-transport-security:
@@ -121,26 +121,26 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - c805095b5eb9ca66fb56ed6a0008437d
+      - 2ebf75b86019eb80ee4cfaf400001f3c
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2sj
+      - bigweb9nuq
       x-proxied:
-      - intlb2sj 5834894b53
-      - intlb1wdc 5834894b53
-      - extlb1wdc 5834894b53
+      - intlb2nuq 9cd9455ca9
+      - intlb2wdc 9cd9455ca9
+      - extlb2wdc 9cd9455ca9
       x-runtime:
-      - '0.030513'
+      - '0.029734'
       x-version-label:
-      - easypost-202005112146-47e058b20a-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode parcel%5Bheight%5D=4.3&parcel%5Blength%5D=10.2&parcel%5Bweight%5D=21.2&parcel%5Bwidth%5D=7.8
+    body: parcel%5Bheight%5D=4.3&parcel%5Blength%5D=10.2&parcel%5Bweight%5D=21.2&parcel%5Bwidth%5D=7.8
     headers:
       Accept:
       - '*/*'
@@ -163,10 +163,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4SOyw6CMBBF/2XWhXSG1kq/woUrN6SPEdAKBEtcGP/dkrh3OfeeczNvGCNYWNaQ
-        uojKaJSSGjwo76jVinTwsnU+mMYrEDD7G4dchJNbA6eShJVd5ti5PSVJspK6QjwTWm2sbi+F2Zb4
-        l0k89XkAi7ImAa8x7oepjwIGHvuhmKpuRHmUI1/HqawtLtxdz2CnLaWi/DDCfeAxx9JA5meGzxcA
-        AP//AwA0A4BT5QAAAA==
+        H4sIAAAAAAAAA4SOuw7CMAxF/8VzqJwHDeQrGJhYKtcxbSG0VUnFgPh3Uomd0feec+U3DBECzAun
+        xrIn63XbstTOG0+mluix3gsemdiBgqm9CecinGhhSSXhRShLbGhLDRq9Q7NDe0YM2gd0l8Ksc/zL
+        JBm73EPQWBkFryFuh68OCnoZur6YrrKqPCpRrsNY1mbiO3UCYVxTKsoPM3obeEyxNJDlmeHzBQAA
+        //8DACHqQWrlAAAA
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -177,7 +177,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/parcels/prcl_d147510023164ba295425cb09abc73b4
+      - /api/v2/parcels/prcl_3c7a371bbce64727a26ed7065e09cac4
       pragma:
       - no-cache
       strict-transport-security:
@@ -186,31 +186,29 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - c805095b5eb9ca66fb56ed6a0008438d
+      - 2ebf75b86019eb80ee4cfaf400001f4b
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7sj
+      - bigweb6nuq
       x-proxied:
-      - intlb2sj 5834894b53
-      - intlb2wdc 5834894b53
-      - extlb1wdc 5834894b53
+      - intlb1nuq 9cd9455ca9
+      - intlb2wdc 9cd9455ca9
+      - extlb2wdc 9cd9455ca9
       x-runtime:
-      - '0.042947'
+      - '0.076211'
       x-version-label:
-      - easypost-202005112146-47e058b20a-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode customs_item%5Bdescription%5D=EasyPost+t-shirts&customs_item%5Bhs_tariff_number%5D=123456&customs_item%5Borigin_country%5D=US&customs_item%5Bquantity%5D=2&customs_item%5Bvalue%5D=96.27&customs_item%5Bweight%5D=21.1
+    body: customs_item%5Bdescription%5D=EasyPost+t-shirts&customs_item%5Bhs_tariff_number%5D=123456&customs_item%5Borigin_country%5D=US&customs_item%5Bquantity%5D=2&customs_item%5Bvalue%5D=96.27&customs_item%5Bweight%5D=21.1
     headers:
       Accept:
       - '*/*'
@@ -233,11 +231,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4SPsU7EMAyGXwVlbk9NrmmbroiBDQlYWKo0ca9BTXIkDqhCvDsu9wBstr/Psv9v
-        5iwbmcnoEPykzobzxYhhGHRrJaiuU3Kem1ZJLnhvWcXi/A4Gaee+ZIw+P9IejU0CjWAnfSDRiKZu
-        ZM35i+Cj7Eep3sgpV/uvYyGb5K7oYiDpQef9KWa8wzqvLmEmY80T6uSWZQrFz5BI4+Lcyu54LrmL
-        C5OJJWDaibw+0/Sj6ED5qBcV+9RbASKqO4me4Be4y0oPCX7iFCNagqFsW8X8X80QMpLndSiLNljS
-        cfJmmJISBLPf+p9fAAAA//8DAAtU4A9NAQAA
+        H4sIAAAAAAAAA4SPPU/EMAyG/wrK3J7SpB/XroiBDQlYWKrU8V1zapMjcUAV4r/jcmJms/08lv1+
+        CWfFICCRI1xHA313bHV/lFbVYLVRU6OlqmvdT1OjpChEmC4IxDv3OVFY0yPv8RgiGkI7mh0pqapS
+        qlLqFymHqhtk/cZOvtp/HYsJoruSC56lB5O2p5Dojso0u0iJjTmNZKI7nUaf1wkja5XSddPuz0V3
+        dn6EkD3FjcnrM0/fs/Gcj3tViA+zZGTStwfVMfxEd575IVUdKo4RLEOfl6UQ628tCBOxtxqfTwYo
+        x/3kzYAcI3rY/noE8Lf6+wcAAP//AwBt7Ev/WQEAAA==
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -248,7 +246,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/customs_items/cstitem_93c11fc2888a4d5e96695bb04951217d
+      - /api/v2/customs_items/cstitem_ac97863980d24cd3a2b53024439bb520
       pragma:
       - no-cache
       strict-transport-security:
@@ -260,26 +258,26 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - c805095b5eb9ca67fb56ed6a0008439b
+      - 2ebf75b86019eb80ee4cfaf400001f53
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8sj
+      - bigweb3nuq
       x-proxied:
-      - intlb2sj 5834894b53
-      - intlb1wdc 5834894b53
-      - extlb1wdc 5834894b53
+      - intlb2nuq 9cd9455ca9
+      - intlb2wdc 9cd9455ca9
+      - extlb2wdc 9cd9455ca9
       x-runtime:
-      - '0.033445'
+      - '0.025237'
       x-version-label:
-      - easypost-202005112146-47e058b20a-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode customs_info%5Bcontents_explanation%5D=&customs_info%5Bcontents_type%5D=gift&customs_info%5Bcustoms_certify%5D=1&customs_info%5Bcustoms_items%5D%5B0%5D%5Bid%5D=cstitem_93c11fc2888a4d5e96695bb04951217d&customs_info%5Bcustoms_signer%5D=Hector+Hammerfall&customs_info%5Beel_pfc%5D=NOEEI+30.37%28a%29&customs_info%5Bnon_delivery_option%5D=return&customs_info%5Brestriction_comments%5D=&customs_info%5Brestriction_type%5D=none
+    body: customs_info%5Bcontents_explanation%5D=&customs_info%5Bcontents_type%5D=gift&customs_info%5Bcustoms_certify%5D=1&customs_info%5Bcustoms_items%5D%5B0%5D%5Bid%5D=cstitem_ac97863980d24cd3a2b53024439bb520&customs_info%5Bcustoms_signer%5D=Hector+Hammerfall&customs_info%5Beel_pfc%5D=NOEEI+30.37%28a%29&customs_info%5Bnon_delivery_option%5D=return&customs_info%5Brestriction_comments%5D=&customs_info%5Brestriction_type%5D=none
     headers:
       Accept:
       - '*/*'
@@ -302,14 +300,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6xSTY/TMBD9K1VOILVV7MRJ0yuqtHsBJOACQtbEHrdGiR38sVCt9r8zpl11kZC4
-        cJz3ZsZv3vNjZXW1r1RM1hkvjajbAbQCIfpWiRE0B66h043ifav7al358RuqRDNvckx+jvc0R7AK
-        CAm1hELxmtebWmwY+8jZXvR7MXymnrzof/Yo7xK6FCX+XCZwkKx31P2SSecFCTpakwp8kSEVhmTN
-        udqnkPEGR3t0GKj9jlT7sLqDecZgYJpoFnGSi1HEvn13ONyvmnrb9K/gNVHOO6lxsg8YztIvVxkB
-        Uw6O6IAxBasKLJWnlSTsIvMlc1VKu5CY2etSJWqgSqOaIFzvc3mabpptwpm2fXm8hUOIHBrFmFF8
-        t9tBqwUOXTeIcaTEBOOs138Lh+b+Yzgaowr22YwDxPN7H9MqbeLJBjJgXZ0oHgjWGOnyPP42nvGm
-        FV0RF+zRFruyS4GCqj59IPR7Bkf3Uc3X1QNMuXg0dFtePtsPtMcTCeJsy8oPKAZevPrTzBlcNqAo
-        nPLks5shoFPnS/309ekXAAAA//8DAKgWmWTsAgAA
+        H4sIAAAAAAAAA4xS0Y7TMBD8lSpPILWV4yRN0ldU6e4FkIAXELIce90aJXZY2wfR6f6d9bVVDwnp
+        eNyZ2c14Jo+F1cW+UCFaZ7zotepa3ZS9LLu6aXhX7yoJmpuO651pVbEu/PADVKSddylEP4V72iNY
+        IcgIWshMccbLDeMbVn1mbF+2e9Z8JU2a9asa5V0EF4OA3/MonYzWO1K/ZOIyA0FHa2KGzzaEAozW
+        LMU+YoIbHOzRAZL8jlx7XN3JaQI0chxpF2AUs1HEvv9wONyvKrat2jfyLVHOO6FhtA+Ai/DzxQZC
+        TOiIRggRrcqwUJ5OkrGzzZfMxSndAmImr/MUSUCTBjVKvLzPpXG8ebYRJrr27fFWDiFCqr7tdlXf
+        Mc1rpSvJh6ZivK6rfhgazv5VDu29Xk79H+U8azQEhfYaxkGG5aMPcRU34WSRAlgXJ6pHojVGuDQN
+        z8GXvKqbXTaH9mhzXMlFpKKKL58I/Zmko/fRzNfFgxxTzqjfbXlL5C+wxxMZ4uW2zH9ADvCc1d9h
+        TtIlIxWVkz95TRMRnFquMyh1Sfrp+9MfAAAA//8DAEKNxiT4AgAA
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -320,7 +318,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/customs_infos/cstinfo_f5049adca5574c5bad2a2da6d3c274d7
+      - /api/v2/customs_infos/cstinfo_9dc87d519a1845528463aed2f82d6f7c
       pragma:
       - no-cache
       strict-transport-security:
@@ -332,26 +330,26 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - c805095b5eb9ca67fb56ed6a000843a6
+      - 2ebf75b86019eb81ee4cfaf400001f67
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb10sj
+      - bigweb6nuq
       x-proxied:
-      - intlb1sj 5834894b53
-      - intlb1wdc 5834894b53
-      - extlb1wdc 5834894b53
+      - intlb1nuq 9cd9455ca9
+      - intlb1wdc 9cd9455ca9
+      - extlb2wdc 9cd9455ca9
       x-runtime:
-      - '0.046511'
+      - '0.030284'
       x-version-label:
-      - easypost-202005112100-59b664a857-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode shipment%5Bcustoms_info%5D%5Bid%5D=cstinfo_f5049adca5574c5bad2a2da6d3c274d7&shipment%5Bfrom_address%5D%5Bid%5D=adr_a2908449b538464dadd4a5eb8eff0f36&shipment%5Bparcel%5D%5Bid%5D=prcl_d147510023164ba295425cb09abc73b4&shipment%5Bto_address%5D%5Bid%5D=adr_342b36a76d784220b8c63d90ce1d7bb4
+    body: shipment%5Bcustoms_info%5D%5Bid%5D=cstinfo_9dc87d519a1845528463aed2f82d6f7c&shipment%5Bfrom_address%5D%5Bid%5D=adr_58ab1c697d0b478b915801d3900745c2&shipment%5Bparcel%5D%5Bid%5D=prcl_3c7a371bbce64727a26ed7065e09cac4&shipment%5Bto_address%5D%5Bid%5D=adr_160c919e2b354e5096b5eb0ab09a10c1
     headers:
       Accept:
       - '*/*'
@@ -374,34 +372,34 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+yZX2/bNhDAv4qhpw1IBf4XmbesTdECWxcs28uGQjiRVKJVljWKausN/e472pYj
-        p2njYt2yYgP8wuPxRN797qiT/8hs8BC9KyFmpxkjjDwi8hGlPzJ6KotTaX7OTrJmKIOPY+iy0xra
-        wZ9kSz8McOWH7PSXlzhaOY+rox8iaq/62Kw6nPojs2MIvrNrnPzp8gnO9bBe+i6mubju06LL8xdP
-        zn/I3p1kDvdRgnsNncUJgpLga5/W47Ab2/YkGyLEES1nY/eqW73p0GIMYF813VVpN5vY6o29u/dQ
-        FUR7XTZuWrMdT0+Yy3aHnYR2HOJqOZRNV6/SQZKJzA4xjctaEmHAWZCyEFZW4BgwB8pxywrhiuSf
-        6ldv08Yebw09T3ZOjgrEMeeyqy6ii4fSv+1b6CAFA7XnMzvXXzV1itd0HutDbGqMVQyjvxEPzVXn
-        A6o/w12vwuIZLJc+IActrvW+Lfva4uyL78/Pny84yXnxFXyNU92qK51vm9c+rMstE6i24yjFdoih
-        sUmMoVsmKobtNuczu52iLZ/d5sx520LYne9WaKJfJjZnwUFJabiltLZMaw3CSW+UMrKqMGKSMlq4
-        u4KD6z5jcJwfbGgmZ5zDsL5YDXERHw3XTUAHnGTXGB4ITV2X3bisNo6njAup0uZCc9Ukd41dDNuk
-        QulvI3R4Phyzk+w1tGPykVE5S7C98c3VNW6I0ZwmAm5y5NCZS+jGGiwGJz1y8uaUvWn87iVmZB1W
-        S8xRhzEa9uyDCyUwQ7QQppJcCyUc6giQvtK+rknN1dy1Z7v197pVH+HWjU4Hy5v0XC176NYz92ap
-        cATvI03OpHrBOre4vBEzFIt4vXiaiLYbT2aX0C2eBixFzWBX2bbyJHc9PsPB702fXCwokZu0OghH
-        f51gRYtUYtQKbUjKkyU07d2etxBC40OJ3m/azcO3WuiixmFWNLBfWHvnA7QIyNtZ4dps7ZYMk66p
-        GwtTJX6HsWu6YQwwq6argOZmi3oI1rf7sPbBtqWjopCUEMapEhVGWQombUUMVLbglZjH9WK7/vNl
-        S+u7q3idnVKSI9pvGpcGRa4xS3ZYi5zjvgP6pW46tNbjZTAr1TP62aHf0R89ooG6ZQuV37sY64mf
-        VY40LJkVBTcUf5oLXQtgvLI1CG0lU1AcsP1DwuTjHtCnhNzngUnnEJXBh9dNil92ERosBnH9HWL1
-        HKt62NZ5aG+A2vB4kYgMW3R5kXORnbx/KWNNRjPlpGZyTm6k72m3zRDLWyY3svc099XfwXp/pc6E
-        0d8pLK9GLOt4KO/27xt4/vJOc1g3+3R3bDDGUV8q5YQnFPOOEKGs1ZaZQjOpJYbLEjVLObCb3N2u
-        tVBWTCpZeKON8sIpDlZTScFyocAK6pGaORdW1K4SVpuCCOEdQFEoYrnXovbcePIAXJy/7VNp/RQs
-        JM01vR8LKXMlj8RiMvnfxKLwjMrKS5kuQs1BKzC14oIoU1EC9AGweNqEIT5uYRgutgXyAI7Lnd6H
-        GaEmL45ghJG8OJaRyeR/kxGoXWFUYUgliLAgDOO+8hpfmGqc8uZhSod3+JrsDjmYY2B0Ttn9GExq
-        R2FAVK7IsRzw9yC4OaX4kfFTTnan/DAW2+7mDir4Z0YCaCV4oWpVVVYwXVRSV0KCpEopS524hQTi
-        g32JK7BGIBTcGA/aeASIAMiieAgkMPiXgB76MBH4Np2LIyrDXu8oJijPmTqWCfYRJvhfZYI9LBPA
-        FSkKxmtnjBDUVk5S7Cu84d4x6+wDMRGhcxA+UijY7h3yvvviE141UVceXSfUR5gwf5UJ9Y8z8XLz
-        KWzs3K3PU4OFrqxXYbkX+BZhwMiG2Q25+UJ209XH1Z0NPBes4qmbcYUWjJFKW8WdIdZTrEmHjd7f
-        1cBj1/1m7cPiG9RfQpfNmvmp1d238WeLbyG8GvoxLB7jZvKDbn7Wx8d8cdZWPsRZE3/2zb6Jj7pj
-        S3HQxW9a/KmLLzRhmhuuxb+kix+Hfih/32xuekL6ovb/R5kv86NMNa5TSfg/Ib/YhEz1d/c/SO2n
-        f0Q+5V7YR/Fyd6tk7/4EAAD//wMA4Ld+ipcZAAA=
+        H4sIAAAAAAAAA+yZ3W/cNgzA/5WDnzbsakiyJMt5S9MULbB1QdO+dCgMWpIvXn0+T5aTXov876N8
+        H/ElaXJFi2QffYsoSieRP5Ki8znSzoK3JgcfHUSMMPqEsCckeUPIAU0PiHgXTaOqy531vWuigxLq
+        zk6jue06mNkuOvjjPY4WxuJqbzuP2ovWV4sGpz5HunfONnqJk29Pn+FcC8u5bXyY88s2LDo9fvXs
+        +HV0OY0MniMHcw6NxgmCEmdLG9bjsOnrehp1HnyPO0d986FZXDS4o3egP1TNLNfDIVZ6fWvuvVQB
+        Xp/lldmsWY03vzCWrS+7Eeq+84t5l1dNuQgXCVtEuvNhnGdGq9QImgFVXAimuEzAGlYqZmSZ6mCf
+        4k+rw8GOVhu9DPtM93LEPvfSi8ajibvcfmxraCA4A7XHM2vTz6oy+GtzH22dr0r0lXe9vRJ31ayx
+        DtVf4KkXbvIC5nPrkIMa11pb522pcfbV78fHLycJiZP0J/gZp5pFkxtbV+fWLfMVE6i25ij4tvOu
+        0kGMrpsHKrrVMccz65PiXja6zpmxuga3vt8113g7D2yOnIOSHHSWKplkihjGtUmAFSIhjPMkKwrB
+        yG3OwXX3O4fv4ZxBx9hOu2pjjGPolieLzk/8k+6scmiAaXSG7gFXlWXe9PNiMDxlCRcyHM5VsyqY
+        q2+8WwUVSv/qocH74ZhNo3Oo+2CjTMYsxckLW83O8ECMxjQQcBUju8acQ9OXoNE54Sc31txE72ps
+        tV5b+vI9RmfpFmhSY9Bf3TYOwLhcKCiolllqSMFTVWRUKEJNkhGScqHZ2MyH6/X3m/gX/IOQPey8
+        VWxgfhW0i3kLzXJk9CikE2etp8HEVE1YYyanV2KGYu7PJs8D53qwb3QKzeS5wwRVdXoRrfJRMOLR
+        IQ4+VW0wPKdEDMG246T2LCCMO1KBvkxVFg5o51DVt/tDg3OVdTn6pKqHH19pobEqg7FSwXZhaY11
+        UCM2H0fpbDjaNRmGYlVWGjb5+RK9WDVd72CUYxcOtxstasFpW28d3Dpd54lOIUlpUWgrecpSYNKa
+        lEhhSaZB87GHT1brv18M1baZ+bPogJIYgb+oTBikscLYWcPO4wTP7dAuZdXgbi2WiFECH8UE27U7
+        2qNFNFA3r6GwWxNjlrGjfBKGuRKGQllSARS4sKzgPNOSKsKVlkVixzZ4HTC51wJyDwsMOruodNad
+        V8F/0YmrMEX45W+I1UvM9W6V/aG+Amrg8SQQ6VboJioWaTS9WaoxU+M2+VqNk1iSK+kN7brqfH5t
+        y0F2Q3NbEwwst4V2JPT2VmE+6zHZ46Ws2b5C8P75rdthNm1DRRkwxlGb0zQpS5uSkhHKpeWZKRVC
+        jFkJK4LhehRyoIfYXa3VkBdMSJHaTGW4zmA514oKCjrhElGnFqkZc4Gpz6CKsWALnqWiwLSXMS5R
+        G6tOph6Bi+OPbUiyX4OFoLGi92MhRCzFnlhstvx/YkFKWXCgVBZCc5CQJdpwWfKySLFQ7hbFB8Li
+        eeU6f1RD152sEuQOHKdrvS8zwkhMs/sZCWl2X0Y2W/4/GRFGMF7KEhSV+D6l2DiItDCUYWmlYnjP
+        PTQjb09OTz00BpzZJWGnhuDjUt4PwkZtrxpCYiX3BYHfoODqmtkblhwk4UX4LrqLi1XTcwsW/Dsz
+        AbTgSSoxHRSaM5UWQhVcgKBSSk0Nv8aEppDh+18nWkqeSF0kmQCTauTJFIQ+FhOAFvoyEJRlMdnj
+        VbHV2wcJynisyL5MsDuYEN/KBHtcJqhIqMHfwdpRcsiUIglLlClJgY2iMY/x9MQnhjXYZN+RJShJ
+        Y7lHmtjq7QUFTWO+d6JI7oBCfSsUyYND8X74RNY35tpnq05Dk5cLN98KbI00oGvdqEYOX86uun2/
+        uLWZp5LojGbY3ySCW0EyfMDYgkBBMqBE04dt5rEDv1haN3mKi+bQRKPGftP2blv6w8mv4D50be8m
+        R3iseKezH/X0Pp4c1oV1ftTQHz7dNvReNWzOdzr6od3fdPSpIkwlWaL4P6Sj77u2yz8Nh9v8Qvjm
+        9uNTzb/9U03RL0Oa+BGk/4EgDdl5/d+T0m7+j/I1VWPrz9N1zYku/wYAAP//AwACTltrzRkAAA==
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -412,7 +410,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_66d4e018900046cc8c29782585c52c06
+      - /api/v2/shipments/shp_173ffe70f20146e49df8c7a1d3786d4c
       pragma:
       - no-cache
       strict-transport-security:
@@ -421,22 +419,24 @@ interactions:
       - chunked
       x-backend:
       - easypost
+      x-canary:
+      - direct
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - c805095b5eb9ca67fb56ed6a000843bc
+      - 2ebf75b86019eb81ee4cfaf400001f73
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6sj
+      - bigweb7nuq
       x-proxied:
-      - intlb1sj 5834894b53
-      - intlb1wdc 5834894b53
-      - extlb1wdc 5834894b53
+      - intlb2nuq 9cd9455ca9
+      - intlb1wdc 9cd9455ca9
+      - extlb2wdc 9cd9455ca9
       x-runtime:
-      - '1.053916'
+      - '1.150323'
       x-version-label:
-      - easypost-202005112100-59b664a857-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -451,6 +451,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '0'
       Content-type:
       - application/x-www-form-urlencoded
       authorization:
@@ -459,23 +461,23 @@ interactions:
       - easypost/v2 pythonclient/suppressed
       x-client-user-agent:
       - suppressed
-    method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_66d4e018900046cc8c29782585c52c06/rates
+    method: POST
+    uri: https://api.easypost.com/v2/shipments/shp_173ffe70f20146e49df8c7a1d3786d4c/rerate
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+SWy27bMBBF/0XrROBr+PC2D6CLAkGdblIUwpAcJWoV2aDkoEaQfy9txE2dOLaC
-        FPUiO83wzlAkDy55WyQcqC8m326LJhaTdVgZL6RB1DyaWpGUlgkhtXMKlcFgbHFSzPwPCkMu+JIL
-        chwS5Y9Y4SonmGCnDE45Pxd8Am7C5EXWLObxoOZ6FimP5n8actRTumnCKnGWmllqhuVnbNpP3UCp
-        w6GZddiu5saUGkpZ9XV6Ns2J1SJyJE0p1Wp8kRJ1YbkWvF+N05DbVBuZKyV7yD5Rt00/VI9arnNP
-        lJHa5obSsoq4zHvaLdp2K7lqsSNZXS4wYV4U5ROose3ppMjrr3a266+a+TV1Q7U+rv5qXmkdFTFu
-        HWNM6RBsEM5YARYCiMD0ww5VGMJssakNWHkBGgw56zSpqCUGy4FjkEpjUJyKu5MtLiiisMgtKK28
-        d1Y6G6Jx3OhgkakjcPHh1zxR378EC+Cl5YexACg1jMRi0/JtYuF94F5p7omc0rZ2rtbAOQqMsiY4
-        hl18bFI/vGux788w/MRL2oJjeq97nhHuSjOCEcFKM5aRTcu3yQhAMECREXmZrQPzZcK8U84rgZkb
-        fxzroNjk6m0O/sbA2ZKLwxhsZKMwYLrUbCwH8gkED6tU50JOJJswdlHsw2JIi91UyH+MBGYXkEbX
-        OhuCEtZ4sF4BAtdaBx7VY9vADI8XHqMAxaHO03hyVDsGUYI8xm2SD3+KeYeeJ4JzW6oRzvBHN4oJ
-        LkuhxzIh9jAhX8uEOC4TgknmalIBeK0MB19HxnO9RRGs9ngkJgbsIqY9RiHu35CH7osXPDWzFkb7
-        hN7DhHstE/q/M/H97jcAAAD//wMA/EYDe5kMAAA=
+        H4sIAAAAAAAAA+TWyW7bMBAG4HfRORE45HDztQvQQwGjTi4pCmHEJVGryAYlBzWCvHtpo07qLLaK
+        FPUhJ4vDn2NT+kDrtkg0hL6YfL0tGl9MNsPKGul9lNYLwxFVXUsWI+cgWE0KkBcnxbz+HtyQF3zJ
+        C/LYpZAvfEXrGmccThk/ZeKMsQmYCTMXObNc+IOZ67kPeTb/piGP+pBuGrcufPi5SKHvP1PTfuqG
+        kDoamnlH7fqrKaUmpBw6n01nubDeQx5JKA2s55cphc6tNoH36/kw5DbVNiZLJR+qT9Jt0w/Vo5ab
+        2pOkD21zE9Kq8rTKt7Rbtu1Ocd3imWJ1uaREeVMhP4BIbR9Oirz96tl2/VWzuA7dUG2eVn+1qECL
+        GINmkTNAFdD6aJwm8EIb5dE93KGKnJsvt2sdVTWXSupgjc3rvBLkDEggJ1CRQwjF3cmfLHztNAjN
+        ggbAKDlFK6yIweVrhy4egcXHJvXDu5b6fkruB12GHRyz37mXjXBWgj1shEPJxxrZtnybRiJI58lr
+        r1WNykrDNZGLPjpkEFl9BCPT1MxTM6z+5uwQppT6sAtkpWIjXWxbvk0X+c9DSoGaB8nRuEAGPSlS
+        GqSW2tMRXJxPZ7OBOk/J70rYgQAlqMMQtrFREFhp1FgI+ETBwzbtGRcTwSaMXRT7XAxp+TwL/Mcm
+        CGoUWsX8xuCQG11LU6MkCUopBx4fmTBWZjKsBl0jauuMCbLOIw/EuI3iSCYo36GXQQC3JRtxNNzn
+        xpAAjqVhY03wPSbka03w45rgGAhtBG+kRhMYWYnamJg/AsRaHefVM/gmr96DgulSjTgm7nOjUIAu
+        cfRBIfagMK9FIf47im93vwAAAP//AwCtsjaMmwwAAA==
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -493,23 +495,21 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - 2b85eb3d5eb9caa6fb320eec00048eb9
+      - 41c33c786019ebbfee4cfb5c0013dfe5
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7sj
+      - bigweb2nuq
       x-proxied:
-      - intlb2sj 5834894b53
-      - extlb1sj 5834894b53
+      - intlb2nuq 9cd9455ca9
+      - extlb2nuq 9cd9455ca9
       x-runtime:
-      - '0.953055'
+      - '0.820664'
       x-version-label:
-      - easypost-202005112146-47e058b20a-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_creation.yaml
+++ b/tests/cassettes/test_shipment_creation.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode address%5Bcity%5D=St.+Albert&address%5Bcountry%5D=CA&address%5Bname%5D=Sawyer+Bateman&address%5Bphone%5D=780-283-9384&address%5Bstate%5D=AB&address%5Bstreet1%5D=1A+Larkspur+Cres.&address%5Bstreet2%5D=&address%5Bzip%5D=t8n2m4
+    body: address%5Bcity%5D=St.+Albert&address%5Bcountry%5D=CA&address%5Bname%5D=Sawyer+Bateman&address%5Bphone%5D=780-283-9384&address%5Bstate%5D=AB&address%5Bstreet1%5D=1A+Larkspur+Cres.&address%5Bstreet2%5D=&address%5Bzip%5D=t8n2m4
     headers:
       Accept:
       - '*/*'
@@ -23,12 +23,12 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4SQMXODMAyF/wrnOcmBCQTYSNZu7dSFUyz56hYMJ0xbmst/r5xeOnTpZul9enry
-        RTlUjQLkDg6AKdqiNBr3WW3rc11ayAvMKbVladRGjedXMkH4FpFpnqVlmCAQdhDbOtXpNi22Wfak
-        s6Y4NEXxLMwy4b+Mh4FEfYSPlTg5Cj+Aj/7jMIFfVeOXvt+oOTBRyITM2uQB+G2eFk5OEman7qoW
-        NU66sEbHsEva/kwcboAYx/xHKb7cJM9QeT3sb5sWHziOnFopp5fRR/RQpbrK67yKjIRy/T3LMGIE
-        As3R2gCzI+4sGNffVv9QEs0h+eDgd9ASEkPfBfjs4vffT5Nsf3rvxM46A8GNflbN5Xr9BgAA//8D
-        AAcghoOxAQAA
+        H4sIAAAAAAAAA4yRPU/DQAyG/0p0K211uTTkY0u7ssEeuXeOuJJcIscBQtX/jq+oDExs/nhe+7V8
+        Ud6pWoGj1nQmrbIqhyrL92VpQVdQdHuNmS6KPLVqo8bTGS0L3zhHOM9SsoTA6FqIZaNNutVmq7MX
+        rev0sc6rBwm0FnCZ3P/AAAMK8gwfK1JyENEAIW4ahwnCquqw9P1GzUyInAqZNskT0Ns8LZQcxdZO
+        3btGulHpeY0TeZc0/QmJb4AMjpccJPnyk4RcBjPsb5uWwBQlx0bS6XUMES1KbcqsysrIiCnf370M
+        o4sA4xxHWyDySG0H1ve31T+UWPMOA3v4FXbokKBvGT7b+Ij7aeLtT+0dyXfeAvsxzKq+XK/fAAAA
+        //8DAFVyKGi7AQAA
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -39,7 +39,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/addresses/adr_a7ad0df56c2d419f9b96fa35d3e0f66c
+      - /api/v2/addresses/adr_2f219395a935488ca09a7f40e307751c
       pragma:
       - no-cache
       strict-transport-security:
@@ -51,25 +51,26 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - a893930c5eb9ca63fb662f2a00051d63
+      - 45e271c56019eb7bee4cfaf300002b11
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb3sj
+      - bigweb9nuq
       x-proxied:
-      - intlb1sj 5834894b53
-      - extlb2sj 5834894b53
+      - intlb2nuq 9cd9455ca9
+      - intlb2wdc 9cd9455ca9
+      - extlb1wdc 9cd9455ca9
       x-runtime:
-      - '0.048580'
+      - '0.081907'
       x-version-label:
-      - easypost-202005112146-47e058b20a-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode address%5Bcity%5D=San+Francisco&address%5Bcompany%5D=EasyPost&address%5Bphone%5D=415-456-7890&address%5Bstate%5D=CA&address%5Bstreet1%5D=118+2nd+St&address%5Bstreet2%5D=4th+Fl&address%5Bzip%5D=94105
+    body: address%5Bcity%5D=San+Francisco&address%5Bcompany%5D=EasyPost&address%5Bphone%5D=415-456-7890&address%5Bstate%5D=CA&address%5Bstreet1%5D=118+2nd+St&address%5Bstreet2%5D=4th+Fl&address%5Bzip%5D=94105
     headers:
       Accept:
       - '*/*'
@@ -92,12 +93,12 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4SQsWrDMBCGX8VobkBSrNjxFkozF9IuXcxFdyYqtmQkpTQNefeeXNpClw4C3cf3
-        Sz93FQ5FJwBjf0QzNLVupTZQa7k+4gY1n622sm3atbgT4fhKNrO/Q4yUEiMbCTJhDwVrqeVKmpVS
-        T1p1pumMeWHnPOO/joeJROfP48hvhmkGf2H5AdLlMaTMQsqRKCuGSrWV9lgdfrFmXOdTtR9LJZdL
-        9gC+2kfw1iUbFpNLML/f8fDhZr5uayVNSYSzz7GEng88zqfgi1krU5tN024lQ5rAjd8Np4BFyLRU
-        sxCjo9gPYN24fP5l8Yocks8OfoIDIUUY+wzvfdn8F12q/WFvFN3gLGQXfBLd9Xb7BAAA//8DACjq
-        ICisAQAA
+        H4sIAAAAAAAAA4yRy2rDMBBFf8Vo2wYkRX7Eu1CadSHt2oylMVGwJSPJpWnIv3fk0Ba66m7mcK50
+        ka7MGtYyMKEzshm47KGq+1I1gvelqVUFWJVqC1AP7JH5/ow6kb83JmCMhHRASGg6yFhyKTZcbvj2
+        lfNW1C3nDzRwTuIym/+JDiZkrVvGkU730wzuQolniJcXHxMJMQXEJAgK0RTSmeL4iyVhlU7FYczl
+        bMrZI7jiEMBpG7VfTWpC/GlPy6edadwpwcuc8ItLIYfejrTOJ++yqUSpyqpudrkgTmDH74aTN1lI
+        uFbTEILF0A2g7bhefrfosaxBlyz8BAc0GGDsEnx0+Q/udK32h71jsIPVkKx3kbXX2+0LAAD//wMA
+        0gcVZLYBAAA=
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -108,7 +109,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/addresses/adr_bd5f7428025a4203bd6d2d6d92c08783
+      - /api/v2/addresses/adr_d28f02ba67b54810b5d746ae6543aa7f
       pragma:
       - no-cache
       strict-transport-security:
@@ -120,25 +121,26 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - a893930c5eb9ca63fb662f2a00051d65
+      - 45e271c56019eb7bee4cfaf300002b22
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb4sj
+      - bigweb4nuq
       x-proxied:
-      - intlb1sj 5834894b53
-      - extlb2sj 5834894b53
+      - intlb2nuq 9cd9455ca9
+      - intlb2wdc 9cd9455ca9
+      - extlb1wdc 9cd9455ca9
       x-runtime:
-      - '0.037633'
+      - '0.024689'
       x-version-label:
-      - easypost-202005112100-59b664a857-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode parcel%5Bheight%5D=4.3&parcel%5Blength%5D=10.2&parcel%5Bweight%5D=21.2&parcel%5Bwidth%5D=7.8
+    body: parcel%5Bheight%5D=4.3&parcel%5Blength%5D=10.2&parcel%5Bweight%5D=21.2&parcel%5Bwidth%5D=7.8
     headers:
       Accept:
       - '*/*'
@@ -161,10 +163,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4SOuw6DMAxF/8VzQHmQAPmKDp26oOC4QJsCokEdqv57jdS9k+Xrc678himCh3XD
-        1DkbdIXGBFSOZ9U2aJxV1LfRBSMNCFj6G2Fm4RQ2pMQJbhQyxS4cqZZaFtIWSp218rb21l6Y2df4
-        l0k0D3kEr2SpBbymeCx12QgYaRpGNqvSCH6UIl2nmdvWgPcwEPh5T4mVH6bVUfBYIl8g0zPD5wsA
-        AP//AwB/r75W5QAAAA==
+        H4sIAAAAAAAAA4SOMQ7CMAxF7+I5VE7SNiinYGBiqdLYtIHQViUVA+LuuBI7o/9/78tvSAQeljXm
+        jtm27IKzLdnaNbZv0VFvalNTtA1ZUDD3N45FhFNYI2dJ4sqhMHVhTw0afUBzQHtG9Np5xIsw20J/
+        mczTUEbwGiuj4JVoP1x1VDByGkYx68oqeZSJr2mStSXEexgY/LTlLMoPM3ofeMwkDRR+Fvh8AQAA
+        //8DAIKpa7vlAAAA
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -175,7 +177,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/parcels/prcl_65a24c33ac164c3498c3651eb9d6a303
+      - /api/v2/parcels/prcl_ee36e7a736d34753b607db2424dc35d3
       pragma:
       - no-cache
       strict-transport-security:
@@ -187,25 +189,26 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - a893930c5eb9ca63fb662f2a00051d69
+      - 45e271c56019eb7cee4cfaf300002b35
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb4sj
+      - bigweb2nuq
       x-proxied:
-      - intlb2sj 5834894b53
-      - extlb2sj 5834894b53
+      - intlb1nuq 9cd9455ca9
+      - intlb2wdc 9cd9455ca9
+      - extlb1wdc 9cd9455ca9
       x-runtime:
-      - '0.028608'
+      - '0.025162'
       x-version-label:
-      - easypost-202005112100-59b664a857-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode customs_item%5Bdescription%5D=EasyPost+t-shirts&customs_item%5Bhs_tariff_number%5D=123456&customs_item%5Borigin_country%5D=US&customs_item%5Bquantity%5D=2&customs_item%5Bvalue%5D=96.27&customs_item%5Bweight%5D=21.1
+    body: customs_item%5Bdescription%5D=EasyPost+t-shirts&customs_item%5Bhs_tariff_number%5D=123456&customs_item%5Borigin_country%5D=US&customs_item%5Bquantity%5D=2&customs_item%5Bvalue%5D=96.27&customs_item%5Bweight%5D=21.1
     headers:
       Accept:
       - '*/*'
@@ -228,11 +231,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4SPsU7EMAyGXwVlbk9J2qSi64mBDQlYWKo0ca9BTXIkDqhCvDsu9wBstr/Psv9v
-        5h0bmS3oEcJkZzkbrjV0/dBzrmfTadADN0IrN3Qda1ia38Ei7ZxrwRTKI+3R2GYwCG4yB5Jc8par
-        VogXKUY1jEq9kVOv7l/HQbHZX9GnSNKDKftTKniHbVl9xkLGWiY02S/LFGuYIZMmZNcrfTyX/cXH
-        yaYaMe9EXp9p+lFNpHzUy4Z9mq0CkXt9kgPBL/CXlR6S4iQoRnIEY922hoW/miEUJC+YWBdjsebj
-        5M2wNWeIdr/1P78AAAD//wMAa9qvKU0BAAA=
+        H4sIAAAAAAAAA4SPzU7EMAyEXwXl3K6S9E/tdcWBGxJw4VKljrsNapMlcUAV4t1xWXHmZs98lme+
+        hLNiEJDIEW6jbduunyaouh5rVRlTyXo2TW1ZajR0ohBhekMgvjnnRGFLD3zHMkQ0hHY0h6WlVqXU
+        payepRxUN0j5yky+2n8Ziwmiu5ILnqF7k/bHkOiOyrS4SImJJY1kopvn0edtwsiY0lXdtEe46C7O
+        jxCyp7iz8/LE6ns2nvvxrgvxYdaM7PTtSR99PtFdFg6k1UlxjWDZ9HldC7H9zoIwEXOb8Xk2QDke
+        L28E5BjRw/63I4C/zd8/AAAA//8DABVvysJZAQAA
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -243,7 +246,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/customs_items/cstitem_cb2ba066e3474006ba36e670a165d733
+      - /api/v2/customs_items/cstitem_d6679bbc379e413aa304fa54dbc352c7
       pragma:
       - no-cache
       strict-transport-security:
@@ -255,25 +258,26 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - a893930c5eb9ca63fb662f2a00051d6c
+      - 45e271c56019eb7cee4cfaf300002b47
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8sj
+      - bigweb9nuq
       x-proxied:
-      - intlb1sj 5834894b53
-      - extlb2sj 5834894b53
+      - intlb2nuq 9cd9455ca9
+      - intlb1wdc 9cd9455ca9
+      - extlb1wdc 9cd9455ca9
       x-runtime:
-      - '0.037151'
+      - '0.024917'
       x-version-label:
-      - easypost-202005112146-47e058b20a-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode customs_info%5Bcontents_explanation%5D=&customs_info%5Bcontents_type%5D=gift&customs_info%5Bcustoms_certify%5D=1&customs_info%5Bcustoms_items%5D%5B0%5D%5Bid%5D=cstitem_cb2ba066e3474006ba36e670a165d733&customs_info%5Bcustoms_signer%5D=Hector+Hammerfall&customs_info%5Beel_pfc%5D=NOEEI+30.37%28a%29&customs_info%5Bnon_delivery_option%5D=return&customs_info%5Brestriction_comments%5D=&customs_info%5Brestriction_type%5D=none
+    body: customs_info%5Bcontents_explanation%5D=&customs_info%5Bcontents_type%5D=gift&customs_info%5Bcustoms_certify%5D=1&customs_info%5Bcustoms_items%5D%5B0%5D%5Bid%5D=cstitem_d6679bbc379e413aa304fa54dbc352c7&customs_info%5Bcustoms_signer%5D=Hector+Hammerfall&customs_info%5Beel_pfc%5D=NOEEI+30.37%28a%29&customs_info%5Bnon_delivery_option%5D=return&customs_info%5Brestriction_comments%5D=&customs_info%5Brestriction_type%5D=none
     headers:
       Accept:
       - '*/*'
@@ -296,14 +300,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6xSwY7TMBD9lconkNoqcRK77RVV2r0AEnABIctxxq1RYoexvRCt9t8Z0666SEhc
-        kHyZ92bGz+/5kbmBHZiJyXkb1K4FIexOWtjbdm8lnc5A1ehdx1u5l2zNQv8NTKKZNzmmMMV7miPY
-        IOgEg9KF4hWvNlW3qeuPvD508tB1n6knz8M/e0zwCXyKCn7Oo/Y6ueCp+yWTlhkIOjmbCnyRoQxg
-        cnZhh4QZbnB0Jw9I7XekOuDqTk8ToNXjSLMAo5qtIfbtu+PxftVU20a+0q+J8sGrAUb3ALioMF9l
-        IKSMnmiEmNCZAisTaCUJu8h8yVyV0i4gZgpDqRI1UDWAGTVe3+fzON40uwQTbfvyeAuHEGV63utK
-        CGha2VaV6HUjQMhK16IbZNP8LRya+4/hDBANumczjjou70NMq7SJZ4dkwJqdKR6Nzlrl89T/Nr7m
-        TduJIg7dyRW7sk9IQbFPHwj9nrWn91HN1+xBj7l4tBdbXj7bD3CnMwni9bYuP6AYePHqTzMn7bPV
-        hsIpVz67iQjeLJf66evTLwAAAP//AwBMeqvr7AIAAA==
+        H4sIAAAAAAAAA6xSy4obMRD8FaNTFmyjeY99DYbdSxJIckkIQiO1bC0z0qQlbTIs++9pxTbeQCCX
+        HLuqu1VdpWdmNdszFaJ1xgvetl0r+8Lwtqp53/RlO+imr+teKa4qydbMD4+gIs28TSH6KTzQHMEK
+        QUbQQmaq5GWx4eWGV5843xfdnvMv1JNm/c8e5V0EF4OAn/MonYzWO+p+zcRlBoKO1sQMn2UIBRit
+        Wdg+YoIbHOzRAVL7Pan2uLqX0wRo5DjSLMAoZqOIfff+cHhYVXxbdW/kHVHOO6FhtE+Ai/DzRQZC
+        TOiIRggRrcqwUJ5WkrCzzNfMRSntAmImr3MVqYEqDWqUeLnPpXG8abYRJtr29fkWDiFCUzi7YVBV
+        t4O6qKSseG1kU2uCmlJ1fwuH5v5jOBqCQns14yDD8sGHuIqbcLJIBqzZieKRaI0RLk3Db+OLsqqb
+        NotDe7TZruQiUlDs80dCvyfp6D6qyzV7kmPKHu3abZnv+QH2eCJBZbEt8g/IBp69+tPMSbpkpKJw
+        8pNXNxHBqeVag1IXp1++vfwCAAD//wMAZo64nvgCAAA=
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -314,7 +318,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/customs_infos/cstinfo_84e66f87fe9f49f79f75ce03a8524797
+      - /api/v2/customs_infos/cstinfo_06676a81f0634085826bd58448cc0c3a
       pragma:
       - no-cache
       strict-transport-security:
@@ -323,30 +327,29 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - a893930c5eb9ca63fb662f2a00051d71
+      - 45e271c56019eb7cee4cfaf300002b52
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7sj
+      - bigweb5nuq
       x-proxied:
-      - intlb1sj 5834894b53
-      - extlb2sj 5834894b53
+      - intlb1nuq 9cd9455ca9
+      - intlb1wdc 9cd9455ca9
+      - extlb1wdc 9cd9455ca9
       x-runtime:
-      - '0.040303'
+      - '0.029153'
       x-version-label:
-      - easypost-202005112146-47e058b20a-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode shipment%5Bcustoms_info%5D%5Bid%5D=cstinfo_84e66f87fe9f49f79f75ce03a8524797&shipment%5Bfrom_address%5D%5Bid%5D=adr_bd5f7428025a4203bd6d2d6d92c08783&shipment%5Bparcel%5D%5Bid%5D=prcl_65a24c33ac164c3498c3651eb9d6a303&shipment%5Bto_address%5D%5Bid%5D=adr_a7ad0df56c2d419f9b96fa35d3e0f66c
+    body: shipment%5Bcustoms_info%5D%5Bid%5D=cstinfo_06676a81f0634085826bd58448cc0c3a&shipment%5Bfrom_address%5D%5Bid%5D=adr_d28f02ba67b54810b5d746ae6543aa7f&shipment%5Bparcel%5D%5Bid%5D=prcl_ee36e7a736d34753b607db2424dc35d3&shipment%5Bto_address%5D%5Bid%5D=adr_2f219395a935488ca09a7f40e307751c
     headers:
       Accept:
       - '*/*'
@@ -369,34 +372,35 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+yZbW/cNhKA/8pCn+4AR6D4Jsrf3NRBA/R6Rt370kMgjMihrUar1VFUkm2R/37D
-        fbPW8dkbNFe3aAEbBodDipx5Zsihf8lsQIjoaojZecYZZy+YelEUP/DiXJXnSv2YnWXtWAeMU+iz
-        cw/diGfZEscRbnDMzv/9hlorhzQ64hhJezXEdtVT1y+ZnULA3q6p81/XX1PfAOsl9jH1xfWQBl1f
-        fvf15ffZx7PM0TpqcO+gt9TBSBLQYxpPzX7qurNsjBAnmjmb+rf96n1PM8YA9m3b39R2s4it3jS4
-        JzfVQLS3dev2Y7bt/Rfmst1m90I7jXG1HOu296u0kTRFZseY2rWRqLU3pcfKy8qX9KMsMgFGcVlW
-        ZbJP8xPatLCX24lep3nOTnLEKfuyqz6SiccaPwwd9JCcQdrznp3pb1qf/LXfj8UQW0++imHCO/HY
-        3vQYSP0bWvUqLL6B5RIDcdDRWMSuHryl3u/+eXn5eiFYLsq/wd+pq1/1tcOufYdhXW+ZILUdR8m3
-        YwytTWJy3TJRMW6XOe/ZrZTmwuw+Zw5tB2G3v3uuibhMbM6cQ5LaNrwBpjUKWUrGdANCoy4ZFFq5
-        UoiHnEPjvqBzHI42tHtjXMK4vlqNcRFfjLdtIAOcZbfkHgit93U/LZuN4QsupNJpcaG9aZO5pj6G
-        bVCR9D8T9LQ/avOz7B10U7JRpXOeYHuP7c0tLYgXeZEIuIuRY2MuoZ88WHJO+uTemvvoTe2Pbygi
-        fVgtKUYd+Wg8sA8u1I1TvpTcMK5AciYapx2n34pbZkpzZNqL3fgvZ9YelnfhuVoO0K9n5s1S4giI
-        sUjGLMyC925xfSfmJJbxdvEqEW03lsyuoV+8CpSK2tGusm3mSeZ6eUGNn9shmVgWTG3C6sgdw22C
-        lWYsFHmtNBVLcbKEtnvY8hZCaDHUZP2223x8q0Umah1FRQuHgR4dBugIkA+zxLVZ2j0ZBV3rWwv7
-        TPyRfNf24xRglk1XgaabDRogWOwObh2C7WqtgEsrBNhC019ZGSu0KrCpnAbBjvx6tR3/5dzaYX8T
-        b7PzguWE9vvWpUaZG4qSHdYyF7TuQHbxbU+zDXQYzFL1jH5+bHeyx0BokG7dQYMHE1M+wVnmSM3a
-        MgCLGrQ0ZACUAJVpKoVFw7mrrJzb4PuEyZMW0CdYYKNzjMqI4V2b/Je9asMYX3YwjlfbHb+m1B62
-        yR66653eAa4Nm1eJzrDFuKjyssjOPj2gKT8TqfVOjbO8VHfST7S7doz1vSk3sk80DyeBg/XheJ0J
-        Iz4orG8mSvG0N3SHuwfZon5wOsqhQzpHNkhTa6hRFFXlBdesaghdSacz6kaDMkKbyrpZ+IHdxPF2
-        rIW64UqrEitTaZROUwCYQhVAIaDBygKJoDkjRiNaUzUanZJSolFN6SvNvSka74x9BkauQksHRlz/
-        g1x3hMcjXIgyF/JpLkSVC3YiF/sp/5xcQFmCFBUyr7kUjhswWoItQRg6KVE8AxeXH4Z0/H4OFqrI
-        zQnpQqlcn5ou9lP+ObEQxkiHTnOuSqk4JQtmJLd00SuNdlg+Dxbo6JrsjjmYY1CZvOBPY7BXO+nU
-        YDrX7FQOxCcQ3O1S/sDFuWDnjP2YPYbFtrp5gArxhZGAopGi1F43jaWbcdko00gFqtBa28LJe0gw
-        L0ualTvwlQTlgFvjnC0RPHpunwMJcv41kIX+NxF0m87lCZnhoHcSE4XIuT6VCf4IE+LXMsGflwlZ
-        WgWFd6wAIRvFGi8r6xljis6QqnyOW0ViIkLvIDySKPjufvDU9fIzrhGkq07OE/oRJqpfy4T+zZl4
-        s3kKm3p373lqtNDXfhWWBwF2BAN5NsxOyM0L2V1VH1cPFvBQgmPOK225k0Xlq6bSHoRyIt1d9BFq
-        /68Cnqru92sMi69Ifwl9Nivm96XuoYy/WHwL4e04TGHxkhaTH1Xzszo+5ouLrsEQZ0X8xVeHIj6a
-        ni/lURW/KfH3VXxpGDeiEkb+Tqr4aRzG+ufN4vZfSC9qfz3K/DEfZZppnVLCXwH5hw3IlH93/wfx
-        uP+PyOecCwcvXu9OlezjfwEAAP//AwCN5aWrlxkAAA==
+        H4sIAAAAAAAAA+yZ3XPUNhDA/5UbP7XT4JFkSZbzFiAMzLQ0Q+ClHcazltaJi8/nyjJwMPzvXd1X
+        fCGQY2CafvAWrVa61e5vV1rnfWI9QkBXQkiOE8EEv8fEPZY9Z+yY58eM/5YcJc1Qegyj75LjGtoB
+        j5I5DgNc4JAc//6SRguHtDrgEEh70Ydm0dHU+8SO3mNnlzT54vwhzfWwnGMX4lxY9nHR+enTh6fP
+        kg9HiSM7SnCvobM0wUjisca4nobd2LZHyRAgjLRzMnavusWbjnYMHuyrprso7cqItd7Yu1sPVUGw
+        l2XjtmvW4+0vTGWbw26FdhzCYj6UTVcv4kHiFokdQhyXTOtcg+E105lkRhmhK6eMlMZaZjOI/qn+
+        QBsNe7De6Enc5+i2QLBo8y3nWunYRRfIxUOJb/sWOojBIO3pzMb1F00d47U9j0UfmppiFfyIV+Kh
+        uejQk/pjsnrhZ49hPkdPHLS0FrEt+9rS7NNfT0+fzDKWZvkP8CNNdYuudNg2r9EvyzUTpLbhKMZ2
+        CL6xUUyhm0cqhrWZ05mNpbQXJtc5c2hb8JvzXQtNwHlkcxIckpSOglNUlc3yAiXPADIma1DSkUgJ
+        m98UHFr3DYPjcLC+2TrjFIbl2WIIs3BvuGw8OeAouaTwgG/quuzGebVyPBeZVDoa55uLJrpr7IJf
+        JxVJ/xyho/PRWBwlr6Edo48KnYp4njfYXFySQYKnPBJwlSP7zpxDN9ZgKTjxJ7fe3GbveozWbjz9
+        4SVlZ+0Xc8pXR/EadnkAzpdOmJqJCnReKWk4q5TLpQbUSpLP83rq5pPN+ttd/BP9wdgBft4pdjC/
+        StrFvIduOXF6EsuJRww8upibmejc7PxKLEgsw+XsUeTcrvybnEM3e+SpQDWDXSTrehSd+OCEBu+a
+        PjpecqZWybYXpP4yIkw7ckWxzE0RDcQ5NO3N8bDgfYO+pJg07erH11rkrMZRrjSwW1ijQw8tYfN2
+        Us5Wpl2TUSo2dWNhW58/UBSbbhg9TGrswtN2k0U9eIvtLsC9t22JmGnMIc+0y2Suskqz3FVCCuko
+        k1w2jfDZev23y6EWu4twmRxzlhLwbxoXB3lqKHc2sMs0I7s9+aVuOtqtpytiUsAnOSH2/U7+6AkN
+        0i1bqHDnYqoyOKkncVjKgtecW5AZpacRDApmOZURZukCKOo9yp9FTG71AD/AAyudfVQG9K+bGL/k
+        zDdUIsLyF8LqCdV6v67+0F4BteLxLBLp1+hmJlV5cvTxVU2VmrYpN2qSpZpdST/SbpshlNe2XMk+
+        0tzdCQ6Wu4t2Igx4o7C8GKnY06HQ7V4hdP7yxu2omvbxRllhTKO+tM7pWimq+kJJ7QQQtbXJAQja
+        zOR6knJgV7m7XmuhrITSKsfCFBql0xlYwxUHm1FNs5IjUTPlgkthhJBWonM0awusc8cJkCxnvGD6
+        Drg4fdvHIvslWCieGn47FkqlWh2IxXbL/ycWiklQdCkqYkFyQ0DUjtWuclmtC8zxy7EQB2AhPofF
+        o8YP4UELw3C2LpB7cJxv9D7NiGApL25nJJbZQxnZbvn/ZMRxqY0qUBkspDJVwYx2qhA6z4VRwtwB
+        Iy/Ozs8DdA682ydh7w6hx6W+HYSt2kF3CEuNPhQE+REFV8csnovsOGO79/enuFg3PTdgIb8xE8Ar
+        meW61tSI0FVBb2RTSQWKa60td/J63TBMysrm9EK1kigypuD06jJGcFW42t0RE0Ae+jQQXBQpO+BV
+        sdM7BAkuZGrYoUyIzzChvpYJcbdMFICxgAjrbCUlVmCLyiHLUUCBXKo7YIKeGOioyf5MleAsT/UB
+        ZWKndxAUPE/lwYUi+wwU5muhyP52KF6uPpGNnbv22Wqw0JX1ws93AmyJBgqtn9yRqy9nV91+WNzY
+        zIta8CIrFBQZNfPGAiuohZcMM5bnitsvb+b1sSoOaub3FNfNPHXgb5boZ/dp0Ry6ZNLYb9veXUt/
+        MvsZ/KuhH/3sAZmV7nX2k54+pLOTtkIfJg39yf1dQx9MJ+Zyr6Nftfvbjj43TJisyIz8h3T049AP
+        5buVcdtfiN/cvn+q+bd/qqnGZSwT35P0P5CksTpv/ntS4/b/KF9ya+zieb65c5IPfwEAAP//AwDU
+        Dn72zRkAAA==
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -407,7 +411,7 @@ interactions:
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_e3199f32609b498484ee6b6a583689cd
+      - /api/v2/shipments/shp_cdd6f554132546d2a753f87aa2423876
       pragma:
       - no-cache
       strict-transport-security:
@@ -419,25 +423,98 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - a893930c5eb9ca63fb662f2a00051d75
+      - 45e271c56019eb7cee4cfaf300002b5e
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2sj
+      - bigweb9nuq
       x-proxied:
-      - intlb1sj 5834894b53
-      - extlb2sj 5834894b53
+      - intlb2nuq 9cd9455ca9
+      - intlb1wdc 9cd9455ca9
+      - extlb1wdc 9cd9455ca9
       x-runtime:
-      - '0.927089'
+      - '1.011332'
       x-version-label:
-      - easypost-202005112146-47e058b20a-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode insurance=100.0&rate%5Bid%5D=rate_86eec89b6ed5444e85b7f962f81bfd8c
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/x-www-form-urlencoded
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: GET
+    uri: https://api.easypost.com/v2/shipments/shp_cdd6f554132546d2a753f87aa2423876/rates
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+TWyW7bMBAA0H/RORE4w93XLkAPBYw6uaQohBE5StQ6tkHJQY0g/17ayFJnsRWk
+        qA+5icPhSCQfSF0XiXruitH366KNxWjTrJSHBiCQkiiVQ0FeBJAaRbCGfNMUR8W8/smhzwO+5QG5
+        HRLnh1jROoYC4VjgsZAnQozAjgSc5ZzlIu7NuZxHzr35m/rc6jhdtWEdGKd2ntp+9ZXa6ZdZz2lG
+        fTuf0XT9bkqp5ZSzTifjSQ6sJ5Fb0pXarvuXKfEsrDYJH9f93Ocy1W2aEqURD9En2dO266tHJTex
+        J5mRp+0Vp1UVaZXXdLacTreC6xLPBKvzJSXKk+K8Aw1NOz4q8vyrZ8t1F+3ikmd9tdmu7mJRhRhN
+        o7UCiVqZiGS1bJwlQoXSWfOwQhWFMF/ejQ1U1aiNtuydN6yikRQcaKAglaGggIubo79dgEKHqILi
+        GHNv8NzYCBmItAK8MAdw8en3InHXvYaFhtLBfhZal0YPZHFX8n2y0EKRxpp0tqDAZRBNFE2so2yM
+        Z8uvZ4EDWOAuFp/b1PUfptR1Ywq/6Jy3cExu8142gqIEv98IQolDjdyVfJ9GIijjtGft2Cvtai+c
+        idqjsRadRncAI6fjyaSnWaQUtyVs3SFQgtkP4S5t0B0iSmeGQlBPFDxM05+gHEkxEuKs2OWiT8vn
+        Wah/bIKgVtKaxtR1yFeFrfNGK00ajDEBonp8bjihVB0sgAsqK3LOg4nSOQTtYxMPZILyCr0MAtCX
+        YsBfxX3eEBKAqnRiqAncYUK/1QQe1oQnXh8gGGKoleKagq8jC8tInkHpA5jIvxgc2zx6BwphSzPg
+        mLjPG4QCbKkGHxRyBwr3VhTyv6P4cfMHAAD//wMAvcMcHpsMAAA=
+    headers:
+      cache-control:
+      - no-cache, no-store, must-revalidate, private
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=15768000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-ep-request-uuid:
+      - 45e271c56019eb7eee4cfaf300002ba4
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb4nuq
+      x-proxied:
+      - intlb1nuq 9cd9455ca9
+      - intlb1wdc 9cd9455ca9
+      - extlb1wdc 9cd9455ca9
+      x-runtime:
+      - '0.046142'
+      x-version-label:
+      - easypost-202102022255-07aacc3c41-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: insurance=100.0&rate%5Bid%5D=rate_491f11ca43234820a90c13520c76a9ff
     headers:
       Accept:
       - '*/*'
@@ -456,48 +533,49 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_e3199f32609b498484ee6b6a583689cd/buy
+    uri: https://api.easypost.com/v2/shipments/shp_cdd6f554132546d2a753f87aa2423876/buy
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+xZ62/cNhL/Vwx9ugNsmW9R/uYmDuJDk6axg55zCASKD1u1VqujpDjrIv/7DfXY
-        l117iyTnFg3ghcHhcDSc+c1wOPwt0t6q1ppMtdFRRBBBB4gfYHxO8BFPjjh/H+1HRZN523a+io6c
-        Khu7H81s06hL20RH//kAo7mxsLq1TQvc87ot5hVM/Rbpzntb6QVMvjt7DnO1Wsxs1Ya5dlGHRWcn
-        r5+fvI0+70cG9MiU+agqDRMIKN46G9bDsOrKcj9qWtV2IDnqqutqflOBxNYrfV1Ul5kelHj2imBJ
-        qJRcvDuD+a42D+0vCfvLVauvssJMnxnG08fWaeO+J6LumnY+a7KicvOwpyAi0k0bxplkVggnE2dT
-        x1KXwB/XFlElOWFJmgRT5b9aHRR7Ngg6DXL2d/LJI/vqefS8asHaTWY/1aWqVPALcK/PjF64LFxw
-        3bQfbX1bOHBb6zu7IjfFZWU9sL8Ered+76WazawHSJSw1toyq52G2dc/nZyc7lEU0+Qf6p8wVc2r
-        zNiy+Gj9IhvgAWwjpIKbm9YXOpDBi7MAkGZQc31m1BRk2WgbcsbqUvlxf1uuae0swHTNOUDJdE5y
-        hYSwlCUMIZErKqxIkMKCm4TS+5wD676ic4xttC8mY5yoZvFm3rR77UFzVXgwwH50Be5RvnAuq7pZ
-        3hseE8q4CMr54rII5uqq1g/xBdT/dqqC/cGY7EcfVdkFG6UiJgFsN7a4vAKFCI5xQIBZwnjTmDNV
-        dU5pcE745GTNKZDD+PMHCE7n5zMIVwM+apbYV8ZnueEuYUQiwhUjiOZGGAK/lGgkE7lh2uNx/dcz
-        a6Vmq/Ccz2pVLdbMG4Uc4q1tcTAmlnukMntnKzIBMmuv9l4EROvektGZqvZeeMhKRaPn0ZCE+kxz
-        DIPbog4mZhjxPqw23FFfBbCCRMzBa4lMUYiTmSrK+y2vlfeF9RlYvyj7jw9cYKLCQFQUarnQWWO9
-        KgEgn9YSV6/aFg2CrnCFVlNS/gy+K6qm80OejTBCMUI9pEDk2sJaeW3LpWtrr8tMcEWYplRpLOA/
-        S6WmgmObp0YoijZ8+2ZY//VcW9rqsr2KjjCKAd43hQmDJJYQKSO0WUxBbw+2cUUF0mo4G9bS9VoE
-        kE3bg01qgAfwZqXKh12vNjLM/NhP7I/WKDPpuBS5wFgQw0yic8eQzXXiOKXYWvP4zpMddt7zbB2N
-        wYGtvfT9Ojf3s1Ve7LXPzIDQ35E28ACo5mU3pB+K0ERuituwVHxiS84x84JRVVe2S7IrSjvNFTMw
-        0GFdXS5nOw9GjK7atm6ODg8txF8w8EFY1MQNPeiagxuw/AGJ1Uzdzit108QQr4c9w+GGMw7DPhDH
-        +JCnKcY5VkyAsV1OU6N4biVBxmieShOva1AbN2gxOH8g3tblXaKtS3KXGjQZ8x2EIFh07RgJw0wj
-        pbQVSjAJkWCZUqnMU25xTohJNVsPhrfBI48CQuwAiJ5nM2801n8s+mB+UfimfVaqpnkzQP8UgOKH
-        k1+VZyPfMtP0iepNSFV+QAxO4wRH+3cLNzisIW1lfgJWnPAV9Q53WTRttiWyp93hXJYFRi2WtdYa
-        sbX3ErPLDs572BuE2VSTgi2ye8XBgVqHoqLPbTCqM0txmjpKBEpzyGEMSjULoay4pEKm2qzlYqX7
-        pD6s1SrLCRc8salMhWVGQCaUmGMFuVAozbCFVLKOESms1TLNhTWcMWYlzxOXCuIkzp2R+gkw8sYX
-        UD20i1fgug14PIALmsSUPY4LmsYU7YiLSeTfExcqSRSjqUVOEEYNkUoKpnSiqISyydInwMXJpzrU
-        Yn8EFhzHcod0wXksdk0Xk8i/Jyzg3sqMNYIQnjBOIFkgyYiGqj+RwtjkaWBhDdyZzCYO1mGQyhiT
-        x2Ewse10aiARC7QrDugdEKx2yc4JhQLnCKH30UOwGK6696CCfmVIKJwzmggn8lzDNSnJucwZVxwL
-        ITQ2bAsSyLEEpBKjXMoUN4poCeVOYpWzjuingAQ4/0yBhX4fEXC1itkOmWHJtxMmMI2J2BUT5AFM
-        0C/FBHlaTLBEc4WdQVhRlnME1XCqHYIiGc6QNHmKqiJgolWVUf6BREHG+uCx8vIPlBHAy3fOE+IB
-        TKRfignxf8fEh75F2lVmq1fZaFWN98KRYEsAA3h2MNq3LVB3vtV+L1D/ZJXI0EwP1h0R0vrrTMPB
-        g7DlOXyGGa2kM6kVRBIJylC0ccs9H9dv+/axJv09ff2BBHZp+3bZ2szXgl/fzTZZvthuDw2jLa+s
-        /PklXlnhdmmSYYfjS4qz05vK5MbJAGNPrsvLQm81V3pR8dRi6bso5tcTYV7+y/+bvL6++OXi5tUv
-        7/DF7JRcnL+9viAn7P3sZ/7+/GLx0/NT9v781adXt8eoB8D83pauSpRBxnGhiWE4dWmeCqcoNzRc
-        YMRGkvhWLd3oTN0srN/7AfhnqgfC1N6dmp/Lxu7x3o/KXzd15/eegTJxtN7fjVad3TbeOy5z69to
-        1dY9/iGa2rqtrMiszyrLvm7f9J36uolERNKUysDzZ+jrdk3dZLe9ctMXwhvL9zb9X7NNn3eLkMi/
-        B+RfNiBDETa0jZfueBHqsvEVIUxnOvSwtZDK5JxZ46Ce51YrJCkcK0ihb1Zx9V8fG/j9u6vXsPGs
-        qD7Ohy5xz/BljfwgYtW/Z9zmJmVIWAy3WqFzRxW3mBNuckawjWvjgue7fFa0YTN93ernFZi1LMf3
-        6M+rc3LdrDZoPO6mf6oZKGoWoAK08MqF+ocufaX85aqUH0roZT0Wblr3Sx3fgbbk9mXilwk+nZ7j
-        tkTjXVX+MOJpx2JkqcXZWMpEn/8HAAD//wMAXseEWQkiAAA=
+        H4sIAAAAAAAAA+xZWXPcuBH+Kyo+JRWJwk1Abz7k2Fsrr9aSK/GmXCwQACVaHA4DkpZHW/7vafCY
+        S7I1LjlRkvXboNHo6ePrRqP5e2S8062zqW6jo4gggg8QOUD0HKEjnBwh/Fu0HxVN6l3b+So6ynXZ
+        uP1o5ppGX7gmOvrHe1jNrYPTrWta4J7XbTGvYOv3yHTeu8osYPPt2XPYq/Vi5qo27LWLOhw6O379
+        /PhN9Hk/sqBHqu1HXRnYQEDxLnfhPCyrriz3o6bVbQeSo666qubXFUhsvTZXRXWRmkGJZydEKpwI
+        htTbM9jvavs1+2iwL9OtuUwLO/3NsJ7+bJ022j0RTde081mTFlU+DzYFEZFp2rBOkRCJ0BLnSFCG
+        JJdEZJZLxqQxyFAdXJV9cCYo9mwQ9CrI2b8vJui3++3qecy8asHbTeo+1aWudIgLcK/vjFG4KPIQ
+        uske43xb5BC21nduRW6Ki8p5YH8JWs/93ks9mzkPkCjhrHNlWucGdl//cnz8ao+imCZ/0n+GrWpe
+        pdaVxUfnF+kAD2AbIRXC3LS+MIEMUZwFgDSDmus7o6Ygy0XbkLPOlNqP9m2FpnWzANO14AAltRAc
+        lWWGJsoxTLWmiOWaMwskTkxyV3Dg3HcMjnWN8cXkjGPdLE7nTbvXHjSXhQcH7EeXEB7tizxPq26W
+        9Y7HhDIugnK+uCiCu7qq9UN+AfWfna7APliT/eijLrvgIyViEuy5dsXFJShEcIwDAuwSxpvOnOmq
+        y7WB4IS/nLw5JfKwdsaMnv78HhI19/MZpK6FeDXLPNDWp5bIHJFMiyTjTGKUcZswoZ3gDHye5Otu
+        fjKev9/Ff4EfCO3g5yVjpWerpJ3Pal0t1pwehcrinWtxcDGWe6Sye2crMgEyay/3XgScm96/0Zmu
+        9l54qFVFY+bRUJr6+vMEFjdFHRzPMOJ9sm0Eqb4MEAaJmEMsE6mCgm6mi/LueBjtfeF8CjEpyv7P
+        By5wVmEhVwq9PJg767wuATaf1spZr9oWDVKxyAujp1L9GaJYVE3nh+obYYTi3nNzDyLXDtbaG1cu
+        g1x7U6bOUeESnVBhKUs4zQRKbEYYYRayydL1KJ8O579fHpWuumgvoyOMYgD9dWHDIokl5M8IeBZT
+        0NuDb/KiAmk13BhrRXwtL8im78EnNcADeNNSZ4PVK0OGnZ/7jf3RG2WKFcqNxRYzRpliBrKCUUV0
+        glVCMsXut5zsYHl/bW1dmCGArbvw/bl87meratlrn9oBoV/4x4EHQDUvu6EoUYQmclPchKPiE1ty
+        jvUYnKq7sl2S86J0014xAwcd1tXFcrfz4MTosm3r5ujw0EH+BQcfhENN3NCDrjm4Bs8fkFjP9M28
+        0tdNDPl62DMcbgTjMNiBCKKHzCCGHMeEUMkUopooAa6nkkqTOOTidQ1qmw9aDMEfiDd1eZvo6pLc
+        pgZNxsoHKQgeXbtcwjJlCucYG80o1GpJkFbIYLhTkIFuQOUbJe9NiMi9gMA7AKLn2awbjfMfiz6Z
+        T30B90W7OIEa8wow4odWQJer6tIXp9NQnvyAEipjnkT7t1s4uLZBTDqyMRQLtKLe4i6Lpk23RPa0
+        W5zLBsHqxbLrWiO27k5ietHBzQ9GObvsTsH+9E5xcLXWob3o6xms6tRYK3LOoQUgnAkLecppLhOt
+        oXpRmYi1+qtNX8iHs0anGeGCJ05JJRyzgmojMcfaULjgDMMOysc6LjAjkhBmmIOKgJ1RLk8sBoDQ
+        BEHREI+Ai+NPdbhxvwUWHMcS3w8LzmPBd4TFJPKPCQuOmObQIXHAAsMSAJFblNvM0lwol7hvh8Uu
+        9wf5GixeFL5pn5W6aU6Hm3IDHGcj35cxQlCM1f0YCfftrhiZRP4xMQLNhJBcOS6dYlxmCklhuSIi
+        SYjkRD4CRt6enp21urLa200kbNwh8NIQ9wNhYtvpDkGxFLsCgd1CwcpMdU4odDjLx9iXcDG8gO+A
+        BfvOmNA4YzQRuYBXKVwV8GCSGeOaYyGEwZZt1w2JGMtMAs8VwwBFUioM7beUBHNlc/tImNDgoS8D
+        AhMVox26iiXfLpDAhMUS7YoJ8hVM8IdigjwuJpR2oYAQY03GmMu0UZl1KHFEK4cZfwRMQIvhbAGn
+        vwIKlMRihzKx5NsJFDiJ2c6Fgn4FFPKhoKD/cVC870enXWW3ZpiN0dX4MhwJrgQ0QGgHr/17nzEP
+        xtKPZ8wj9SLDkD14d0RI66/SzGaKJSo3ucDMMQAIFpwQxKS2ArmNpuR8PL8d2/uG93fM+wcS+KXt
+        B2ZrO/fAj+46Vumn3DbNFtsDonH0uRmVVTwfEpUVbpcuGSwcv7DkbvrWMoVxcsA4leuysjBb45Ve
+        VDwNWfo5iv1wLOzLn/zfyU9X7z5codc35ewdeUdOzt+Ur58/vfzl/Ji8Pn+1OHn+K3v3t1/JyV/f
+        sh4A8zvHuyQnWFHFtaIcOhCjkdJJzpCjKEk4NtE3j3fFEVc7jXc3GIfxbnSmrxfO7z2FQzPdQ2Ia
+        9U6D0OWQ98nez9pfNXXn956BWnG0PuuNVlPeNt57UmbOt9FqxPvkaTSNeFtZkVk/01vOePsB8DTj
+        TSQikioqA89/w4y3a+omvemVm/4hfIX5Mbz/Xx/eZ90iFPcfSfp/kKShRRvGysvAvAhd2/iVIWyn
+        WCSOOqlUzqE/E1YbbohjxPEMaIn8jhfiphf6fx8H/P3XWm/A8LSoPs6HsVDP8LBBfxCxmu8TkxF4
+        1ViFqWaQctJB1+tyIAvHqdJxbUMtarpsVrTBmL6r9fMK3FqW41fsz6tbdN2tLmg8WtN/yhkoehag
+        ArTwFQz18DWX2l+sGv2hwV52a+EhdrfU8TvRlty+iXyY4FfT57ot0XhXld+PeNqxVVlqcTY2OtHn
+        fwEAAP//AwAgOkWgPyIAAA==
     headers:
       cache-control:
       - no-cache, no-store, must-revalidate, private
@@ -518,18 +596,19 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ep-request-uuid:
-      - a893930c5eb9ca64fb662f2a00051da6
+      - 45e271c56019eb7eee4cfaf300002bb4
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6sj
+      - bigweb2nuq
       x-proxied:
-      - intlb1sj 5834894b53
-      - extlb2sj 5834894b53
+      - intlb2nuq 9cd9455ca9
+      - intlb1wdc 9cd9455ca9
+      - extlb1wdc 9cd9455ca9
       x-runtime:
-      - '1.520205'
+      - '1.176205'
       x-version-label:
-      - easypost-202005112100-59b664a857-master
+      - easypost-202102022255-07aacc3c41-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -71,6 +71,12 @@ def test_shipment_creation():
     rate_id = shipment.rates[0].id
     assert rate_id is not None
 
+    previous_ids = set(r.id for r in shipment.rates)
+
+    # Get the rates back
+    shipment.get_rates()
+    assert set(r.id for r in shipment.rates) == previous_ids
+
     # Assert address values match
     assert shipment.buyer_address.country == to_address.country
     assert shipment.buyer_address.phone == to_address.phone
@@ -170,7 +176,7 @@ def test_rerate(vcr):
 
     easypost.requests_session.close()
 
-    shipment.get_rates()
+    shipment.regenerate_rates()
 
     new_rate_id = shipment.rates[0].id
     assert new_rate_id is not None


### PR DESCRIPTION
Starting soon in the future,`get_rates()` will always be read-only (as you would expect from a GET), and re-rating will be triggered through the new `regenerate_rates()` function. This adds the new function. No change has occurred to `get_rates()` yet.