### PR TITLE
clean up address verify property and some miscellaneous request logic

### DIFF
--- a/tests/cassettes/test_address_creation_with_verify_bool.yaml
+++ b/tests/cassettes/test_address_creation_with_verify_bool.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: address%5Bcity%5D=San+Francisco&address%5Bcompany%5D=EasyPost&address%5Bcountry%5D=US&address%5Bphone%5D=415-456-7890&address%5Bstate%5D=CA&address%5Bstreet1%5D=118+2&address%5Bstreet2%5D=FLoor+4&address%5Bzip%5D=94105
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '218'
+      Content-type:
+      - application/x-www-form-urlencoded
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: POST
+    uri: https://api.easypost.com/v2/addresses?verify%5B%5D=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4ySzU7jMBSFXyXylhRsN2nS7KIySCOhgkhZjEYocuwbxiPHrmwHARXvznULs5hV
+        s3Hu8Xeuj38ORCvSEKF8v+IDH0ZVg2R1IYWoGZMg1uuCVeuqHgaSEzf8BRmRb5XyEAJK0oOIoHqR
+        ZE45W9DVgrId503JG0YvKG0oRXDeq/NAKyYgjZ2Nwe5u2gv7ho4fbffr/q7bIRCiB4gMRcbqjG+v
+        s26X3dxmxb85jnMpm47J2rXb7Oah3W5+dpu7I4NBUN+0WLzrPf7iJmm5WK54CiDdbKNPzscOy/0f
+        ZxNesLIoV1W9TgxMQpvvlJNTCYgQYrIL7zX4fhRSm2OCE4UHphXYqAUaR2EC5GQEBV6YPorXPl3E
+        iTwG/E97Aa9HLUXUzgbSHFLwIo1hljJdRRP9jB3Be+ex+v2UEwURU4ZTi49UG4193s61HYjB9eKc
+        dresLqu6qsqcGGefv8QF4/xyiU+kyknUE/Tvp6NqJ0wrxdWtC31rn8FAIB/4fQIAAP//AwDow9Tp
+        bgIAAA==
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"b7d8f69ebe4ba9aee3182e54d399f72a"
+      expires:
+      - '0'
+      location:
+      - /api/v2/addresses/adr_62b2bfd8ec184caa811cea99417978bb
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=15768000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - d6502afc60b6ba1afb32a2c100f6fc6a
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb5nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq 15c8815ace
+      - extlb1nuq 15c8815ace
+      x-request-id:
+      - 1d5229af-27c8-4ffb-a2f9-b2fa88d35b9e
+      x-runtime:
+      - '0.056680'
+      x-version-label:
+      - easypost-202106012134-e838b9cad4-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -50,6 +50,27 @@ def test_address_creation_with_verify():
 
 
 @pytest.mark.vcr()
+def test_address_creation_with_verify_bool():
+    # Create an address with a verify parameter to test that it verifies accurately
+    address = easypost.Address.create(
+        verify=True,
+        street1='118 2',
+        street2='FLoor 4',
+        city='San Francisco',
+        state='CA',
+        zip='94105',
+        country='US',
+        company='EasyPost',
+        phone='415-456-7890'
+    )
+
+    assert address.id is not None
+    assert address.street1 == '118 2ND ST FL 4'
+    assert address.street2 == ''
+    assert address.country == 'US'
+
+
+@pytest.mark.vcr()
 def test_address_creation_with_verify_failure():
     # Create an address with a verify parameter to test that it fails elegantly
     address = easypost.Address.create(


### PR DESCRIPTION
allows users to just pass `True` for verify and verify_strict instead of having to pass `[True]`. Also properly quotes in case a user accidentally passes something icky.

as always, I am a firm believer that functions should be functions, not classmethods