### PR TITLE
chore: bump version for smartrate correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v5.1.2 2021-06-10
+
+* Strips away the `result` key from SmartRate and simply returns an array of SmartRate objects
+
 ### 5.1.1 2021-05-18
 
 * fix: stops appending smartrates to Shipment object

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ Client Library Development
 ### Releasing
 
    1. Add new features to [CHANGELOG.md](CHANGELOG.md)
-   1. Bump the version in `easypost/version.py` and `setup.py`
+   1. Bump the version in `easypost/version.py`
+   1. Bump the version in `setup.py`
    1. Create and push a signed git tag
    1. Create a Release in Github based on the tag, with a human-readable summary of changes
    1. Build sdist and wheel: `rm -rf build/ dist/ ./*.egg-info; python3 setup.py sdist bdist_wheel`

--- a/easypost/version.py
+++ b/easypost/version.py
@@ -1,4 +1,4 @@
-VERSION = '5.1.1'
+VERSION = '5.1.2'
 
 if '-' in VERSION:
     VERSION_INFO = tuple([int(v) for v in VERSION.split('-')[0].split('.')] + VERSION.split('-')[1:])

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import io
 import sys
 
-
 try:
     from setuptools import setup
 except ImportError:
@@ -24,7 +23,7 @@ with long_description_open('README.md', encoding='utf-8') as f:
 
 setup(
     name='easypost',
-    version='5.1.1',
+    version='5.1.2',
     description='EasyPost Shipping API Client Library for Python',
     author='EasyPost',
     author_email='support@easypost.com',


### PR DESCRIPTION
Bumps version to 5.1.2 for Smartrate fix (patch).

Not sure the best version bump here as we intended for Smartrate to not include the `result` key but it is a breaking change. Open to thoughts.