### PR TITLE
Make unit tests run in a local appengine environment

### DIFF
--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -174,7 +174,8 @@ def test_rerate(vcr):
         # we only rerate on get_rates calls for shipments made at least 60 seconds ago
         time.sleep(61)
 
-    easypost.requests_session.close()
+    if hasattr(easypost, 'requests_session'):  # the urlfetch code has no session obj
+        easypost.requests_session.close()
 
     shipment.regenerate_rates()
 


### PR DESCRIPTION
Some small tweaks are needed to prevent non-test-error failures when testing with the appengine sdk instead of requests lib.

closes #140 

With the google cloud SDK installed and PYTHONPATH pointing at `google-cloud-sdk/platform/google_appengine/`, tests fail abruptly without these changes and pass with them.