### PR TITLE
chore: bump to v5.1.0 for SmartRate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+### 5.1.0 2021-05-14
+
+* Adds `SmartRate` functionality to the `Shipments` object (available by calling `get_smartrates()` on a shipment)
+
 ### 5.0.0 2020-08-10
+
 * Add `all` method for retrieving Events
 * _[backwards-compatibility break]_ Remove `all` method for some un-supported types: CustomsItem, CustomsInfo, Pickup, and Order
 
 ### 4.1.0 2020-05-11
+
 * change tests to use [vcrpy](https://github.com/kevin1024/vcrpy) so they are more reliable
 * add `original_exception` to `easypost.Error` in cases where we are re-raising an underlying error (e.g., an HTTP exception)
 * fix a bunch of flake8 warnings
@@ -10,6 +16,7 @@
 * Swap GET to POST on Refund method
 
 ### 4.0.2 2020-05-05
+
 * cleaned up how the `__version__` attribute is populated to no longer throw warnings (#95, #98, #104)
 * added some misding reports
 * fix stale tests

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-import sys
 import io
+import sys
+
 try:
     from setuptools import setup
 except ImportError:
@@ -22,7 +23,7 @@ with long_description_open('README.md', encoding='utf-8') as f:
 
 setup(
     name='easypost',
-    version='5.0.0',
+    version='5.1.0',
     description='EasyPost Shipping API Client Library for Python',
     author='EasyPost',
     author_email='support@easypost.com',


### PR DESCRIPTION
Version bump from v5.0.0 to v5.1.0 for new SmartRate functionality.

Will need help cutting a new release on PyPi. Would be cool to have auto-releasing via GitHub Actions when a new tag is created.