### PR TITLE
feat(smartrate): adds smartrate functionality

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -2,12 +2,12 @@ import datetime
 import json
 import platform
 import re
-import six
 import ssl
 import time
 import types
 
-from six.moves.urllib.parse import urlencode, quote_plus, urlparse
+import six
+from six.moves.urllib.parse import quote_plus, urlencode, urlparse
 
 from .version import VERSION, VERSION_INFO
 
@@ -724,6 +724,14 @@ class Shipment(AllResource, CreateResource):
     def get_rates(self):
         requestor = Requestor(self._api_key)
         url = "%s/%s" % (self.instance_url(), "rates")
+        response, api_key = requestor.request('get', url)
+        self.refresh_from(response, api_key)
+        return self
+
+    def get_smartrates(self):
+        requestor = Requestor(self._api_key)
+        url = "%s/%s" % (self.instance_url(), "smartrate")
+
         response, api_key = requestor.request('get', url)
         self.refresh_from(response, api_key)
         return self

--- a/tests/cassettes/test_smartrate.yaml
+++ b/tests/cassettes/test_smartrate.yaml
@@ -1,0 +1,191 @@
+interactions:
+- request:
+    body: shipment%5Bfrom_address%5D%5Bcity%5D=San+Francisco&shipment%5Bfrom_address%5D%5Bcountry%5D=US&shipment%5Bfrom_address%5D%5Bemail%5D=support%40easypost.com&shipment%5Bfrom_address%5D%5Bname%5D=EasyPost&shipment%5Bfrom_address%5D%5Bphone%5D=4153334444&shipment%5Bfrom_address%5D%5Bstate%5D=CA&shipment%5Bfrom_address%5D%5Bstreet1%5D=417+Montgomery+Street&shipment%5Bfrom_address%5D%5Bstreet2%5D=5th+Floor&shipment%5Bfrom_address%5D%5Bzip%5D=94104&shipment%5Bparcel%5D%5Bheight%5D=5&shipment%5Bparcel%5D%5Blength%5D=20.2&shipment%5Bparcel%5D%5Bweight%5D=65.9&shipment%5Bparcel%5D%5Bwidth%5D=10.9&shipment%5Bto_address%5D%5Bcity%5D=Redondo+Beach&shipment%5Bto_address%5D%5Bcountry%5D=US&shipment%5Bto_address%5D%5Bemail%5D=dr_steve_brule%40gmail.com&shipment%5Bto_address%5D%5Bname%5D=Dr.+Steve+Brule&shipment%5Bto_address%5D%5Bphone%5D=4153334444&shipment%5Bto_address%5D%5Bstate%5D=CA&shipment%5Bto_address%5D%5Bstreet1%5D=179+N+Harbor+Dr&shipment%5Bto_address%5D%5Bzip%5D=90277
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '976'
+      Content-type:
+      - application/x-www-form-urlencoded
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: POST
+    uri: https://api.easypost.com/v2/shipments
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xZS5PTOBD+Ky5fd3DpaUk5MTCwe1golsCFLcqllycGx87KDhAo/vu2nMeEYSZj
+        YGpSUOQUt1pSq7+vu/X4lNrgde9doft0khJE8D3E72H0guAJohMiXqUnadUVwffL0KSTUtedP0nn
+        vuv0ue/Syb+fUqtDqHyA/g91s9ABemxEhba2XTZ9UTlotbrgknHsiTDcWFbm1jCsnDIec4GgTUDX
+        frXwoBzAqsKH0MbhNtOB+GWjTe2Tvk3AIpjinU/WkyaxQ5eUbUiatrn38DRpQ3VeNUk3qxZz3/Rd
+        ln5+DUO1Lo4Duj0M3C76qm1gGbCKZQi+sas4yfQM2hZ6FfvFto1N00dPzx49Tz+fpC5ap9073Vho
+        QCAJvvSxP3w2y7o+Sbte90sYOV02b5v2fROXFrR9WzXnhR2MWOstF+4QADICYHRvZ4MT133W39sZ
+        9mU7T62Fdtn17bwrqqZst7IytHOw3QVQjYsbsNEuFIpJ6wnTQhDJkGXKIUwAGGNzhjk10V/mjbfR
+        0NNN/5MbCfQHQhOE0hsXeqHY6Hn09iPdrZ61A0y2nS90s7pwbfC+x6DDsEietE1/3s59WCXToSHd
+        ahDQ4P0seVy3A41s1Ud4p7pJHgeArupsm66RihM+PIWPj9UC/iqGERsmBvaGNSciJWZt44dpOaWU
+        wQ+Efq6rGoTdcrFoQ3/fg90LsDsDq9PLhNsGRqltVQ/mrJcEzqwcsK3S9Q4n73zQddHrD3vQD8Ze
+        kr3zoSorq7dc/gx8rJpuGfQeH9sAw+11gpixvt4RYBFsXSginSsx8xyXTBgpidA0RxYjiojScp8B
+        z9b9bybAqxHYR53aN+f9LJ0QlJGT9H3l4gdGmTpJZ746n0FXniEwPIBjyqqB4RYQT3tsf79Ry3ns
+        tO94cEiEBHSLWhu/8/GQNIYkNjhhSDrOAOdz7hkAwEqKTalybiU32pVSIrfvhOeROTe6QI5wwaDz
+        JVc6H95VdgiFD4tttO1y7cvps0jJsOYuI5ngsf1yFoM0CfQstmoqY/xC+pV2XXV9cWnIQfaVpvN1
+        BbxbFU6vdjloT9j7K4XF+VIDLXvv3a6YwGqLK4fbpu51+ehmi8JwixQUC8Z1yUiZS6dLyXDuABxL
+        hTxQev5r8n8e5qUDLuyjDQzHmDFuS+eZFcII5oQiBmnHnZflEdB+FiqoXZAbrodbZZzejDYmGUcj
+        0d6MOApscotIk7uB2WGuhc81ZzRnQgvNieReWo0wEkiKY8A8JNCpr+Osh6Am8maoN1rjkB5URyHN
+        bxFpfjdI54LmxjojkaXMSCMtVC6jlVIit3lOj4A0PdOrq3Deh5nwTIzAeas2BmiSZ2o00vQrpC9W
+        SV8QOhl2Z6/S78Oe3jL2Qc7+rtWb6SXsmSLCYkyFpzxuZs3ABeYUhLx1Qy68a+yf+g89wH9ahUc6
+        1KvTJ9dTAFOa0TFpfas3hgSYyixHY1mAD7AAv0Dyx1iA74YFiDslJVfKIsOkcZoSBOfOsiSsFJzZ
+        I7CANG5NgkP4U5FxdjP8W7VReziUcfX9Zf1imeSHU8BtF/rrwJcljCAE7NThHKOwIlQj77HDueFS
+        HGP3/mcAw92BuGcZHbF336qNi/pvSP2/BO6lRjmThBNnIcx5KbUnGjHBGKQB2OUdNfVPNTjkegIo
+        mZEReX+rNooAiGU4v520/6MMuKO0Lz0RWBIFR3bFcqy1LXOBhciNwBh7c1QGHIh+hDOKR4T/Vm8c
+        /HnGRyeAw/BjNKE/AfyYaSe4K3NqMVNIKCMx1cwzoozNET9m1T9Q82nGyYiav1Ebgz3Ns/wHjvI/
+        R+5/Pdy4Q1m9dAveWd0UZRvmO8Fw7gIAw97xdbiIj2BsPtsr78MlxTljBI6NXDLYQ0gGlcVDaOlS
+        GUK/OEnewX34WciSaR9fPB6EZT3w97prcSxU8jT5SwfThuQs0m93Ib55F1jfhD/3rm1cmzzw2s7S
+        q2/CEREi/babcPBdFw0tTDT0/nkUH/c2fNktuuLjYDIbomgZmt9vIL/6G4hZrmIS+R3av3Jox2Qf
+        n3Bex4H85t+3FJsd0NNNqUo//w8AAP//AwDv00GpFx8AAA==
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"1541d88e28c3e5183353ef0e5952b194"
+      expires:
+      - '0'
+      location:
+      - /api/v2/shipments/shp_b5c0915745af42f68daf8416dbadc378
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=15768000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-canary:
+      - direct
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - b12f390860999f9fe789f99e000458cf
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb7nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq 7ba176609e
+      - extlb1nuq 7ba176609e
+      x-request-id:
+      - 174696e5-4098-4c44-b1ea-65a8cec50451
+      x-runtime:
+      - '1.304631'
+      x-version-label:
+      - easypost-202105102029-6e7a60b19a-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/x-www-form-urlencoded
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: GET
+    uri: https://api.easypost.com/v2/shipments/shp_b5c0915745af42f68daf8416dbadc378/smartrate
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+zYXW/bNhQG4P+ia1fg4Td1V6zFbrahm7ObDoPAz0WF4niUXNQI8t9H2Q5sh8JG
+        pHUHdwNyk6NXtGQ94NHxQxX9sOnHqvntobI6xs7Hqql+Xb5bVounQqutvd+sxrZz6ZjV7Z8r/vN3
+        PLgpEr0evWt1WqLCCMMrxF4BusHQINJg+X7KbGL0K7vdLfwmFZzvu48+bluXzq2a1abvnxXbPzY6
+        6tXoffrIoPvBnwW2w9NZfhjb2QO7a43TUs4wgTjzNHhHAwETFGdWMqNdkBJNd9F3aZnsMnfVuLtE
+        imvBFtXdvUv/VGP61HT83nzwdrrvX6bMojqLRj/qrs8XPdQPWVXTlB18/NjZaeW3n9bpgQwpN9x2
+        6zv/9KUPt+vWMIsUMEGZDhQHLp0OkgJ36UYsETKdNHZ3vu1W7Zi+u6FLl/ZQrX20aZmu9y1DVYMX
+        pxXBnldkqpCzikJZJWXoeUVUDTuvqKoRj4tqs3b/4ONxcW3y8Cw7fGoOCw1AKbPBeWqFMII6obBB
+        2jHnZSgxp2pGysjtk0XiANdn4N7F7j524/Zy4qBAHH6ROJqJ49+oODYrjp3tcsC08FwzSjgVWmiG
+        JfPSagRIICnKxGFZKm5KFonbR0/E6fTI+qXvp2W/4j7HMnU8UyczdQAZO8CZO5Avgfe37qK8/aFX
+        H5ZfyN3xPHKDSYNQ+nv/PFYgkcxKJKcSuSDcWGcksoQaaaTFShutlBLcck5KJGJeq0KKmNWi1OIh
+        e8RI3ujtpSm+bAPEGUWcSSQZRHI9DuEGyZc7hFmHcOqQKiwsABGeMCqtNzuX1Km0PVqXnkyBQyCy
+        5mUOgZCaFLfhQ/go8Sf/aUwYX3fxrY799vWPlwO570HPTGZFOVdUc6er2aSYK6p98XqU4s/aLQve
+        FBFzSkqmlEWGSuM0wUhSFgKmQTBqi6YTVDNVppSImtFCpIfs0SheuT3R/3X+V3TKkJ6gEGlOBuoV
+        KEw08h4ccMOkKJqdgRT3cqA1KZ2dD9mjzu9j+tLd1+zj8IX6eP5Cia/HIHyWwYI+HjTiVGKGnU17
+        IgtSe6wRFZSmPTONN0UGEa2hsJErWePSPn7IzrXxpU439O9qhEwj5ANOPt/k4801aQTUkAtqlB4L
+        kFgFAopy0NoGLkAIbgQAeFOmkdesdEtEUBMo3RMP4TmP3wbFK9oYL96cgWonmAucWKAKCWUkEE09
+        xcpYjlgJRcJrXvgrYxpZGC59ddxnZ14dr3HOzvtz4Zz9++NfAAAA//8DAHy8jJJhGQAA
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"f858b3a97b81e649b56017ad96b408b9"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=15768000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - b12f390860999fa0e789f99e00045946
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb2nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq 7ba176609e
+      - extlb1nuq 7ba176609e
+      x-request-id:
+      - c6f83f52-f7f2-40bd-a54f-92269ab0a987
+      x-runtime:
+      - '0.082920'
+      x-version-label:
+      - easypost-202105102029-6e7a60b19a-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -206,13 +206,20 @@ def test_smartrate(vcr):
         'height': 5,
         'weight': 65.9
     }
+
     shipment = easypost.Shipment.create(
         to_address=to_address,
         from_address=from_address,
         parcel=parcel,
     )
-
     assert shipment.rates
 
     smartrates = shipment.get_smartrates()
-    assert smartrates['result'][0]['time_in_transit']
+    assert shipment.rates[0]['id'] == smartrates['result'][0]['id']
+    assert smartrates['result'][0]['time_in_transit']['percentile_50'] == 2
+    assert smartrates['result'][0]['time_in_transit']['percentile_75'] == 2
+    assert smartrates['result'][0]['time_in_transit']['percentile_85'] == 3
+    assert smartrates['result'][0]['time_in_transit']['percentile_90'] == 3
+    assert smartrates['result'][0]['time_in_transit']['percentile_95'] == 4
+    assert smartrates['result'][0]['time_in_transit']['percentile_97'] == 5
+    assert smartrates['result'][0]['time_in_transit']['percentile_99'] == 7

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -12,23 +12,23 @@ def test_shipment_creation():
 
     # create a to address and a from address
     to_address = easypost.Address.create(
-        name="Sawyer Bateman",
-        street1="1A Larkspur Cres.",
-        street2="",
-        city="St. Albert",
-        state="AB",
-        zip="t8n2m4",
-        country="CA",
-        phone="780-283-9384"
+        name='Sawyer Bateman',
+        street1='1A Larkspur Cres.',
+        street2='',
+        city='St. Albert',
+        state='AB',
+        zip='t8n2m4',
+        country='CA',
+        phone='780-283-9384'
     )
     from_address = easypost.Address.create(
-        company="EasyPost",
-        street1="118 2nd St",
-        street2="4th Fl",
-        city="San Francisco",
-        state="CA",
-        zip="94105",
-        phone="415-456-7890"
+        company='EasyPost',
+        street1='118 2nd St',
+        street2='4th Fl',
+        city='San Francisco',
+        state='CA',
+        zip='94105',
+        phone='415-456-7890'
     )
 
     # create a parcel
@@ -41,22 +41,22 @@ def test_shipment_creation():
 
     # create customs_info form for intl shipping
     customs_item = easypost.CustomsItem.create(
-        description="EasyPost t-shirts",
+        description='EasyPost t-shirts',
         hs_tariff_number=123456,
-        origin_country="US",
+        origin_country='US',
         quantity=2,
         value=96.27,
         weight=21.1
     )
     customs_info = easypost.CustomsInfo.create(
         customs_certify=1,
-        customs_signer="Hector Hammerfall",
-        contents_type="gift",
-        contents_explanation="",
-        eel_pfc="NOEEI 30.37(a)",
-        non_delivery_option="return",
-        restriction_type="none",
-        restriction_comments="",
+        customs_signer='Hector Hammerfall',
+        contents_type='gift',
+        contents_explanation='',
+        eel_pfc='NOEEI 30.37(a)',
+        non_delivery_option='return',
+        restriction_type='none',
+        restriction_comments='',
         customs_items=[customs_item]
     )
 
@@ -105,23 +105,23 @@ def test_rerate(vcr):
 
     # create a to address and a from address
     to_address = easypost.Address.create(
-        name="Sawyer Bateman",
-        street1="1A Larkspur Cres.",
-        street2="",
-        city="St. Albert",
-        state="AB",
-        zip="t8n2m4",
-        country="CA",
-        phone="780-283-9384"
+        name='Sawyer Bateman',
+        street1='1A Larkspur Cres.',
+        street2='',
+        city='St. Albert',
+        state='AB',
+        zip='t8n2m4',
+        country='CA',
+        phone='780-283-9384'
     )
     from_address = easypost.Address.create(
-        company="EasyPost",
-        street1="118 2nd St",
-        street2="4th Fl",
-        city="San Francisco",
-        state="CA",
-        zip="94105",
-        phone="415-456-7890"
+        company='EasyPost',
+        street1='118 2nd St',
+        street2='4th Fl',
+        city='San Francisco',
+        state='CA',
+        zip='94105',
+        phone='415-456-7890'
     )
 
     # create a parcel
@@ -134,22 +134,22 @@ def test_rerate(vcr):
 
     # create customs_info form for intl shipping
     customs_item = easypost.CustomsItem.create(
-        description="EasyPost t-shirts",
+        description='EasyPost t-shirts',
         hs_tariff_number=123456,
-        origin_country="US",
+        origin_country='US',
         quantity=2,
         value=96.27,
         weight=21.1
     )
     customs_info = easypost.CustomsInfo.create(
         customs_certify=1,
-        customs_signer="Hector Hammerfall",
-        contents_type="gift",
-        contents_explanation="",
-        eel_pfc="NOEEI 30.37(a)",
-        non_delivery_option="return",
-        restriction_type="none",
-        restriction_comments="",
+        customs_signer='Hector Hammerfall',
+        contents_type='gift',
+        contents_explanation='',
+        eel_pfc='NOEEI 30.37(a)',
+        non_delivery_option='return',
+        restriction_type='none',
+        restriction_comments='',
         customs_items=[customs_item]
     )
 
@@ -175,3 +175,44 @@ def test_rerate(vcr):
     new_rate_id = shipment.rates[0].id
     assert new_rate_id is not None
     assert new_rate_id != rate_id
+
+
+@pytest.mark.vcr()
+def test_smartrate(vcr):
+    to_address = {
+        'name': 'Dr. Steve Brule',
+        'street1': '179 N Harbor Dr',
+        'city': 'Redondo Beach',
+        'state': 'CA',
+        'zip': '90277',
+        'country': 'US',
+        'phone': '4153334444',
+        'email': 'dr_steve_brule@gmail.com'
+    }
+    from_address = {
+        'name': 'EasyPost',
+        'street1': '417 Montgomery Street',
+        'street2': '5th Floor',
+        'city': 'San Francisco',
+        'state': 'CA',
+        'zip': '94104',
+        'country': 'US',
+        'phone': '4153334444',
+        'email': 'support@easypost.com'
+    }
+    parcel = {
+        'length': 20.2,
+        'width': 10.9,
+        'height': 5,
+        'weight': 65.9
+    }
+    shipment = easypost.Shipment.create(
+        to_address=to_address,
+        from_address=from_address,
+        parcel=parcel,
+    )
+
+    assert shipment.rates
+
+    smartrates = shipment.get_smartrates()
+    assert smartrates['result'][0]['time_in_transit']


### PR DESCRIPTION
Adds the new `/smartrate` endpoint/method on the `Shipment` object.

Simply call `get_smartrates` on the shipment object and you'll be returned a list of smartrates like so:

```json
{
    "result": [
        {
            "carrier": "USPS",
            "carrier_account_id": "ca_123...",
            "created_at": "2021-05-04T21:15:59Z",
            "currency": "USD",
            "delivery_date": null,
            "delivery_date_guaranteed": true,
            "delivery_days": null,
            "est_delivery_days": null,
            "id": "rate_123...",
            "list_currency": null,
            "list_rate": null,
            "mode": "test",
            "object": "Rate",
            "rate": 0.01,
            "retail_currency": null,
            "retail_rate": null,
            "service": "First",
            "shipment_id": "shp_123",
            "time_in_transit": {
                "percentile_50": 2,
                "percentile_75": 3,
                "percentile_85": 4,
                "percentile_90": 4,
                "percentile_95": 4,
                "percentile_97": 4,
                "percentile_99": 4
            },
            "updated_at": "2021-05-04T21:15:59Z"
        },
...
    ]
}
```

A full code example would look like this:

```python
shipment = easypost.Shipment.retrieve('shp_123...')
smartrates = shipment.get_smartrates()
print(smartrates)
```