### PR TITLE
remove 2015-vintage experimental "all_updated" action on trackers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### NEXT
+
+* Remove 2015-vintage experimental "`all_updated`" action from trackers
+
 ### v5.1.2 2021-06-10
 
 * Strips away the `result` key from SmartRate and simply returns an array of SmartRate objects

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -874,13 +874,6 @@ class Tracker(AllResource, CreateResource):
         response, api_key = requestor.request('post', url, params)
         return True
 
-    @classmethod
-    def all_updated(cls, api_key=None, **params):
-        requestor = Requestor(api_key)
-        url = "%s/%s" % (cls.class_url(), "all_updated")
-        response, api_key = requestor.request('get', url, params)
-        return convert_to_easypost_object(response["trackers"], api_key), response["has_more"]
-
 
 class Pickup(CreateResource):
     def buy(self, **params):


### PR DESCRIPTION
This endpoint was introduced as an experiment in 2015 and never documented. It has no users and is being removed.