### PR TITLE
Remove old `get_rates()` method on `Shipment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add the `update_brand()` method to the User object
 * Removes `_max_timeout` and instead uses a flat 60 second timeout for requests
 * Adds Python version to user-agent header on requests
-* Removes `shipment.get_rates()` method since the shipment struct already has rates. If you need to get new rates for a shipment, please use the `shipment.regenerate_rates()` method.
+* Removes `shipment.get_rates()` method since the shipment object already has rates. If you need to get new rates for a shipment, please use the `shipment.regenerate_rates()` method.
 
 ### v6.0.0 2021-10-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add the `update_brand()` method to the User object
 * Removes `_max_timeout` and instead uses a flat 60 second timeout for requests
 * Adds Python version to user-agent header on requests
+* Removes `shipment.get_rates()` function. Retrieve rates via `shipment.rates` instead
 
 ### v6.0.0 2021-10-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add the `update_brand()` method to the User object
 * Removes `_max_timeout` and instead uses a flat 60 second timeout for requests
 * Adds Python version to user-agent header on requests
-* Removes `shipment.get_rates()` function. Retrieve rates via `shipment.rates` instead
+* Removes `shipment.get_rates()` method since the shipment struct already has rates. If you need to get new rates for a shipment, please use the `shipment.regenerate_rates()` method.
 
 ### v6.0.0 2021-10-12
 

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -654,13 +654,6 @@ class Shipment(AllResource, CreateResource):
         self.refresh_from(response, api_key)
         return self
 
-    def get_rates(self):
-        requestor = Requestor(self._api_key)
-        url = "%s/%s" % (self.instance_url(), "rates")
-        response, api_key = requestor.request("get", url)
-        self.refresh_from(response, api_key)
-        return self
-
     def get_smartrates(self):
         requestor = Requestor(self._api_key)
         url = "%s/%s" % (self.instance_url(), "smartrate")

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -72,12 +72,6 @@ def test_shipment_creation():
     rate_id = shipment.rates[0].id
     assert rate_id is not None
 
-    previous_ids = set(r.id for r in shipment.rates)
-
-    # Get the rates back
-    shipment.get_rates()
-    assert set(r.id for r in shipment.rates) == previous_ids
-
     # Assert address values match
     assert shipment.buyer_address.country == to_address.country
     assert shipment.buyer_address.phone == to_address.phone


### PR DESCRIPTION
Rather than calling `shipment.get_rates()`, use `shipment.rates`. To refresh rates, call `shipment.regenerate_rates()`