### PR TITLE
feat: adds the Python version to user-agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT RELEASE
 
 * Removes `_max_timeout` and instead uses a flat 60 second timeout for requests
+* Adds Python version to user-agent header on requests
 
 ### v6.0.0 2021-10-12
 

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -14,7 +14,7 @@ __author__ = "EasyPost <oss@easypost.com>"
 __version__ = VERSION
 version_info = VERSION_INFO
 SUPPORT_EMAIL = "support@easypost.com"
-USER_AGENT = "EasyPost/v2 PythonClient/{0} Python{1}".format(VERSION, platform.python_version())
+USER_AGENT = "EasyPost/v2 PythonClient/{0} Python/{1}".format(VERSION, platform.python_version())
 TIMEOUT = 60
 
 # config

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -14,7 +14,7 @@ __author__ = "EasyPost <oss@easypost.com>"
 __version__ = VERSION
 version_info = VERSION_INFO
 SUPPORT_EMAIL = "support@easypost.com"
-USER_AGENT = "EasyPost/v2 PythonClient/{0}".format(VERSION)
+USER_AGENT = "EasyPost/v2 PythonClient/{0} Python{1}".format(VERSION, platform.python_version())
 TIMEOUT = 60
 
 # config


### PR DESCRIPTION
Adds the Python version to user-agent header.

Tested via the repl:
```bash
jhammond@easypost $ python3
Python 3.9.9 (main, Nov 21 2021, 03:23:42) 
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> platform.python_version()
'3.9.9'
```