### PR TITLE
Removes `_max_timeout` and instead uses a flat 60 second timeout for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### NEXT RELEASE
+
+* Lowers the default timeout from 90 seconds to 60 seconds for all requests
+
 ### v6.0.0 2021-10-12
 
 * JSON encodes POST bodies instead of form encoding them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT RELEASE
 
-* Lowers the default timeout from 90 seconds to 60 seconds for all requests
+* Removes `_max_timeout` and instead uses a flat 60 second timeout for requests
 
 ### v6.0.0 2021-10-12
 

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -14,7 +14,12 @@ __author__ = "EasyPost <oss@easypost.com>"
 __version__ = VERSION
 version_info = VERSION_INFO
 SUPPORT_EMAIL = "support@easypost.com"
+USER_AGENT = "EasyPost/v2 PythonClient/{0}".format(VERSION)
 TIMEOUT = 60
+
+# config
+api_key = None
+api_base = "https://api.easypost.com/v2"
 
 # use urlfetch as request_lib on google app engine, otherwise use requests
 request_lib = None
@@ -23,9 +28,9 @@ try:
 
     request_lib = "urlfetch"
     # use the GAE application-wide "deadline" (or its default)
-    _platform_timeout = urlfetch.get_default_fetch_deadline() or TIMEOUT
+    timeout = urlfetch.get_default_fetch_deadline() or TIMEOUT
 except ImportError:
-    _platform_timeout = TIMEOUT
+    timeout = TIMEOUT
     try:
         import requests
 
@@ -56,14 +61,6 @@ except ImportError:
                 'requests via "pip install -U requests" or contact us '
                 "at {}.".format(SUPPORT_EMAIL)
             )
-
-# config
-api_key = None
-api_base = "https://api.easypost.com/v2"
-timeout = _platform_timeout
-
-
-USER_AGENT = "EasyPost/v2 PythonClient/{0}".format(VERSION)
 
 
 class Error(Exception):

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -15,17 +15,12 @@ __version__ = VERSION
 version_info = VERSION_INFO
 SUPPORT_EMAIL = "support@easypost.com"
 
-
 # use urlfetch as request_lib on google app engine, otherwise use requests
 request_lib = None
-# use a max timeout equal to that of all customer-facing backend operations
-_max_timeout = 90
 try:
     from google.appengine.api import urlfetch
 
     request_lib = "urlfetch"
-    # use the GAE application-wide "deadline" (or its default) if it's less than our existing max timeout
-    _max_timeout = min(urlfetch.get_default_fetch_deadline() or 60, _max_timeout)
 except ImportError:
     try:
         import requests
@@ -61,8 +56,7 @@ except ImportError:
 # config
 api_key = None
 api_base = "https://api.easypost.com/v2"
-# use our default timeout, or our max timeout if that is less
-timeout = min(60, _max_timeout)
+timeout = 60
 
 
 USER_AGENT = "EasyPost/v2 PythonClient/{0}".format(VERSION)
@@ -249,9 +243,6 @@ class Requestor(object):
             "Authorization": "Bearer %s" % my_api_key,
             "Content-type": "application/json",
         }
-
-        if timeout > _max_timeout:
-            raise Error("`timeout` must not exceed %d; it is %d" % (_max_timeout, timeout))
 
         if request_lib == "urlfetch":
             http_body, http_status = self.urlfetch_request(method, abs_url, headers, params)

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -14,6 +14,7 @@ __author__ = "EasyPost <oss@easypost.com>"
 __version__ = VERSION
 version_info = VERSION_INFO
 SUPPORT_EMAIL = "support@easypost.com"
+TIMEOUT = 60
 
 # use urlfetch as request_lib on google app engine, otherwise use requests
 request_lib = None
@@ -21,7 +22,10 @@ try:
     from google.appengine.api import urlfetch
 
     request_lib = "urlfetch"
+    # use the GAE application-wide "deadline" (or its default)
+    _platform_timeout = urlfetch.get_default_fetch_deadline() or TIMEOUT
 except ImportError:
+    _platform_timeout = TIMEOUT
     try:
         import requests
 
@@ -56,7 +60,7 @@ except ImportError:
 # config
 api_key = None
 api_base = "https://api.easypost.com/v2"
-timeout = 60
+timeout = _platform_timeout
 
 
 USER_AGENT = "EasyPost/v2 PythonClient/{0}".format(VERSION)


### PR DESCRIPTION
Removes `_max_timeout` and instead uses a flat 60 second timeout for requests to match other client libraries.