### PR TITLE
fix: strips the result key from smartrate

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -740,7 +740,7 @@ class Shipment(AllResource, CreateResource):
         url = "%s/%s" % (self.instance_url(), "smartrate")
 
         response, api_key = requestor.request('get', url)
-        return response
+        return response.get('result', [])
 
     def buy(self, **params):
         requestor = Requestor(self._api_key)

--- a/tests/cassettes/test_smartrate.yaml
+++ b/tests/cassettes/test_smartrate.yaml
@@ -23,34 +23,34 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+xZW4/bthL+K4Jez0bgVST91G02bR/aICdOX1IEAq9rtbLkUnISt8h/71C+rLtX
-        tVms0bQLLGANZ4bD+T7OUNTvuY1eD95VeshnOUEEP0P8GRZvCJlRNsP4bX6W130V/bCObT4Luun9
-        Wb70fa8vfZ/Pfvo9tzrG2kewf67blY5gsRNV2tpu3Q5V7WDU6opLxrEnwnBjWSitYVg5ZTzmAsGY
-        ANNhs/KgHCGqysfYJXe76UD8Y6tN47OhyyAimOK9z7aTZsmgz0IXs7Zrnz0/z7pYX9Zt1i/q1dK3
-        Q1/kn96Bq84lP6A7gONuNdRdC8uAVaxj9K3dpEnmFzC20ptkl8Z2Mc1fvLx48Tr/dJa7FJ1273Vr
-        YQCBJPrgkz08tuumOcv7QQ9r8Jyv21/a7kOblha1/aVuLys7BrHVW6/cfQDQBIDRg12MSdzabJ/3
-        MxzLDpnaCu26H7plX9Vt6PayELslxO4iqKbFjdhoB2AhIqh20kunmSydIYJQrJDQmsG/TfkyP3ub
-        Aj3f2Z89SKD/ITRDKH9woVeKrV6mbL/Q/eZVN8Jku+VKt5ur1EbvBww6DIvsh64dLrulj5tsPg7k
-        ew0CGnxYZN803UgjWw8J3rlus28iQFf3tsu3SKUJn5/Dw2/1Cn4qhhEbJwb2xi0nEiUWXevHaTml
-        lMEfCP1S1w0I+/Vq1cXhKw9xryDuAqLOrxNuvzGCtnUzhrNdEiSzdsC2WjcHnLzzUTfVoD8eQT8G
-        e0323sc61FbvufwJ+Fi3/TrqIz52EdwdGcGesb45EGAVbVMp4yjnlnkZFOPIaVQGRDxRGgdB/syA
-        V1v7hwnwdgL2Safx7eWwyGcEFeQs/1C79IBRoc7yha8vF2DKCwSBR0hMqFtwt4L9dMT2Dzu1kiej
-        48RDQhIkoFs12vhDjseiMRaxMQlj0dGqdF67gL3wrDRWBamdUYgTiozy/DgJrxNzHkwBnZCCUefP
-        XOl9fF/bcSt8XO1326HW/jh/lSgZt9xlpBApshtVDMok0LPaq6mC8SvpDe2m7ofqmstRdkPT+aYG
-        3m0qpzeHGnQkHPytwupyrYGWg/fu0ExgtdWt7vale9s++sWq8o4IhnGJBA3MOamVsBYRjS1Bjo7Y
-        3NV6fm3L/z8vgwMuHKMtoOqZ4IMS2jHttKZSUIq5Bb5zItUJ0H4Va+hdUBvuhlsVnD6MNiYFRxPR
-        3nmcBDZ5RKTJ08CsS1SWgmlmMGecGCM8Et4h46C/lVieAuaxgM59k2a9D2oiH4Z6pzUN6VF1EtL8
-        EZHmT4M0wYZi5KQpsWeMIGVKiiwlCiMaJMMnQJpe6M1tOB/DTHgh2cM479WmAE1EMR5iJiFNbyB9
-        WCVBbwidjaezt/nfw54+MvZRLr5v1M/za9hLqSSWhEsZKKNCaY61ZSZYI6TV3J0A+5f+4wDwn9fx
-        hY7N5vyHuymAKS3KCRw46E0hAaayUJMrO76bBVi+QfLzWICfhgXBS3hdKQW8TzLmpJQ08cCVcLJV
-        0NLLE7CAtG5Lgvvwp6IoJ3T1vdqkMxwqysnF/mZbv1qm+uwS8NiN/g7wRWlLhzzjtuRMoVISIwi3
-        DpyWDttTnN6/jRC4u2ffs4JOOLvv1SbtelYg/K/CXRJljQlBCOwY/IR6byR2ngdCMFOnwP2q9M81
-        JORuAihZsHLCGW+nNokAiBUMPU7Z/1wGPFHZtxxJjY2ghnHmgtHB8ZIxjVkZFHT/kzLgnt2PcMGn
-        dP293jT4y0I+UtfHaEb/AfCr4OC1XQctEGeMIW0CJxgZBdWAaRJO2fXv6flwlEMTev5ObQr2tCzE
-        F1/734037tBWr92C91a3Veji8iAY37sAwHj0+jpexCcwdo/drffhHttgoKkILhArbdCYuBJ6CUFU
-        WaVF/rT34RexyOZD+uLxdVw3I3/vuhbHQmUvs+90NF3MLhL9Dhfiu+8C25vw1951reuyr722i/z2
-        m3BEhMj/2k045K5PgVYmBfrVZRKf9jZ83a/66rcxZDbuonVs//sG8qV/AzHrTSoi/23tL3lrp2Kf
-        PuG8S4787tdfaTYHoOe7VpV/+gMAAP//AwCfrPYWFx8AAA==
+        H4sIAAAAAAAAA+xZSZPbthL+Kyxe35iFfdEpE4+THBKXn+VcnHKxQCwjJhSpgJRtJeX/nga1jDIr
+        E0+NKk50EpuNRqO/r7sB8PfcRm8G70oz5LOcIIKfIfEMsTdYzxCeMfk2P8vrvox+WMc2nwXT9P4s
+        X/q+N5e+z2c//Z5bE2PtI4x/btqViTBiJyqNtd26HcrawVtrSq4Yx57IileWBWErhrXTlcdcIngn
+        YeiwWXlQjuBV6WPskrnddCD+sTVV47Ohy8AjmOK9z7aTZmlAn4UuZm3XPnt+nnWxvqzbrF/Uq6Vv
+        h77IP70DU51LdkB3AMPdaqi7FpYBq1jH6Fu7SZPML+DdymzSuPRu59P8xcuLF6/zT2e5S94Z9960
+        Fl4gkEQffBoPj+26ac7yfjDDGizn6/aXtvvQpqVFY3+p28vSjk5s9dYrdx8AKgFQmcEuxiBux2yf
+        9zMcyw6R2grtuh+6ZV/Wbej2shC7JfjuIqimxY3YGBdLhCVmQgttHGYy4Epoy4Q31mjCpeUpXtXP
+        3iZHz3fjzx4k0P8QmiGUP7jQK8XWLFO0X5h+86obYbLdcmXazVVoo/cDBh2GZfZD1w6X3dLHTTYf
+        X+R7DQIafFhk3zTdSCNbDwneuWmzbyJAV/e2y7dIpQmfn8PDb/UK/mqGERsnBvbGLScSJRZd68dp
+        OaWUwQ+EfmnqBoT9erXq4vCVB79X4HcBXufXCbdPjGBs3YzubJcEwawdsK02zQEn73w0TTmYj0fQ
+        j85ek733sQ61NXsufwI+1m2/juaIj10Ec0eDIGesbw4EWEXblIRzjgzXgVrBqFJKCieUF4FLwYjD
+        xwx4tR3/MAHeTsA+6TS+vRwW+YyggpzlH2qXHjAq9Fm+8PXlAobyAoHjEQIT6hbMrSCfjtj+Yacm
+        eBp0HHgISIIEdMvGVP4Q47FojEVsDMJYdDQJFnFkmaaYeSRMkNQFbFPZEoba4yC8Tsx5MARqQghG
+        nT9zpffxfW3HVPi42mfbodb+OH+VKBm33GWkkClBb1QxKJNAz3KvpgvGr6Q3tJu6H8prJkfZDU3n
+        mxp4tymd2Rxq0JFw8LcKy8u1AVoO3rtDM4HVlrea25fubfvoF6uSGqRQFQwTSDEVTKUDMpWx3gaH
+        TGD3tJ5fW/H/5yI44MIx2kbo4HnARiHJrKa60h7ZimjnqVSEnQDtV7GG3gW14W64dcHpw2hjUnA0
+        Ee2dxUlgk0dEmjwNzDZIXBGFlPCMCSGMZMo7Ck3bSwRTnALmsYDOfZNmvQ9qoh6Geqc1DelRdRLS
+        /BGR5k+DdIU9ZpR7UQnKJJMq9bIK8ts4TTA5RfmmF2ZzG87HMBNeKPYwznu1KUATWYybmElI0xtI
+        X61SvyF0Nu7O3uZ/D3v6yNhHtfi+0T/Pr2EvEOxcKEOBWMQqsGap4AQbL5BUXFQnwP6l/zgA/Od1
+        fGFiszn/4W4KYEoLMYEDB70pJMBUFXpyZcf3sEC+QerzWICfhgXMwO5dKWSFkyx4oYnSWBiuKoQr
+        jE/R0knrtiS4D38qCzGhq+/VJu3hUCEmF/ubbf1qmeqzS8BjN/o7wNcEUeyo88QpFjDR2HILx1rY
+        3UFLMOgE4H8bwXF3T96zgk7Yu+/VJmU9KxD+V+GuKiN9YEyTijLY1MPhLSDpZTCIEC34CXC/Kv1z
+        AwG5mwBaFUxM2OPt1CYRALGCoccp+5/LgCcq+4TCho9XFlo9ZlJ6zQwXkjlliA3MkJMy4J7sR7jg
+        U7r+Xm8a/KJQj9T1MZrRfwD82hjpCPYE/jCimMFUCCksoqZClXOn7Pr39HzYyqEJPX+nNgV7Kgr5
+        xdf+d+ONO7TVa7fgvTVtGbq4PAjGcxcAGI+Or+NFfAJj99jdeh/uOZUMMR0cnCihhWiuKzhZkoCl
+        1PjPBeUJ7sMvYpHNh/TF4+u4bkb+3nUtjqXOXmbfmVh1MbtI9DtciO++C2xvwl9717Wuy772xi7y
+        22/CEZEy/2s34RC7PjlaVsnRry6T+LS34et+1Ze/jS6zMYvWsf3vG8iX/g2kWm9SEfkvtb/k1E7F
+        Pn3CeZcM+d2/v9JsDkDPd60q//QHAAAA//8DAOwYlI8XHwAA
     headers:
       cache-control:
       - no-cache, no-store
@@ -59,11 +59,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"28c58340b2309b33c41b1d1589ed8a29"
+      - W/"ca9032fdae03378fa979da66a16e21fc"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_ed274116073f4dd8a97cc02a1c20d3e5
+      - /api/v2/shipments/shp_3a080bfa460848fab9f0abacecfd0af4
       pragma:
       - no-cache
       referrer-policy:
@@ -79,7 +79,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 6396224460a2ef63e788e1440022ae60
+      - 301bf52860ba789be7873c5c001c5140
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -87,14 +87,14 @@ interactions:
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq 7ba176609e
-      - extlb1nuq 7ba176609e
+      - intlb2nuq 15c8815ace
+      - extlb2nuq 15c8815ace
       x-request-id:
-      - fec61f6b-9729-4d94-9318-7d490a357504
+      - e4281d94-7e13-4e9f-ba77-135682dceae6
       x-runtime:
-      - '1.229500'
+      - '1.409997'
       x-version-label:
-      - easypost-202105172007-9b7dfa0a52-master
+      - easypost-202106031829-2d7fd21737-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -118,27 +118,27 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_ed274116073f4dd8a97cc02a1c20d3e5/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_3a080bfa460848fab9f0abacecfd0af4/smartrate
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+zXXW/bNhQG4P+ia1fgOfzWXbEWu9mGbsluOhQCPxsViuPRclEjyH8fZTuLHQkb
-        kTZBswXwhX30iqakBzrkdZXCetMPVfPHdeVMSl1IVVP9fvburFrcFlrj3NVmObSdz8ecaf9cil9/
-        ENGPkRTMEHxr8hAVEoRXhL8CeY7YUNYAfT9mNimFpdvuBn6TCz703eeQtq3P51bNctP394rtx41J
-        ZjmEkP8ymn4dTgLb9e1ZYT20swd2c03jUEYLH4yPEGRgwjodlfFWE46UWB14nlDf5WEm09xV026K
-        DGvJF9Xllc8/qiH/az5+ZT8FN173b2NmUZ1EUxhM108HPdQPWV2znF2H9Llz48hvv6zyA1nn3Pqi
-        W12G25u+vli1waNkAIJIGpn3ymjpHEEDDomnu+sYusvQdst2yPdu3eWpXVerkFweputDy0nVwOK4
-        InnV4ElFTSo6n0VPK3xSkflaTiu6avjNotqs/L/4uFk8N3k4yw6PzUlD0MYQtTSeGW8MVZJS4E6i
-        4ah0iTldc1pGbp8sEgdYn4B7l7qr1A3b700cvog7ssVnxfGTt5wgQkhmmAXOOForA5HBE+s1kQJU
-        mThUpeLGZJG4ffRInMmPrD8L/TjsE6qjE3Vsoo5P1OmJOoAJO1APcfeP7JK6+KnXn86+Ebu/z0Ny
-        jrQhJH/e348VQKSzEOkxRARLgXhlBQTGkGgrKHEUNRAaFYMSiChrwsokIq8VK6R4yN5ZpG/M9rEl
-        4qO9/+gEIn02DkGdE/VwhzDrEI4dKqUVKORKRcqo1IaDccxGZ6VyhvsSh0BVrQubMFBai1KJt+E7
-        ir+EL0PW+LpLb03qt69/fjyR+x50D+WkqOaKeu50PZuUc0W9Lz4fpvqrXpcFK8UYlDRGSMUkY14p
-        RUeoXnDudF4piqLdCalFYeOmshala8VD9s4oLv2e6IvO/4lOKZzwJDDuBGeaCIVWInc+P1ThwRXt
-        nYHVBArfoaympXvnQ/ZO548p33T/0sifvJF/jcGSRo7aWRujlOBZ/pq7t1XgA4+IwHSZQcLqwgWl
-        VjUTpXubfXaui5+ZfD1Pub+BCUaYYIQJRpjubyYY8TlhBNLQR8ToOFEGrKSWceajNdFzwZgBJqLO
-        y8oyjKJWpatKAjUvXlUewnMeXyj+13qzjp4CN9FIwhljxNjIEYjV+SXJDMYSilTUsrA3jzuW0oXj
-        Ljqzbvz+mzNOEOJDm/OHm78AAAD//wMACB+UIl4ZAAA=
+        H4sIAAAAAAAAA+yXW2/bNhTHv4ueXeHw8IgXvRVrsZdt6ObspUMhULwsKhTHo+WiRpDvPvoS2I6E
+        jXCXolkD+EH+688jSvzhXO6K6FfrfijqP+4Ka2LsfCzq4vf5u3kxexAaY+3tejE0nUv3rGn+Wohf
+        fxDBbS3Rm8G7xqQQBQKyVyBeAV0xXQOrSb3fetYx+oXd7AK/SYLzfffJx03j0tqiXqz7/pHY/Lk2
+        0SwG79Mjg+lX/sywWT2s8quhmbyx22vchtIYLFRgSXNGHoQJkrvArEfZCsNt2lDfpTCjbe7UuNsi
+        YSmrWXFz69KfYkhPTfdv24/ebt/7t61nVpxZox9M14+DHvSDV5eUvCsfP3V2G/nt52U6kFXyra67
+        5Y1/+Oir62XDDShogyEBilQwrQ5gWmO9DQ5MoLRo6G580y2aIX27VZe2dlcsfbQpTNf7poKiZrNT
+        RVZFjWeKSgo/UzSMlLFHpnc5V3RRV/ezYr10/8LH/ey5kYeT2OEpc0bo4KvAjAJJVnPdag+2Re08
+        lwophzldVjwPub0ziziG5Rlw72J3G7th83TEYQZxeBFx/LshrpokrjolzgbJWlSghCcSQhhJyjvu
+        g/cS0uHlEYcql7itM4u4vfWEOJOOrJ/7fhv2G8tzNKJOjqjTI+oYXoLdP1IX1fVPvf44/4+oO67T
+        V8hrgPR7/9iWwSGf5JCfctgyz4hXXrSCkySpuBXUpkRonEaGWdUWZQmUByJWpaJMEg/eI4r8jdk8
+        NYiXpT+8KP3x58OhvAJ1OYdskkN2yqGAwC0nCGiB2nRwlosKmfECpKpEm8Mh46rUmTWYcV6KXBIf
+        zEcUf/Gfh0Tj6y6+NbHfvP756Yjcl6BHUI5ENSXqqeV60imnRL0Xnw+m6ovSZUajSIYYKAVWOEnB
+        C41KM2Eq1QJrGctqFAlKkVm3uSxFbqt48B4ZxYXbI/pC53dCp0bgzHHn0SkKDDWzlWXpfCWlAm8g
+        K4lSCSwzh1LJc0fng/dI548xfXT3Usi/eiH/EgYzCrlqjfSBSGPLKc3VmrMA0stgAFGLKotBoDKz
+        odSqJJE72uy9U1V8btL7fM3xho1gZCMY2QhGNoKRjWB8RtONvGJQ8yeEEXmaaqrWph6SkZRek6mE
+        JKcM2kAG82AUpcrtKoGVVXZXeTBP8fiC4v+uNhsjHTKP6YJQkWFcCCkscNNC61wOilyUMrM2byeW
+        3MZxZ53oG7/94owjCPHS4vzh/m8AAAD//wMAld1syl0ZAAA=
     headers:
       cache-control:
       - no-cache, no-store
@@ -147,7 +147,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"6b6de9556b760834ec199eca44cadfdf"
+      - W/"41febe7fad6e20e66658b2f6eef82e53"
       expires:
       - '0'
       pragma:
@@ -160,27 +160,29 @@ interactions:
       - chunked
       x-backend:
       - easypost
+      x-canary:
+      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 6396224460a2ef65e788e1440022aefe
+      - 301bf52860ba789ce7873c5c001c51e8
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb7nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq 7ba176609e
-      - extlb1nuq 7ba176609e
+      - intlb2nuq 15c8815ace
+      - extlb2nuq 15c8815ace
       x-request-id:
-      - d7be0689-1a6b-46df-a172-633ede2f6753
+      - e05fdf7f-da9d-400a-a60d-3155f5ed1ac0
       x-runtime:
-      - '0.095311'
+      - '0.097927'
       x-version-label:
-      - easypost-202105172007-9b7dfa0a52-master
+      - easypost-202106031829-2d7fd21737-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -221,11 +221,11 @@ def test_smartrate(vcr):
     assert shipment.rates
 
     smartrates = shipment.get_smartrates()
-    assert shipment.rates[0]['id'] == smartrates['result'][0]['id']
-    assert smartrates['result'][0]['time_in_transit']['percentile_50'] == 1
-    assert smartrates['result'][0]['time_in_transit']['percentile_75'] == 2
-    assert smartrates['result'][0]['time_in_transit']['percentile_85'] == 2
-    assert smartrates['result'][0]['time_in_transit']['percentile_90'] == 3
-    assert smartrates['result'][0]['time_in_transit']['percentile_95'] == 3
-    assert smartrates['result'][0]['time_in_transit']['percentile_97'] == 4
-    assert smartrates['result'][0]['time_in_transit']['percentile_99'] == 5
+    assert shipment.rates[0]['id'] == smartrates[0]['id']
+    assert smartrates[0]['time_in_transit']['percentile_50'] == 1
+    assert smartrates[0]['time_in_transit']['percentile_75'] == 2
+    assert smartrates[0]['time_in_transit']['percentile_85'] == 3
+    assert smartrates[0]['time_in_transit']['percentile_90'] == 3
+    assert smartrates[0]['time_in_transit']['percentile_95'] == 3
+    assert smartrates[0]['time_in_transit']['percentile_97'] == 4
+    assert smartrates[0]['time_in_transit']['percentile_99'] == 5


### PR DESCRIPTION
To provide a more idiomatic experience using SmartRate, we've decided to strip out the `result` key from the response of SmartRate. If for whatever reason we can't get smartrates, we'll fallback to an empty array.