### PR TITLE
fix: stops appending smartrates to Shipment object

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -733,8 +733,7 @@ class Shipment(AllResource, CreateResource):
         url = "%s/%s" % (self.instance_url(), "smartrate")
 
         response, api_key = requestor.request('get', url)
-        self.refresh_from(response, api_key)
-        return self
+        return response
 
     def buy(self, **params):
         requestor = Requestor(self._api_key)

--- a/tests/cassettes/test_smartrate.yaml
+++ b/tests/cassettes/test_smartrate.yaml
@@ -23,34 +23,34 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+xZS5PTOBD+Ky5fd3DpaUk5MTCwe1golsCFLcqllycGx87KDhAo/vu2nMeEYSZj
-        YGpSUOQUt1pSq7+vu/X4lNrgde9doft0khJE8D3E72H0guAJohMiXqUnadUVwffL0KSTUtedP0nn
-        vuv0ue/Syb+fUqtDqHyA/g91s9ABemxEhba2XTZ9UTlotbrgknHsiTDcWFbm1jCsnDIec4GgTUDX
-        frXwoBzAqsKH0MbhNtOB+GWjTe2Tvk3AIpjinU/WkyaxQ5eUbUiatrn38DRpQ3VeNUk3qxZz3/Rd
-        ln5+DUO1Lo4Duj0M3C76qm1gGbCKZQi+sas4yfQM2hZ6FfvFto1N00dPzx49Tz+fpC5ap9073Vho
-        QCAJvvSxP3w2y7o+Sbte90sYOV02b5v2fROXFrR9WzXnhR2MWOstF+4QADICYHRvZ4MT133W39sZ
-        9mU7T62Fdtn17bwrqqZst7IytHOw3QVQjYsbsNEuFIpJ6wnTQhDJkGXKIUwAGGNzhjk10V/mjbfR
-        0NNN/5MbCfQHQhOE0hsXeqHY6Hn09iPdrZ61A0y2nS90s7pwbfC+x6DDsEietE1/3s59WCXToSHd
-        ahDQ4P0seVy3A41s1Ud4p7pJHgeArupsm66RihM+PIWPj9UC/iqGERsmBvaGNSciJWZt44dpOaWU
-        wQ+Efq6rGoTdcrFoQ3/fg90LsDsDq9PLhNsGRqltVQ/mrJcEzqwcsK3S9Q4n73zQddHrD3vQD8Ze
-        kr3zoSorq7dc/gx8rJpuGfQeH9sAw+11gpixvt4RYBFsXSginSsx8xyXTBgpidA0RxYjiojScp8B
-        z9b9bybAqxHYR53aN+f9LJ0QlJGT9H3l4gdGmTpJZ746n0FXniEwPIBjyqqB4RYQT3tsf79Ry3ns
-        tO94cEiEBHSLWhu/8/GQNIYkNjhhSDrOAOdz7hkAwEqKTalybiU32pVSIrfvhOeROTe6QI5wwaDz
-        JVc6H95VdgiFD4tttO1y7cvps0jJsOYuI5ngsf1yFoM0CfQstmoqY/xC+pV2XXV9cWnIQfaVpvN1
-        BbxbFU6vdjloT9j7K4XF+VIDLXvv3a6YwGqLK4fbpu51+ehmi8JwixQUC8Z1yUiZS6dLyXDuABxL
-        hTxQev5r8n8e5qUDLuyjDQzHmDFuS+eZFcII5oQiBmnHnZflEdB+FiqoXZAbrodbZZzejDYmGUcj
-        0d6MOApscotIk7uB2WGuhc81ZzRnQgvNieReWo0wEkiKY8A8JNCpr+Osh6Am8maoN1rjkB5URyHN
-        bxFpfjdI54LmxjojkaXMSCMtVC6jlVIit3lOj4A0PdOrq3Deh5nwTIzAeas2BmiSZ2o00vQrpC9W
-        SV8QOhl2Z6/S78Oe3jL2Qc7+rtWb6SXsmSLCYkyFpzxuZs3ABeYUhLx1Qy68a+yf+g89wH9ahUc6
-        1KvTJ9dTAFOa0TFpfas3hgSYyixHY1mAD7AAv0Dyx1iA74YFiDslJVfKIsOkcZoSBOfOsiSsFJzZ
-        I7CANG5NgkP4U5FxdjP8W7VReziUcfX9Zf1imeSHU8BtF/rrwJcljCAE7NThHKOwIlQj77HDueFS
-        HGP3/mcAw92BuGcZHbF336qNi/pvSP2/BO6lRjmThBNnIcx5KbUnGjHBGKQB2OUdNfVPNTjkegIo
-        mZEReX+rNooAiGU4v520/6MMuKO0Lz0RWBIFR3bFcqy1LXOBhciNwBh7c1QGHIh+hDOKR4T/Vm8c
-        /HnGRyeAw/BjNKE/AfyYaSe4K3NqMVNIKCMx1cwzoozNET9m1T9Q82nGyYiav1Ebgz3Ns/wHjvI/
-        R+5/Pdy4Q1m9dAveWd0UZRvmO8Fw7gIAw97xdbiIj2BsPtsr78MlxTljBI6NXDLYQ0gGlcVDaOlS
-        GUK/OEnewX34WciSaR9fPB6EZT3w97prcSxU8jT5SwfThuQs0m93Ib55F1jfhD/3rm1cmzzw2s7S
-        q2/CEREi/babcPBdFw0tTDT0/nkUH/c2fNktuuLjYDIbomgZmt9vIL/6G4hZrmIS+R3av3Jox2Qf
-        n3Bex4H85t+3FJsd0NNNqUo//w8AAP//AwDv00GpFx8AAA==
+        H4sIAAAAAAAAA+xZW4/bthL+K4Jez0bgVST91G02bR/aICdOX1IEAq9rtbLkUnISt8h/71C+rLtX
+        tVms0bQLLGANZ4bD+T7OUNTvuY1eD95VeshnOUEEP0P8GRZvCJlRNsP4bX6W130V/bCObT4Luun9
+        Wb70fa8vfZ/Pfvo9tzrG2kewf67blY5gsRNV2tpu3Q5V7WDU6opLxrEnwnBjWSitYVg5ZTzmAsGY
+        ANNhs/KgHCGqysfYJXe76UD8Y6tN47OhyyAimOK9z7aTZsmgz0IXs7Zrnz0/z7pYX9Zt1i/q1dK3
+        Q1/kn96Bq84lP6A7gONuNdRdC8uAVaxj9K3dpEnmFzC20ptkl8Z2Mc1fvLx48Tr/dJa7FJ1273Vr
+        YQCBJPrgkz08tuumOcv7QQ9r8Jyv21/a7kOblha1/aVuLys7BrHVW6/cfQDQBIDRg12MSdzabJ/3
+        MxzLDpnaCu26H7plX9Vt6PayELslxO4iqKbFjdhoB2AhIqh20kunmSydIYJQrJDQmsG/TfkyP3ub
+        Aj3f2Z89SKD/ITRDKH9woVeKrV6mbL/Q/eZVN8Jku+VKt5ur1EbvBww6DIvsh64dLrulj5tsPg7k
+        ew0CGnxYZN803UgjWw8J3rlus28iQFf3tsu3SKUJn5/Dw2/1Cn4qhhEbJwb2xi0nEiUWXevHaTml
+        lMEfCP1S1w0I+/Vq1cXhKw9xryDuAqLOrxNuvzGCtnUzhrNdEiSzdsC2WjcHnLzzUTfVoD8eQT8G
+        e0323sc61FbvufwJ+Fi3/TrqIz52EdwdGcGesb45EGAVbVMp4yjnlnkZFOPIaVQGRDxRGgdB/syA
+        V1v7hwnwdgL2Safx7eWwyGcEFeQs/1C79IBRoc7yha8vF2DKCwSBR0hMqFtwt4L9dMT2Dzu1kiej
+        48RDQhIkoFs12vhDjseiMRaxMQlj0dGqdF67gL3wrDRWBamdUYgTiozy/DgJrxNzHkwBnZCCUefP
+        XOl9fF/bcSt8XO1326HW/jh/lSgZt9xlpBApshtVDMok0LPaq6mC8SvpDe2m7ofqmstRdkPT+aYG
+        3m0qpzeHGnQkHPytwupyrYGWg/fu0ExgtdWt7vale9s++sWq8o4IhnGJBA3MOamVsBYRjS1Bjo7Y
+        3NV6fm3L/z8vgwMuHKMtoOqZ4IMS2jHttKZSUIq5Bb5zItUJ0H4Va+hdUBvuhlsVnD6MNiYFRxPR
+        3nmcBDZ5RKTJ08CsS1SWgmlmMGecGCM8Et4h46C/lVieAuaxgM59k2a9D2oiH4Z6pzUN6VF1EtL8
+        EZHmT4M0wYZi5KQpsWeMIGVKiiwlCiMaJMMnQJpe6M1tOB/DTHgh2cM479WmAE1EMR5iJiFNbyB9
+        WCVBbwidjaezt/nfw54+MvZRLr5v1M/za9hLqSSWhEsZKKNCaY61ZSZYI6TV3J0A+5f+4wDwn9fx
+        hY7N5vyHuymAKS3KCRw46E0hAaayUJMrO76bBVi+QfLzWICfhgXBS3hdKQW8TzLmpJQ08cCVcLJV
+        0NLLE7CAtG5Lgvvwp6IoJ3T1vdqkMxwqysnF/mZbv1qm+uwS8NiN/g7wRWlLhzzjtuRMoVISIwi3
+        DpyWDttTnN6/jRC4u2ffs4JOOLvv1SbtelYg/K/CXRJljQlBCOwY/IR6byR2ngdCMFOnwP2q9M81
+        JORuAihZsHLCGW+nNokAiBUMPU7Z/1wGPFHZtxxJjY2ghnHmgtHB8ZIxjVkZFHT/kzLgnt2PcMGn
+        dP293jT4y0I+UtfHaEb/AfCr4OC1XQctEGeMIW0CJxgZBdWAaRJO2fXv6flwlEMTev5ObQr2tCzE
+        F1/734037tBWr92C91a3Veji8iAY37sAwHj0+jpexCcwdo/drffhHttgoKkILhArbdCYuBJ6CUFU
+        WaVF/rT34RexyOZD+uLxdVw3I3/vuhbHQmUvs+90NF3MLhL9Dhfiu+8C25vw1951reuyr722i/z2
+        m3BEhMj/2k045K5PgVYmBfrVZRKf9jZ83a/66rcxZDbuonVs//sG8qV/AzHrTSoi/23tL3lrp2Kf
+        PuG8S4787tdfaTYHoOe7VpV/+gMAAP//AwCfrPYWFx8AAA==
     headers:
       cache-control:
       - no-cache, no-store
@@ -59,11 +59,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"1541d88e28c3e5183353ef0e5952b194"
+      - W/"28c58340b2309b33c41b1d1589ed8a29"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_b5c0915745af42f68daf8416dbadc378
+      - /api/v2/shipments/shp_ed274116073f4dd8a97cc02a1c20d3e5
       pragma:
       - no-cache
       referrer-policy:
@@ -74,29 +74,27 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - b12f390860999f9fe789f99e000458cf
+      - 6396224460a2ef63e788e1440022ae60
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq 7ba176609e
+      - intlb1nuq 7ba176609e
       - extlb1nuq 7ba176609e
       x-request-id:
-      - 174696e5-4098-4c44-b1ea-65a8cec50451
+      - fec61f6b-9729-4d94-9318-7d490a357504
       x-runtime:
-      - '1.304631'
+      - '1.229500'
       x-version-label:
-      - easypost-202105102029-6e7a60b19a-master
+      - easypost-202105172007-9b7dfa0a52-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -120,27 +118,27 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_b5c0915745af42f68daf8416dbadc378/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_ed274116073f4dd8a97cc02a1c20d3e5/smartrate
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+zYXW/bNhQG4P+ia1fg4Td1V6zFbrahm7ObDoPAz0WF4niUXNQI8t9H2Q5sh8JG
-        pHUHdwNyk6NXtGQ94NHxQxX9sOnHqvntobI6xs7Hqql+Xb5bVounQqutvd+sxrZz6ZjV7Z8r/vN3
-        PLgpEr0evWt1WqLCCMMrxF4BusHQINJg+X7KbGL0K7vdLfwmFZzvu48+bluXzq2a1abvnxXbPzY6
-        6tXoffrIoPvBnwW2w9NZfhjb2QO7a43TUs4wgTjzNHhHAwETFGdWMqNdkBJNd9F3aZnsMnfVuLtE
-        imvBFtXdvUv/VGP61HT83nzwdrrvX6bMojqLRj/qrs8XPdQPWVXTlB18/NjZaeW3n9bpgQwpN9x2
-        6zv/9KUPt+vWMIsUMEGZDhQHLp0OkgJ36UYsETKdNHZ3vu1W7Zi+u6FLl/ZQrX20aZmu9y1DVYMX
-        pxXBnldkqpCzikJZJWXoeUVUDTuvqKoRj4tqs3b/4ONxcW3y8Cw7fGoOCw1AKbPBeWqFMII6obBB
-        2jHnZSgxp2pGysjtk0XiANdn4N7F7j524/Zy4qBAHH6ROJqJ49+oODYrjp3tcsC08FwzSjgVWmiG
-        JfPSagRIICnKxGFZKm5KFonbR0/E6fTI+qXvp2W/4j7HMnU8UyczdQAZO8CZO5Avgfe37qK8/aFX
-        H5ZfyN3xPHKDSYNQ+nv/PFYgkcxKJKcSuSDcWGcksoQaaaTFShutlBLcck5KJGJeq0KKmNWi1OIh
-        e8RI3ujtpSm+bAPEGUWcSSQZRHI9DuEGyZc7hFmHcOqQKiwsABGeMCqtNzuX1Km0PVqXnkyBQyCy
-        5mUOgZCaFLfhQ/go8Sf/aUwYX3fxrY799vWPlwO570HPTGZFOVdUc6er2aSYK6p98XqU4s/aLQve
-        FBFzSkqmlEWGSuM0wUhSFgKmQTBqi6YTVDNVppSImtFCpIfs0SheuT3R/3X+V3TKkJ6gEGlOBuoV
-        KEw08h4ccMOkKJqdgRT3cqA1KZ2dD9mjzu9j+tLd1+zj8IX6eP5Cia/HIHyWwYI+HjTiVGKGnU17
-        IgtSe6wRFZSmPTONN0UGEa2hsJErWePSPn7IzrXxpU439O9qhEwj5ANOPt/k4801aQTUkAtqlB4L
-        kFgFAopy0NoGLkAIbgQAeFOmkdesdEtEUBMo3RMP4TmP3wbFK9oYL96cgWonmAucWKAKCWUkEE09
-        xcpYjlgJRcJrXvgrYxpZGC59ddxnZ14dr3HOzvtz4Zz9++NfAAAA//8DAHy8jJJhGQAA
+        H4sIAAAAAAAAA+zXXW/bNhQG4P+ia1fgOfzWXbEWu9mGbsluOhQCPxsViuPRclEjyH8fZTuLHQkb
+        kTZBswXwhX30iqakBzrkdZXCetMPVfPHdeVMSl1IVVP9fvburFrcFlrj3NVmObSdz8ecaf9cil9/
+        ENGPkRTMEHxr8hAVEoRXhL8CeY7YUNYAfT9mNimFpdvuBn6TCz703eeQtq3P51bNctP394rtx41J
+        ZjmEkP8ymn4dTgLb9e1ZYT20swd2c03jUEYLH4yPEGRgwjodlfFWE46UWB14nlDf5WEm09xV026K
+        DGvJF9Xllc8/qiH/az5+ZT8FN173b2NmUZ1EUxhM108HPdQPWV2znF2H9Llz48hvv6zyA1nn3Pqi
+        W12G25u+vli1waNkAIJIGpn3ymjpHEEDDomnu+sYusvQdst2yPdu3eWpXVerkFweputDy0nVwOK4
+        InnV4ElFTSo6n0VPK3xSkflaTiu6avjNotqs/L/4uFk8N3k4yw6PzUlD0MYQtTSeGW8MVZJS4E6i
+        4ah0iTldc1pGbp8sEgdYn4B7l7qr1A3b700cvog7ssVnxfGTt5wgQkhmmAXOOForA5HBE+s1kQJU
+        mThUpeLGZJG4ffRInMmPrD8L/TjsE6qjE3Vsoo5P1OmJOoAJO1APcfeP7JK6+KnXn86+Ebu/z0Ny
+        jrQhJH/e348VQKSzEOkxRARLgXhlBQTGkGgrKHEUNRAaFYMSiChrwsokIq8VK6R4yN5ZpG/M9rEl
+        4qO9/+gEIn02DkGdE/VwhzDrEI4dKqUVKORKRcqo1IaDccxGZ6VyhvsSh0BVrQubMFBai1KJt+E7
+        ir+EL0PW+LpLb03qt69/fjyR+x50D+WkqOaKeu50PZuUc0W9Lz4fpvqrXpcFK8UYlDRGSMUkY14p
+        RUeoXnDudF4piqLdCalFYeOmshala8VD9s4oLv2e6IvO/4lOKZzwJDDuBGeaCIVWInc+P1ThwRXt
+        nYHVBArfoaympXvnQ/ZO548p33T/0sifvJF/jcGSRo7aWRujlOBZ/pq7t1XgA4+IwHSZQcLqwgWl
+        VjUTpXubfXaui5+ZfD1Pub+BCUaYYIQJRpjubyYY8TlhBNLQR8ToOFEGrKSWceajNdFzwZgBJqLO
+        y8oyjKJWpatKAjUvXlUewnMeXyj+13qzjp4CN9FIwhljxNjIEYjV+SXJDMYSilTUsrA3jzuW0oXj
+        Ljqzbvz+mzNOEOJDm/OHm78AAAD//wMACB+UIl4ZAAA=
     headers:
       cache-control:
       - no-cache, no-store
@@ -149,7 +147,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"f858b3a97b81e649b56017ad96b408b9"
+      - W/"6b6de9556b760834ec199eca44cadfdf"
       expires:
       - '0'
       pragma:
@@ -167,22 +165,22 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - b12f390860999fa0e789f99e00045946
+      - 6396224460a2ef65e788e1440022aefe
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb1nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq 7ba176609e
+      - intlb2nuq 7ba176609e
       - extlb1nuq 7ba176609e
       x-request-id:
-      - c6f83f52-f7f2-40bd-a54f-92269ab0a987
+      - d7be0689-1a6b-46df-a172-633ede2f6753
       x-runtime:
-      - '0.082920'
+      - '0.095311'
       x-version-label:
-      - easypost-202105102029-6e7a60b19a-master
+      - easypost-202105172007-9b7dfa0a52-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -216,10 +216,10 @@ def test_smartrate(vcr):
 
     smartrates = shipment.get_smartrates()
     assert shipment.rates[0]['id'] == smartrates['result'][0]['id']
-    assert smartrates['result'][0]['time_in_transit']['percentile_50'] == 2
+    assert smartrates['result'][0]['time_in_transit']['percentile_50'] == 1
     assert smartrates['result'][0]['time_in_transit']['percentile_75'] == 2
-    assert smartrates['result'][0]['time_in_transit']['percentile_85'] == 3
+    assert smartrates['result'][0]['time_in_transit']['percentile_85'] == 2
     assert smartrates['result'][0]['time_in_transit']['percentile_90'] == 3
-    assert smartrates['result'][0]['time_in_transit']['percentile_95'] == 4
-    assert smartrates['result'][0]['time_in_transit']['percentile_97'] == 5
-    assert smartrates['result'][0]['time_in_transit']['percentile_99'] == 7
+    assert smartrates['result'][0]['time_in_transit']['percentile_95'] == 3
+    assert smartrates['result'][0]['time_in_transit']['percentile_97'] == 4
+    assert smartrates['result'][0]['time_in_transit']['percentile_99'] == 5


### PR DESCRIPTION
Fixes Smartrate by not appending the results to a Shipment object anymore.

Previously we were appending the `results` list from Smartrates to the Shipment object by refreshing the record. We don't want to be doing this - instead we want to simply return the smartrate results without the accompanying shipment data.

[This was caught](https://github.com/EasyPost/easypost-ruby/pull/117#discussion_r632764921) in the Ruby library and others but I failed to see it here.

I was able to end-to-end test this to ensure it only returned the Smartrate `results` array and not the `Shipment` object in addition.