### PR TITLE
improve create_list for tracker class.

### DIFF
--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -791,11 +791,11 @@ class PostageLabel(AllResource, CreateResource):
 
 class Tracker(AllResource, CreateResource):
     @classmethod
-    def create_list(cls, params={}, api_key=None):
+    def create_list(cls, trackers, api_key=None):
         requestor = Requestor(api_key)
         url = "%s/%s" % (cls.class_url(), "create_list")
-        new_params = {"trackers": params}
-        response, api_key = requestor.request("post", url, new_params)
+        new_params = {"trackers": trackers}
+        _, _ = requestor.request("post", url, new_params)
         return True
 
 

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -794,7 +794,7 @@ class Tracker(AllResource, CreateResource):
     def create_list(cls, api_key=None, **params):
         requestor = Requestor(api_key)
         url = "%s/%s" % (cls.class_url(), "create_list")
-        newParams = {'trackers': params}
+        newParams = {"trackers": params}
         response, api_key = requestor.request("post", url, newParams)
         return True
 

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -794,8 +794,8 @@ class Tracker(AllResource, CreateResource):
     def create_list(cls, api_key=None, **params):
         requestor = Requestor(api_key)
         url = "%s/%s" % (cls.class_url(), "create_list")
-        newParams = {"trackers": params}
-        response, api_key = requestor.request("post", url, newParams)
+        new_params = {"trackers": params}
+        response, api_key = requestor.request("post", url, new_params)
         return True
 
 

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -791,7 +791,7 @@ class PostageLabel(AllResource, CreateResource):
 
 class Tracker(AllResource, CreateResource):
     @classmethod
-    def create_list(cls, api_key=None, **params):
+    def create_list(cls, params={}, api_key=None):
         requestor = Requestor(api_key)
         url = "%s/%s" % (cls.class_url(), "create_list")
         new_params = {"trackers": params}

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -794,7 +794,8 @@ class Tracker(AllResource, CreateResource):
     def create_list(cls, api_key=None, **params):
         requestor = Requestor(api_key)
         url = "%s/%s" % (cls.class_url(), "create_list")
-        response, api_key = requestor.request("post", url, params)
+        newParams = {'trackers': params}
+        response, api_key = requestor.request("post", url, newParams)
         return True
 
 

--- a/tests/cassettes/test_tracker_create_list.yaml
+++ b/tests/cassettes/test_tracker_create_list.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
-    body: !!python/unicode '{"trackers": {"params": {"1": {"tracking_code": "EZ2000000002"},
+    body: !!python/unicode '{"trackers": {"1": {"tracking_code": "EZ2000000002"},
       "0": {"tracking_code": "EZ1000000001"}, "3": {"tracking_code": "EZ4000000004"},
-      "2": {"tracking_code": "EZ3000000003"}}}}'
+      "2": {"tracking_code": "EZ3000000003"}}}'
     headers:
       Accept:
       - '*/*'
@@ -11,7 +11,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '186'
+      - '174'
       Content-type:
       - application/json
       authorization:
@@ -52,23 +52,22 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - acf0f34861fb26ebff23419a0066281c
+      - 64ca848261fb68b2ff23e71c00731fd7
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb3nuq
+      - bigweb9nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq 88c34981dc
-      - intlb1wdc 88c34981dc
-      - extlb1wdc 88c34981dc
+      - intlb1nuq 88c34981dc
+      - extlb2nuq 88c34981dc
       x-request-id:
-      - 11cf1870-cd5c-4f99-8d46-85a4b38ea509
+      - e3dc6de7-87f4-4cc9-97da-c8274041e633
       x-runtime:
-      - '0.045006'
+      - '0.046576'
       x-version-label:
-      - easypost-202202022304-2ed53fc3ab-master
+      - easypost-202202030055-9caa06770a-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_tracker_create_list.yaml
+++ b/tests/cassettes/test_tracker_create_list.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
-    body: '{"trackers": {"0": {"tracking_code": "EZ1000000001"}, "1": {"tracking_code":
-      "EZ2000000002"}, "2": {"tracking_code": "EZ3000000003"}, "3": {"tracking_code":
-      "EZ4000000004"}}}'
+    body: !!python/unicode '{"trackers": {"params": {"1": {"tracking_code": "EZ2000000002"},
+      "0": {"tracking_code": "EZ1000000001"}, "3": {"tracking_code": "EZ4000000004"},
+      "2": {"tracking_code": "EZ3000000003"}}}}'
     headers:
       Accept:
       - '*/*'
@@ -11,7 +11,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '174'
+      - '186'
       Content-type:
       - application/json
       authorization:
@@ -52,22 +52,23 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 81f96ebc61e71da3e7886e68003bdc33
+      - acf0f34861fb26ebff23419a0066281c
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq ffc213653a
-      - extlb2nuq ffc213653a
+      - intlb2nuq 88c34981dc
+      - intlb1wdc 88c34981dc
+      - extlb1wdc 88c34981dc
       x-request-id:
-      - 950d74b6-f59a-4a06-8543-e78780ded06c
+      - 11cf1870-cd5c-4f99-8d46-85a4b38ea509
       x-runtime:
-      - '0.043259'
+      - '0.045006'
       x-version-label:
-      - easypost-202201181926-d15669a17d-master
+      - easypost-202202022304-2ed53fc3ab-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -73,7 +73,7 @@ def test_tracker_interactions(per_run_unique):
 def test_tracker_create_list():
     """Tests that we can create a list of trackers in bulk."""
     trackers_list = easypost.Tracker.create_list(
-        trackers={
+        params={
             "0": {"tracking_code": "EZ1000000001"},
             "1": {"tracking_code": "EZ2000000002"},
             "2": {"tracking_code": "EZ3000000003"},

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -73,7 +73,7 @@ def test_tracker_interactions(per_run_unique):
 def test_tracker_create_list():
     """Tests that we can create a list of trackers in bulk."""
     trackers_list = easypost.Tracker.create_list(
-        params={
+        {
             "0": {"tracking_code": "EZ1000000001"},
             "1": {"tracking_code": "EZ2000000002"},
             "2": {"tracking_code": "EZ3000000003"},

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -72,7 +72,7 @@ def test_tracker_interactions(per_run_unique):
 @pytest.mark.vcr()
 def test_tracker_create_list():
     """Tests that we can create a list of trackers in bulk."""
-    trackers_list = easypost.Tracker.create_list(
+    success = easypost.Tracker.create_list(
         {
             "0": {"tracking_code": "EZ1000000001"},
             "1": {"tracking_code": "EZ2000000002"},
@@ -82,4 +82,4 @@ def test_tracker_create_list():
     )
 
     # This endpoint/method does not return anything, just make sure the request doesn't fail
-    assert trackers_list is True
+    assert success is True


### PR DESCRIPTION
# what
Improve the **create_list** for our Python library Tracker class.
# why
Currently, the user must define a map that is named "trackers". An error can be thrown if the user mistypes the word. Instead, in our create_list method, we are going to create another map that has "trackers" as the key and user input as the value.
# how
Add another map in **create_list** method and define "trackers" as the key and store user input as the value.
# testing
Re-record the cassette and pass the unit test.