### PR TITLE
Add parameter and return type hints to all functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ["pypy-3.6", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        pythonversion: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: set up python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        pythonversion: ["pypy-3.6", "3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: set up python
@@ -30,6 +30,6 @@ jobs:
         with:
           python-version: ${{ matrix.pythonversion }}
       - name: Install Dependencies
-        run: make install
+        run: make ${{ matrix.pythonversion == 'pypy-3.6' && 'install-pypy' || 'install' }}
       - name: Run Tests
         run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@
 * Bumps minimum Python version from 2.7 to 3.6
 * Bumps all dependencies
 * Add the `update_brand()` method to the User object
-* Removes `_max_timeout` and instead uses a flat 60 second timeout for requests
+* Removes `_max_timeout` and instead uses a flat 60-second timeout for requests
 * Adds Python version to user-agent header on requests
 * Removes `shipment.get_rates()` method since the shipment object already has rates. If you need to get new rates for a shipment, please use the `shipment.regenerate_rates()` method.
 * Add `retrieve_me()` convenience function that allow users to retrieve without specifying an ID.
 * Remove `blob` class since it's never being used
 * Remove `track_with_code` in shipment class since it's no longer being used
 * Add support for `columns` and `additional_columns` on Report creation
+* Must pass a list object to `Shipment.lowest_rate()` rather than a comma-separated list
 
 ### v6.0.0 2021-10-12
 

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ black-check:
 	$(VIRTUAL_BIN)/black $(PROJECT_NAME)/ $(TEST_DIR)/ --check
 
 ## format - Runs all formatting tools against the project
-format: black isort lint
+format: black isort lint mypy
 
 ## format-check - Checks if the project is formatted correctly against all formatting rules
-format-check: black-check isort-check lint
+format-check: black-check isort-check lint mypy
 
 ## install - Install the project locally
 install:
@@ -55,8 +55,12 @@ isort-check:
 lint:
 	$(VIRTUAL_BIN)/flake8 $(PROJECT_NAME)/ $(TEST_DIR)/
 
+## mypy - Run mypy type checking on the project
+mypy:
+	$(VIRTUAL_BIN)/mypy $(PROJECT_NAME)/ $(TEST_DIR)/
+
 ## test - Test the project
 test:
 	$(VIRTUAL_BIN)/pytest
 
-.PHONY: help build coverage clean black black-check format format-check install isort isort-check lint test
+.PHONY: help build coverage clean black black-check format format-check install isort isort-check lint mypy test

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ install:
 	$(PYTHON_BINARY) -m venv $(VIRTUAL_ENV)
 	$(VIRTUAL_BIN)/pip install -e ."[dev]"
 
+install-pypy:
+	$(PYTHON_BINARY) -m venv $(VIRTUAL_ENV)
+	$(VIRTUAL_BIN)/pip install -e ."[pypy_dev]"
 ## isort - Sorts imports throughout the project
 isort:
 	$(VIRTUAL_BIN)/isort $(PROJECT_NAME)/ $(TEST_DIR)/

--- a/easypost/address.py
+++ b/easypost/address.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, Optional
+
 from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource
@@ -5,9 +7,15 @@ from easypost.resource import AllResource, CreateResource
 
 class Address(AllResource, CreateResource):
     @classmethod
-    def create(cls, api_key=None, verify=None, verify_strict=None, **params):
+    def create(
+        cls,
+        api_key: Optional[str] = None,
+        verify: Optional[Dict[str, Any]] = None,
+        verify_strict: Dict[str, Any] = None,
+        **params
+    ) -> "Address":
         """Create an address."""
-        requestor = Requestor(api_key)
+        requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
 
         wrapped_params = {cls.snakecase_name(): params}
@@ -18,45 +26,45 @@ class Address(AllResource, CreateResource):
                 value = [value]
             wrapped_params[key] = value
 
-        response, api_key = requestor.request("post", url, wrapped_params)
-        return convert_to_easypost_object(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=wrapped_params)
+        return convert_to_easypost_object(response=response, api_key=api_key)
 
     @classmethod
-    def create_and_verify(cls, api_key=None, carrier=None, **params):
+    def create_and_verify(cls, api_key: Optional[str] = None, carrier: Optional[str] = None, **params) -> "Address":
         """Create and verify an address."""
-        requestor = Requestor(api_key)
+        requestor = Requestor(local_api_key=api_key)
         url = "%s/%s" % (cls.class_url(), "create_and_verify")
 
         wrapped_params = {cls.snakecase_name(): params, "carrier": carrier}
-        response, api_key = requestor.request("post", url, wrapped_params)
+        response, api_key = requestor.request(method="post", url=url, params=wrapped_params)
 
         response_address = response.get("address", None)
         response_message = response.get("message", None)
 
         if response_address is not None:
-            verified_address = convert_to_easypost_object(response_address, api_key)
+            verified_address = convert_to_easypost_object(response=response_address, api_key=api_key)
             if response_message is not None:
                 verified_address.message = response_message
                 verified_address._immutable_values.update("message")
             return verified_address
         else:
-            return convert_to_easypost_object(response, api_key)
+            return convert_to_easypost_object(response=response, api_key=api_key)
 
-    def verify(self, carrier=None):
+    def verify(self, carrier: Optional[str] = None) -> "Address":
         """Verify an address."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "verify")
         params = {"carrier": carrier}
-        response, api_key = requestor.request("get", url, params=params)
+        response, api_key = requestor.request(method="get", url=url, params=params)
 
         response_address = response.get("address", None)
         response_message = response.get("message", None)
 
         if response_address is not None:
-            verified_address = convert_to_easypost_object(response_address, api_key)
+            verified_address = convert_to_easypost_object(response=response_address, api_key=api_key)
             if response_message is not None:
                 verified_address.message = response_message
                 verified_address._immutable_values.update("message")
             return verified_address
         else:
-            return convert_to_easypost_object(response, api_key)
+            return convert_to_easypost_object(response=response, api_key=api_key)

--- a/easypost/batch.py
+++ b/easypost/batch.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource
@@ -5,50 +7,50 @@ from easypost.resource import AllResource, CreateResource
 
 class Batch(AllResource, CreateResource):
     @classmethod
-    def create_and_buy(cls, api_key=None, **params):
+    def create_and_buy(cls, api_key: Optional[str] = None, **params) -> "Batch":
         """Create and buy a Batch."""
-        requestor = Requestor(api_key)
+        requestor = Requestor(local_api_key=api_key)
         url = "%s/%s" % (cls.class_url(), "create_and_buy")
         wrapped_params = {cls.snakecase_name(): params}
-        response, api_key = requestor.request("post", url, wrapped_params)
-        return convert_to_easypost_object(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=wrapped_params)
+        return convert_to_easypost_object(response=response, api_key=api_key)
 
-    def buy(self, **params):
+    def buy(self, **params) -> "Batch":
         """Buy a batch."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def label(self, **params):
+    def label(self, **params) -> "Batch":
         """Create a batch label."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "label")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def remove_shipments(self, **params):
+    def remove_shipments(self, **params) -> "Batch":
         """Remove shipments from a batch."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "remove_shipments")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def add_shipments(self, **params):
+    def add_shipments(self, **params) -> "Batch":
         """Add shipments from a batch."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "add_shipments")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def create_scan_form(self, **params):
+    def create_scan_form(self, **params) -> "Batch":
         """Create a scanform for a batch."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "scan_form")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self

--- a/easypost/carrier_account.py
+++ b/easypost/carrier_account.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import (
@@ -10,8 +12,8 @@ from easypost.resource import (
 
 class CarrierAccount(AllResource, CreateResource, UpdateResource, DeleteResource):
     @classmethod
-    def types(cls, api_key=None):
+    def types(cls, api_key: Optional[str] = None) -> List[str]:
         """Get the types of carrier accounts available to the user."""
-        requestor = Requestor(api_key)
-        response, api_key = requestor.request("get", "/carrier_types")
-        return convert_to_easypost_object(response, api_key)
+        requestor = Requestor(local_api_key=api_key)
+        response, api_key = requestor.request(method="get", url="/carrier_types")
+        return convert_to_easypost_object(response=response, api_key=api_key)

--- a/easypost/easypost_object.py
+++ b/easypost/easypost_object.py
@@ -5,7 +5,10 @@ import easypost
 
 
 def convert_to_easypost_object(
-    response: Dict[str, Any], api_key: Optional[str] = None, parent: object = None, name: Optional[str] = None
+    response: Dict[str, Any],
+    api_key: Optional[str] = None,
+    parent: object = None,
+    name: Optional[str] = None,
 ):
     """Convert a response to an EasyPost object."""
     types = {
@@ -156,7 +159,11 @@ class EasyPostObject(object):
 
     @classmethod
     def construct_from(
-        cls, values: Dict[str, Any], api_key: Optional[str] = None, parent: object = None, name: Optional[str] = None
+        cls,
+        values: Dict[str, Any],
+        api_key: Optional[str] = None,
+        parent: object = None,
+        name: Optional[str] = None,
     ) -> object:
         """Construct an object."""
         instance = cls(easypost_id=values.get("id"), api_key=api_key, parent=parent, name=name)

--- a/easypost/error.py
+++ b/easypost/error.py
@@ -1,17 +1,25 @@
 import json
+from typing import Optional, Union
 
 
 class Error(Exception):
-    def __init__(self, message=None, http_status=None, http_body=None, original_exception=None):
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        http_status: Optional[int] = None,
+        http_body: Optional[Union[str, bytes]] = None,
+        original_exception: Optional[Exception] = None,
+    ):
         super(Error, self).__init__(message)
         self.message = message
         self.http_status = http_status
         self.http_body = http_body
         self.original_exception = original_exception
-        try:
-            self.json_body = json.loads(http_body)
-        except Exception:
-            self.json_body = None
+        if http_body:
+            try:
+                self.json_body = json.loads(http_body)
+            except Exception:
+                self.json_body = None
 
         self.param = None
         try:

--- a/easypost/event.py
+++ b/easypost/event.py
@@ -7,5 +7,5 @@ from easypost.resource import AllResource, Resource
 
 class Event(AllResource, Resource):
     @classmethod
-    def receive(cls, values):
-        return convert_to_easypost_object(json.loads(values), easypost.api_key)
+    def receive(cls, values: str) -> "Event":
+        return convert_to_easypost_object(response=json.loads(s=values), api_key=easypost.api_key)

--- a/easypost/order.py
+++ b/easypost/order.py
@@ -3,18 +3,18 @@ from easypost.resource import CreateResource
 
 
 class Order(CreateResource):
-    def get_rates(self):
+    def get_rates(self) -> "Order":
         """Get rates for an order."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "rates")
-        response, api_key = requestor.request("get", url)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="get", url=url)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def buy(self, **params):
+    def buy(self, **params) -> "Order":
         """Buy an order."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self

--- a/easypost/pickup.py
+++ b/easypost/pickup.py
@@ -3,18 +3,18 @@ from easypost.resource import CreateResource
 
 
 class Pickup(CreateResource):
-    def buy(self, **params):
+    def buy(self, **params) -> "Pickup":
         """Buy a pickup."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def cancel(self, **params):
+    def cancel(self, **params) -> "Pickup":
         """Cancel a pickup."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "cancel")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self

--- a/easypost/report.py
+++ b/easypost/report.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource
@@ -5,17 +7,17 @@ from easypost.resource import AllResource, CreateResource
 
 class Report(AllResource, CreateResource):
     @classmethod
-    def create(cls, api_key=None, **params):
+    def create(cls, api_key: Optional[str] = None, **params):
         """Create a report."""
-        requestor = Requestor(api_key)
+        requestor = Requestor(local_api_key=api_key)
         url = f"{cls.class_url()}/{params.get('type')}"
-        response, api_key = requestor.request("post", url, params, False)
-        return convert_to_easypost_object(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        return convert_to_easypost_object(response=response, api_key=api_key)
 
     @classmethod
-    def all(cls, api_key=None, **params):
+    def all(cls, api_key: Optional[str] = None, **params):
         """Retrieve all reports."""
-        requestor = Requestor(api_key)
-        url = "%s/%s" % (cls.class_url(), params["type"])
-        response, api_key = requestor.request("get", url, params)
-        return convert_to_easypost_object(response, api_key)
+        requestor = Requestor(local_api_key=api_key)
+        url = f"{cls.class_url()}/{params.get('type')}"
+        response, api_key = requestor.request(method="get", url=url, params=params)
+        return convert_to_easypost_object(response=response, api_key=api_key)

--- a/easypost/requestor.py
+++ b/easypost/requestor.py
@@ -34,7 +34,7 @@ class Requestor:
             return param
 
     def request(
-        self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
+            self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
     ) -> Tuple[dict, Optional[str]]:
         """Make a request to the EasyPost API."""
         if params is None:
@@ -46,7 +46,7 @@ class Requestor:
         return response, my_api_key
 
     def request_raw(
-        self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
+            self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
     ) -> Tuple[str, int, Optional[str]]:
         """Internal logic required to make a request to the EasyPost API."""
         # Importing here to avoid circular imports
@@ -69,11 +69,18 @@ class Requestor:
             "lang": "python",
             "publisher": "easypost",
             "request_lib": request_lib,
-            "lang_version": platform.python_version(),
-            "platform": platform.platform(),
-            "uname": " ".join(platform.uname()),
-            "implementation": platform.python_implementation(),
         }
+        for attr, func in (
+                ("lang_version", platform.python_version),
+                ("platform", platform.platform),
+                ("uname", lambda: " ".join(platform.uname())),
+                ("implementation", platform.python_implementation),
+        ):
+            try:
+                val = func()
+            except Exception as e:
+                val = "!! %s" % e
+            ua[attr] = val
 
         if hasattr(ssl, "OPENSSL_VERSION"):
             ua["openssl_version"] = ssl.OPENSSL_VERSION
@@ -111,7 +118,7 @@ class Requestor:
         return response
 
     def requests_request(
-        self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
+            self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
     ) -> Tuple[str, int]:
         """Make a request by using the `request` library."""
         method = method.lower()
@@ -143,7 +150,7 @@ class Requestor:
         return http_body, http_status
 
     def urlfetch_request(
-        self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
+            self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
     ) -> Tuple[str, int]:
         """Make a request by using the `urlfetch` library."""
         fetch_args = {"method": method, "headers": headers, "validate_certificate": False, "deadline": timeout}

--- a/easypost/requestor.py
+++ b/easypost/requestor.py
@@ -4,7 +4,7 @@ import platform
 import ssl
 import time
 from json import JSONDecodeError
-from typing import Optional, Tuple, Union, Dict, Any
+from typing import Any, Dict, Optional, Tuple, Union
 from urllib.parse import urlencode
 
 from easypost.constant import SUPPORT_EMAIL, TIMEOUT, USER_AGENT
@@ -110,7 +110,9 @@ class Requestor:
             self.handle_api_error(http_status=http_status, http_body=http_body, response=response)
         return response
 
-    def requests_request(self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]) -> Tuple[str, int]:
+    def requests_request(
+        self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
+    ) -> Tuple[str, int]:
         """Make a request by using the `request` library."""
         method = method.lower()
         if method == "get" or method == "delete":
@@ -140,7 +142,9 @@ class Requestor:
             )
         return http_body, http_status
 
-    def urlfetch_request(self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]) -> Tuple[str, int]:
+    def urlfetch_request(
+        self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
+    ) -> Tuple[str, int]:
         """Make a request by using the `urlfetch` library."""
         fetch_args = {"method": method, "headers": headers, "validate_certificate": False, "deadline": timeout}
         if method == "get" or method == "delete":

--- a/easypost/requestor.py
+++ b/easypost/requestor.py
@@ -34,7 +34,11 @@ class Requestor:
             return param
 
     def request(
-        self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        api_key_required: bool = True,
     ) -> Tuple[dict, Optional[str]]:
         """Make a request to the EasyPost API."""
         if params is None:
@@ -46,7 +50,11 @@ class Requestor:
         return response, my_api_key
 
     def request_raw(
-        self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        api_key_required: bool = True,
     ) -> Tuple[str, int, Optional[str]]:
         """Internal logic required to make a request to the EasyPost API."""
         # Importing here to avoid circular imports
@@ -111,14 +119,18 @@ class Requestor:
             response = json.loads(http_body)
         except JSONDecodeError:
             raise Exception(
-                "Unable to parse response body from API: %s\nHTTP response code was: %d" % (http_body, http_status)
+                f"Unable to parse response body from API: {http_body}\nHTTP response code was: {http_status}"
             )
         if not (200 <= http_status < 300):
             self.handle_api_error(http_status=http_status, http_body=http_body, response=response)
         return response
 
     def requests_request(
-        self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
+        self,
+        method: str,
+        abs_url: str,
+        headers: Dict[str, Any],
+        params: Dict[str, Any],
     ) -> Tuple[str, int]:
         """Make a request by using the `request` library."""
         method = method.lower()
@@ -150,7 +162,11 @@ class Requestor:
         return http_body, http_status
 
     def urlfetch_request(
-        self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
+        self,
+        method: str,
+        abs_url: str,
+        headers: Dict[str, Any],
+        params: Dict[str, Any],
     ) -> Tuple[str, int]:
         """Make a request by using the `urlfetch` library."""
         fetch_args = {"method": method, "headers": headers, "validate_certificate": False, "deadline": timeout}

--- a/easypost/requestor.py
+++ b/easypost/requestor.py
@@ -34,7 +34,7 @@ class Requestor:
             return param
 
     def request(
-            self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
+        self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
     ) -> Tuple[dict, Optional[str]]:
         """Make a request to the EasyPost API."""
         if params is None:
@@ -46,7 +46,7 @@ class Requestor:
         return response, my_api_key
 
     def request_raw(
-            self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
+        self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
     ) -> Tuple[str, int, Optional[str]]:
         """Internal logic required to make a request to the EasyPost API."""
         # Importing here to avoid circular imports
@@ -71,13 +71,13 @@ class Requestor:
             "request_lib": request_lib,
         }
         for attr, func in (
-                ("lang_version", platform.python_version),
-                ("platform", platform.platform),
-                ("uname", lambda: " ".join(platform.uname())),
-                ("implementation", platform.python_implementation),
+            ("lang_version", platform.python_version),
+            ("platform", platform.platform),
+            ("uname", lambda: " ".join(platform.uname())),
+            ("implementation", platform.python_implementation),
         ):
             try:
-                val = func()
+                val = func()  # type: ignore
             except Exception as e:
                 val = "!! %s" % e
             ua[attr] = val
@@ -118,7 +118,7 @@ class Requestor:
         return response
 
     def requests_request(
-            self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
+        self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
     ) -> Tuple[str, int]:
         """Make a request by using the `request` library."""
         method = method.lower()
@@ -150,7 +150,7 @@ class Requestor:
         return http_body, http_status
 
     def urlfetch_request(
-            self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
+        self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]
     ) -> Tuple[str, int]:
         """Make a request by using the `urlfetch` library."""
         fetch_args = {"method": method, "headers": headers, "validate_certificate": False, "deadline": timeout}

--- a/easypost/requestor.py
+++ b/easypost/requestor.py
@@ -3,6 +3,8 @@ import json
 import platform
 import ssl
 import time
+from json import JSONDecodeError
+from typing import Optional, Tuple, Union, Dict, Any
 from urllib.parse import urlencode
 
 from easypost.constant import SUPPORT_EMAIL, TIMEOUT, USER_AGENT
@@ -11,37 +13,45 @@ from easypost.error import Error
 
 
 class Requestor:
-    def __init__(self, local_api_key=None):
+    def __init__(self, local_api_key: Optional[str] = None):
         self._api_key = local_api_key
 
     @classmethod
-    def _objects_to_ids(cls, param):
+    def _objects_to_ids(cls, param: Dict[str, Any]) -> Dict[str, Any]:
         """If providing an object as a parameter to another object,
         only pass along the ID so the API will use the object reference correctly."""
         if isinstance(param, EasyPostObject):
             return {"id": param.id}
         elif isinstance(param, dict):
-            return {k: cls._objects_to_ids(v) for k, v in param.items()}
-        elif isinstance(param, list):
-            return [cls._objects_to_ids(v) for v in param]
+            data = {}
+            for (k, v) in param.items():
+                if isinstance(v, list):
+                    data[k] = [cls._objects_to_ids(item) for item in v]  # type: ignore
+                else:
+                    data[k] = cls._objects_to_ids(v)  # type: ignore
+            return data
         else:
             return param
 
-    def request(self, method, url, params=None, api_key_required=True):
+    def request(
+        self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
+    ) -> Tuple[dict, Optional[str]]:
         """Make a request to the EasyPost API."""
         if params is None:
             params = {}
-        http_body, http_status, my_api_key = self.request_raw(method, url, params, api_key_required)
-        response = self.interpret_response(http_body, http_status)
+        http_body, http_status, my_api_key = self.request_raw(
+            method=method, url=url, params=params, api_key_required=api_key_required
+        )
+        response = self.interpret_response(http_body=http_body, http_status=http_status)
         return response, my_api_key
 
-    def request_raw(self, method, url, params=None, api_key_required=True):
+    def request_raw(
+        self, method: str, url: str, params: Optional[Dict[str, Any]] = None, api_key_required: bool = True
+    ) -> Tuple[str, int, Optional[str]]:
         """Internal logic required to make a request to the EasyPost API."""
         # Importing here to avoid circular imports
         from easypost import VERSION, api_base, api_key
 
-        if params is None:
-            params = {}
         my_api_key = self._api_key or api_key
 
         if api_key_required and my_api_key is None:
@@ -52,25 +62,18 @@ class Requestor:
             )
 
         abs_url = "%s%s" % (api_base, url or "")
-        params = self._objects_to_ids(params)
+        params = self._objects_to_ids(param=params or {})
 
         ua = {
             "client_version": VERSION,
             "lang": "python",
             "publisher": "easypost",
             "request_lib": request_lib,
+            "lang_version": platform.python_version(),
+            "platform": platform.platform(),
+            "uname": " ".join(platform.uname()),
+            "implementation": platform.python_implementation(),
         }
-        for attr, func in (
-            ("lang_version", platform.python_version),
-            ("platform", platform.platform),
-            ("uname", lambda: " ".join(platform.uname())),
-            ("implementation", platform.python_implementation),
-        ):
-            try:
-                val = func()
-            except Exception as e:
-                val = "!! %s" % e
-            ua[attr] = val
 
         if hasattr(ssl, "OPENSSL_VERSION"):
             ua["openssl_version"] = ssl.OPENSSL_VERSION
@@ -83,29 +86,35 @@ class Requestor:
         }
 
         if request_lib == "urlfetch":
-            http_body, http_status = self.urlfetch_request(method, abs_url, headers, params)
+            http_body, http_status = self.urlfetch_request(
+                method=method, abs_url=abs_url, headers=headers, params=params
+            )
         elif request_lib == "requests":
-            http_body, http_status = self.requests_request(method, abs_url, headers, params)
+            http_body, http_status = self.requests_request(
+                method=method, abs_url=abs_url, headers=headers, params=params
+            )
         else:
             raise Error(f"Bug discovered: invalid request_lib: {request_lib}. Please report to {SUPPORT_EMAIL}.")
 
         return http_body, http_status, my_api_key
 
-    def interpret_response(self, http_body, http_status):
+    def interpret_response(self, http_body: str, http_status: int) -> Dict[str, Any]:
         """Interpret the response body we receive from the API."""
         try:
             response = json.loads(http_body)
-        except Exception:
-            raise Error("Invalid response body from API: (%d) %s " % (http_status, http_body), http_status, http_body)
+        except JSONDecodeError:
+            raise Exception(
+                "Unable to parse response body from API: %s\nHTTP response code was: %d" % (http_body, http_status)
+            )
         if not (200 <= http_status < 300):
-            self.handle_api_error(http_status, http_body, response)
+            self.handle_api_error(http_status=http_status, http_body=http_body, response=response)
         return response
 
-    def requests_request(self, method, abs_url, headers, params):
+    def requests_request(self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]) -> Tuple[str, int]:
         """Make a request by using the `request` library."""
         method = method.lower()
         if method == "get" or method == "delete":
-            abs_url = self.add_params_to_url(abs_url, params)
+            abs_url = self.add_params_to_url(url=abs_url, params=params)
             data = None
         elif method == "post" or method == "put":
             data = json.dumps(params, default=self._utf8)
@@ -131,21 +140,21 @@ class Requestor:
             )
         return http_body, http_status
 
-    def urlfetch_request(self, method, abs_url, headers, params):
+    def urlfetch_request(self, method: str, abs_url: str, headers: Dict[str, Any], params: Dict[str, Any]) -> Tuple[str, int]:
         """Make a request by using the `urlfetch` library."""
         fetch_args = {"method": method, "headers": headers, "validate_certificate": False, "deadline": timeout}
-        if method == "post" or method == "put":
+        if method == "get" or method == "delete":
+            fetch_args["url"] = self.add_params_to_url(url=abs_url, params=params)
+        elif method == "post" or method == "put":
             fetch_args["url"] = abs_url
             fetch_args["payload"] = json.dumps(params, default=self._utf8)
-        elif method == "get" or method == "delete":
-            fetch_args["url"] = self.add_params_to_url(abs_url, params)
         else:
             raise Error(f"Bug discovered: invalid request method: {method}. Please report to {SUPPORT_EMAIL}.")
 
         try:
-            from google.appengine.api import urlfetch
+            from google.appengine.api import urlfetch  # type: ignore
 
-            result = urlfetch.fetch(**fetch_args)
+            result = urlfetch.fetch(**fetch_args)  # type: ignore
         except Exception as e:
             raise Error(
                 "Unexpected error communicating with EasyPost. "
@@ -155,7 +164,7 @@ class Requestor:
 
         return result.content, result.status_code
 
-    def handle_api_error(self, http_status, http_body, response):
+    def handle_api_error(self, http_status: int, http_body: str, response: Dict[str, Any]) -> None:
         """Handles API errors returned from EasyPost."""
         try:
             error = response["error"]
@@ -163,17 +172,17 @@ class Requestor:
             raise Error("Invalid response from API: (%d) %r " % (http_status, http_body), http_status, http_body)
 
         try:
-            raise Error(error.get("message", ""), http_status, http_body)
+            raise Error(message=error.get("message", ""), http_status=http_status, http_body=http_body)
         except AttributeError:
-            raise Error(error, http_status, http_body)
+            raise Error(message=error, http_status=http_status, http_body=http_body)
 
-    def _utf8(self, value):
+    def _utf8(self, value: Union[str, bytes]) -> str:
         # Python3's str(bytestring) returns "b'bytestring'" so we use .decode instead
         if isinstance(value, bytes):
-            return value.decode("utf-8")
+            return value.decode(encoding="utf-8")
         return value
 
-    def encode_url_params(self, params):
+    def encode_url_params(self, params: Dict[str, Any]) -> Union[str, None]:
         """Encode params for a URL."""
         converted_params = []
         for key, value in sorted(params.items()):
@@ -182,11 +191,11 @@ class Requestor:
             elif isinstance(value, datetime.datetime):
                 value = int(time.mktime(value.timetuple()))  # to UTC timestamp
             converted_params.append((key, value))
-            return urlencode(converted_params)
+        return urlencode(query=converted_params)
 
-    def add_params_to_url(self, url, params):
+    def add_params_to_url(self, url: str, params: Dict[str, Any]) -> str:
         """Add params to the URL."""
-        encoded_params = self.encode_url_params(params)
+        encoded_params = self.encode_url_params(params=params)
         if encoded_params:
             return "%s?%s" % (url, encoded_params)
         return url
@@ -208,7 +217,7 @@ except ImportError:
         request_lib = "requests"
         requests_session = requests.Session()
         requests_http_adapter = requests.adapters.HTTPAdapter(max_retries=3)
-        requests_session.mount("https://api.easypost.com", requests_http_adapter)
+        requests_session.mount(prefix="https://api.easypost.com", adapter=requests_http_adapter)
     except Exception:
         raise ImportError(
             "EasyPost requires an up to date requests library. "

--- a/easypost/resource.py
+++ b/easypost/resource.py
@@ -1,4 +1,5 @@
 import re
+from typing import List, Optional, Any
 
 from easypost.easypost_object import EasyPostObject, convert_to_easypost_object
 from easypost.error import Error
@@ -6,37 +7,32 @@ from easypost.requestor import Requestor
 
 
 class Resource(EasyPostObject):
-    def _ident(self):
+    def _ident(self) -> List[str]:
         return [self.get("id")]
 
     @classmethod
-    def retrieve(cls, easypost_id, api_key=None, **params):
+    def retrieve(cls, easypost_id: str, api_key: Optional[str] = None, **params) -> object:
         """Retrieve an object from the EasyPost API."""
-        try:
-            easypost_id = easypost_id["id"]
-        except (KeyError, TypeError):
-            pass
-
-        instance = cls(easypost_id, api_key, **params)
+        instance = cls(easypost_id=easypost_id, api_key=api_key, **params)
         instance.refresh()
         return instance
 
-    def refresh(self):
+    def refresh(self) -> object:
         """Refresh the local object from the API response."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = self.instance_url()
-        response, api_key = requestor.request("get", url, self._retrieve_params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="get", url=url, params=self._retrieve_params)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
     @classmethod
-    def snakecase_name(cls):
+    def snakecase_name(cls) -> str:
         """Return the class name as snake_case."""
         snake_name = (cls.__name__[0:1] + re.sub(r"([A-Z])", r"_\1", cls.__name__[1:])).lower()
         return snake_name
 
     @classmethod
-    def class_url(cls):
+    def class_url(cls) -> str:
         """Generate a URL based on class name."""
         cls_name = cls.snakecase_name()
         if cls_name[-1:] in ("s", "h"):
@@ -44,7 +40,7 @@ class Resource(EasyPostObject):
         else:
             return "/%ss" % cls_name
 
-    def instance_url(self):
+    def instance_url(self) -> str:
         """Generate an instance URL based on the ID of the object."""
         easypost_id = self.get("id")
         if not easypost_id:
@@ -54,30 +50,30 @@ class Resource(EasyPostObject):
 
 class AllResource(Resource):
     @classmethod
-    def all(cls, api_key=None, **params):
+    def all(cls, api_key: Optional[str] = None, **params) -> List[Any]:
         """Retrieve a list of records from the API."""
-        requestor = Requestor(api_key)
+        requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
-        response, api_key = requestor.request("get", url, params)
-        return convert_to_easypost_object(response, api_key)
+        response, api_key = requestor.request(method="get", url=url, params=params)
+        return convert_to_easypost_object(response=response, api_key=api_key)
 
 
 class CreateResource(Resource):
     @classmethod
-    def create(cls, api_key=None, **params):
+    def create(cls, api_key: Optional[str] = None, **params) -> Any:
         """Create an EasyPost object."""
-        requestor = Requestor(api_key)
+        requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
         wrapped_params = {cls.snakecase_name(): params}
-        response, api_key = requestor.request("post", url, wrapped_params)
-        return convert_to_easypost_object(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=wrapped_params)
+        return convert_to_easypost_object(response=response, api_key=api_key)
 
 
 class UpdateResource(Resource):
-    def save(self):
+    def save(self) -> Any:
         """Update an EasyPost object."""
         if self._unsaved_values:
-            requestor = Requestor(self._api_key)
+            requestor = Requestor(local_api_key=self._api_key)
             params = {}
             for k in self._unsaved_values:
                 params[k] = getattr(self, k)
@@ -85,17 +81,17 @@ class UpdateResource(Resource):
                     params[k] = params[k].flatten_unsaved()
             params = {self.snakecase_name(): params}
             url = self.instance_url()
-            response, api_key = requestor.request("put", url, params)
-            self.refresh_from(response, api_key)
+            response, api_key = requestor.request(method="put", url=url, params=params)
+            self.refresh_from(values=response, api_key=api_key)
 
         return self
 
 
 class DeleteResource(Resource):
-    def delete(self, **params):
+    def delete(self, **params) -> Any:
         """Delete an EasyPost object."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = self.instance_url()
-        response, api_key = requestor.request("delete", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="delete", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self

--- a/easypost/resource.py
+++ b/easypost/resource.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional, Any
+from typing import Any, List, Optional
 
 from easypost.easypost_object import EasyPostObject, convert_to_easypost_object
 from easypost.error import Error

--- a/easypost/scanform.py
+++ b/easypost/scanform.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource
@@ -5,9 +7,9 @@ from easypost.resource import AllResource, CreateResource
 
 class ScanForm(AllResource, CreateResource):
     @classmethod
-    def create(cls, api_key=None, **params):
+    def create(cls, api_key: Optional[str] = None, **params):
         """Create a scanform."""
-        requestor = Requestor(api_key)
+        requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
-        response, api_key = requestor.request("post", url, params)
-        return convert_to_easypost_object(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        return convert_to_easypost_object(response=response, api_key=api_key)

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -1,72 +1,66 @@
+from typing import List
+
+from easypost import Rate
 from easypost.error import Error
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource
 
 
 class Shipment(AllResource, CreateResource):
-    def regenerate_rates(self):
+    def regenerate_rates(self) -> "Shipment":
         """Regenerate rates for a shipment."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "rerate")
-        response, api_key = requestor.request("post", url)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def get_smartrates(self):
+    def get_smartrates(self) -> List[object]:
         """Get smartrates for a shipment."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "smartrate")
-        response, api_key = requestor.request("get", url)
+        response, api_key = requestor.request(method="get", url=url)
         return response.get("result", [])
 
-    def buy(self, **params):
+    def buy(self, **params) -> "Shipment":
         """Buy a shipment."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def refund(self, **params):
+    def refund(self, **params) -> "Shipment":
         """Refund a shipment."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "refund")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def insure(self, **params):
+    def insure(self, **params) -> "Shipment":
         """Insure a shipment."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "insure")
-        response, api_key = requestor.request("post", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def label(self, **params):
+    def label(self, **params) -> "Shipment":
         """Convert the label format of a shipment."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "label")
-        response, api_key = requestor.request("get", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="get", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self
 
-    def lowest_rate(self, carriers=None, services=None):
+    def lowest_rate(self, carriers: List[str] = None, services: List[str] = None) -> Rate:
         """Get the lowest rate of a shipment."""
         carriers = carriers or []
         services = services or []
         lowest_rate = None
 
-        try:
-            carriers = carriers.split(",")
-        except AttributeError:
-            pass
         carriers = [c.lower() for c in carriers]
-
-        try:
-            services = services.split(",")
-        except AttributeError:
-            pass
         services = [service.lower() for service in services]
 
         for rate in self.rates:
@@ -80,6 +74,6 @@ class Shipment(AllResource, CreateResource):
                 lowest_rate = rate
 
         if lowest_rate is None:
-            raise Error("No rates found.")
+            raise Error(message="No rates found.")
 
         return lowest_rate

--- a/easypost/tracker.py
+++ b/easypost/tracker.py
@@ -1,13 +1,15 @@
+from typing import List, Optional, Dict, Any
+
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource
 
 
 class Tracker(AllResource, CreateResource):
     @classmethod
-    def create_list(cls, trackers, api_key=None):
+    def create_list(cls, trackers: List[Dict[str, Any]], api_key: Optional[str] = None) -> bool:
         """Create a list of trackers."""
-        requestor = Requestor(api_key)
+        requestor = Requestor(local_api_key=api_key)
         url = "%s/%s" % (cls.class_url(), "create_list")
         new_params = {"trackers": trackers}
-        _, _ = requestor.request("post", url, new_params)
+        _, _ = requestor.request(method="post", url=url, params=new_params)
         return True

--- a/easypost/tracker.py
+++ b/easypost/tracker.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, Any
+from typing import Any, Dict, List, Optional
 
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource

--- a/easypost/user.py
+++ b/easypost/user.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import CreateResource, DeleteResource, UpdateResource
@@ -5,62 +7,56 @@ from easypost.resource import CreateResource, DeleteResource, UpdateResource
 
 class User(CreateResource, UpdateResource, DeleteResource):
     @classmethod
-    def create(cls, api_key=None, **params):
+    def create(cls, api_key: Optional[str] = None, **params) -> "User":
         """Create a user."""
-        requestor = Requestor(api_key)
+        requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
         wrapped_params = {cls.snakecase_name(): params}
-        response, api_key = requestor.request("post", url, wrapped_params, False)
-        return convert_to_easypost_object(response, api_key)
+        response, api_key = requestor.request(method="post", url=url, params=wrapped_params, api_key_required=False)
+        return convert_to_easypost_object(response=response, api_key=api_key)
 
     @classmethod
-    def retrieve(cls, easypost_id="", api_key=None, **params):
+    def retrieve(cls, easypost_id: Optional[str] = None, api_key: Optional[str] = None, **params) -> "User":
         """Retrieve a user."""
-        try:
-            easypost_id = easypost_id["id"]
-        except (KeyError, TypeError):
-            pass
-
-        if easypost_id == "":
-            requestor = Requestor(api_key)
-            response, api_key = requestor.request("get", cls.class_url())
-            return convert_to_easypost_object(response, api_key)
+        if not easypost_id:
+            requestor = Requestor(local_api_key=api_key)
+            response, api_key = requestor.request(method="get", url=cls.class_url())
+            return convert_to_easypost_object(response=response, api_key=api_key)
         else:
-            instance = cls(easypost_id, api_key, **params)
+            instance = cls(easypost_id=easypost_id, api_key=api_key, **params)
             instance.refresh()
             return instance
 
     @classmethod
-    def retrieve_me(cls, api_key=None, **params):
+    def retrieve_me(cls, api_key: Optional[str] = None, **params) -> "User":
         """Retrieve the authenticated user."""
-        requestor = Requestor(api_key)
-        response, api_key = requestor.request("get", cls.class_url())
-        return convert_to_easypost_object(response, api_key)
+        requestor = Requestor(local_api_key=api_key)
+        response, api_key = requestor.request(method="get", url=cls.class_url())
+        return convert_to_easypost_object(response=response, api_key=api_key)
 
     @classmethod
-    def all_api_keys(cls, api_key=None):
+    def all_api_keys(cls, api_key: Optional[str] = None) -> "User":
         """Get all API keys including child user keys."""
-        requestor = Requestor(api_key)
+        requestor = Requestor(local_api_key=api_key)
         url = "/api_keys"
-        response, api_key = requestor.request("get", url)
-        return convert_to_easypost_object(response, api_key)
+        response, api_key = requestor.request(method="get", url=url)
+        return convert_to_easypost_object(response=response, api_key=api_key)
 
-    def api_keys(self):
+    def api_keys(self) -> List[str]:
         """Get the authenticated user's API keys."""
         api_keys = self.all_api_keys()
 
         if api_keys.id == self.id:
-            my_api_keys = api_keys.keys
+            return api_keys.keys
         else:
             for child in api_keys.children:
                 if child.id == self.id:
-                    my_api_keys = child.keys
-                    break
+                    return child.keys
 
-        return my_api_keys
+        return []
 
-    def update_brand(self, api_key=None, **params):
+    def update_brand(self, api_key: Optional[str] = None, **params) -> "User":
         """Update the User's Brand."""
-        requestor = Requestor(api_key)
-        response, api_key = requestor.request("put", self.instance_url() + "/brand", params)
-        return convert_to_easypost_object(response, api_key)
+        requestor = Requestor(local_api_key=api_key)
+        response, api_key = requestor.request(method="put", url=self.instance_url() + "/brand", params=params)
+        return convert_to_easypost_object(response=response, api_key=api_key)

--- a/easypost/version.py
+++ b/easypost/version.py
@@ -1,6 +1,8 @@
 VERSION = "6.0.0"
 
-if "-" in VERSION:
-    VERSION_INFO = tuple([int(v) for v in VERSION.split("-")[0].split(".")] + VERSION.split("-")[1:])
-else:
-    VERSION_INFO = tuple(int(v) for v in VERSION.split("."))
+elements = VERSION.split("-")
+numbers = [str(v) for v in elements[0].split(".")]
+if len(elements) > 1:
+    numbers.extend(elements[1])
+numbers.extend(elements[1:])
+VERSION_INFO = numbers

--- a/easypost/webhook.py
+++ b/easypost/webhook.py
@@ -3,10 +3,10 @@ from easypost.resource import AllResource, CreateResource, DeleteResource
 
 
 class Webhook(AllResource, CreateResource, DeleteResource):
-    def update(self, **params):
+    def update(self, **params) -> "Webhook":
         """Update a webhook."""
-        requestor = Requestor(self._api_key)
+        requestor = Requestor(local_api_key=self._api_key)
         url = self.instance_url()
-        response, api_key = requestor.request("put", url, params)
-        self.refresh_from(response, api_key)
+        response, api_key = requestor.request(method="put", url=url, params=params)
+        self.refresh_from(values=response, api_key=api_key)
         return self

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,16 @@ DEV_REQUIREMENTS = [
     "black",
     "flake8",
     "isort",
-    "mypy",
     "pytest-cov==3.*",
     "pytest-vcr==1.*",
     "pytest==7.*",
     "types-requests",
     "types-urllib3",
     "vcrpy==4.*",
+]
+
+CPYTHON_DEV_REQUIREMENTS = [
+    "mypy",
 ]
 
 with open("README.md", encoding="utf-8") as f:
@@ -31,7 +34,8 @@ setup(
     packages=["easypost"],
     install_requires=REQUIREMENTS,
     extras_require={
-        "dev": DEV_REQUIREMENTS,
+        "dev": DEV_REQUIREMENTS + CPYTHON_DEV_REQUIREMENTS,
+        "pypy_dev": DEV_REQUIREMENTS,
     },
     package_data={
         'easypost': ['py.typed']

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ DEV_REQUIREMENTS = [
     "vcrpy==4.*",
 ]
 
+# packages incompatible with PyPy go here
 CPYTHON_DEV_REQUIREMENTS = [
     "mypy",
 ]
@@ -35,7 +36,7 @@ setup(
     install_requires=REQUIREMENTS,
     extras_require={
         "dev": DEV_REQUIREMENTS + CPYTHON_DEV_REQUIREMENTS,
-        "pypy_dev": DEV_REQUIREMENTS,
+        "pypy_dev": DEV_REQUIREMENTS,  # no cpython requirements
     },
     package_data={
         'easypost': ['py.typed']

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,19 @@ from setuptools import setup
 
 REQUIREMENTS = [
     "requests >= 2.4.3",
+    "typing-extensions"
 ]
 
 DEV_REQUIREMENTS = [
     "black",
     "flake8",
     "isort",
+    "mypy",
     "pytest-cov==3.*",
     "pytest-vcr==1.*",
     "pytest==7.*",
+    "types-requests",
+    "types-urllib3",
     "vcrpy==4.*",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
     extras_require={
         "dev": DEV_REQUIREMENTS,
     },
+    package_data={
+        'easypost': ['py.typed']
+    },
     test_suite="test",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/cassettes/test_report_all.yaml
+++ b/tests/cassettes/test_report_all.yaml
@@ -17,26 +17,26 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: GET
-    uri: https://api.easypost.com/v2/reports/shipment?page_size=5
+    uri: https://api.easypost.com/v2/reports/shipment?page_size=5&type=shipment
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA9yW648bNRDA/5eV4NMl8YzfkSIUFdBVgHikUrkiFI3tcbMoL3Y3LVzV/53Zy7WC
-        SoWqPT7cfVl5Z8aeh38e+1XT8fHQDX0z/+VV05Zm3vSbo8jWyVXGoGrmCia7SMkVjRqBs/OQa3PR
-        HNJvnAeZstq0xx3vh59u1hJN7pgGLmsatagQJ0pPwD9BnEOYY3gmNqdj+U+bfqBuWI92f7NRIBre
-        l3flMMp3hzLKBu6H8/zhJLk19ILaLaUtj467rUg2w3Ds57MZU//n8dAPk9puuZ/2enrqJy9l+gSn
-        tKPrw55e9tN82M1uDGb9ba7rc+Fmo3elwc+KscGZiKB0MJAMpQTaB0ZbXQkYp9ft8YufJ8vd9WS5
-        fX7o2mGzWyyfrszk8rvlo8nqconWfX42eNRxER8tbRfLbx4vr9B/+727+nFlVz9cPXn6+DP8+o1b
-        Gb6NV8a9lo8EbCS8308ivV3wSynV4s0cKTFIQM9udV/9cWw77hda3QpW7fM9l0umwl2/2BzerjIq
-        pKAdL1LxkhR5zZCDJQaPkqXTCSG6TAguBOCQUXmVVFHZ1+yVA3Spgo76vA1rPrt+DwM2jgy0+7w9
-        FV7nTbstHe+beaVtz68v3uEVwGCKoeacDAcTS83Bx+BRK0zmk3h1H8Crv2+8VmMjVdQuaW8o12Aw
-        RoeOtCkVnH9QvMoZNCr44Kzy1hmKxeaMLmMJwqWRToeadCo6sjUmqGIVVbKIKYBR5X/gNVpLEEqq
-        tnrxWGNkJCzRWGCrbk7IR/AKEsQc8V95Pdvo+8ZrSuhAtsfGTEYxS/NBlSkaj8UU0g+KV7LKcixJ
-        ehpbkJ86ntGxrVlASp6lsVZbqsm1GpTbuTqpQnAhYWQd0t3zSj5aT9FpX9AYKBGsZgYNIB59hk/h
-        VX0Ar3DfeAUqWQgtGRQbyCoqlEuRo6012JD5QfGKxSuN3oOlmE2U96GysRbpaAKsqdk5ZuOLcnI9
-        GxlphzGhAGSzNORQ755XX8RpDCiEZuPZJZOpODCsyBsd6CN4dSOLRs/Bvp/Xf9rcH17dLKhosjZY
-        ZROlpyIR5ZBjtg6zR8YHxav3lpQ8Up1Fn5iDJCmQAvpcBA/ns7yEjM1cwBbxyU4e9Cqw4O0VKevv
-        gNdfL5oN9evdoZMNH7oTv/4LAAD//wMAWdTngI0NAAA=
+        H4sIAAAAAAAAA9yWa2tbRxCG/4ug/WRZuzN7FYgi0haHtvQiQ+qUImZ3ZiMV3XrOcdI65L93FLmG
+        tmBC4n6wYTkcZmd39vLsO/N21Mlh3w39aPrL29GaR9NRvzqobZlbLWCKRMDkXIEklJ24ANYGrtGN
+        zkb78pvUQYcsVuvDVnbDT+/n0p7aCQ3CSzr2ggEYGxzbeAlmat0U8KX6XB/4Ph9/9OkH6obl0e/O
+        R5vVHtnxf+yo9u2ej7ZB+uE0frjWvY3oNa03VDZyDNxt1LIahkM/nUyE+j8P+34Yt/VG+vMez6/7
+        8RsdPoZz2tLNfkdv+vO6307eO0z6270uTwc3OUY3aOPEp5awVqiWnMu+UcFiIFBml5IhPL9ZH774
+        eTzf3oznm1f7bj2strP5i4UbX3w3fzZeXMzBh89PDs86YY2xps1s/s3z+RXEb78PVz8u/OKHq8sX
+        zz+Dr2/DJv29W6/+96gfXbDT5f1+rdbbCb/Uo5r9PebSZmeseXnb99Ufh3Un/QzNrWGxfrUTvhBi
+        6frZan83y7FDD7STmTWcyIfYEifjqTkbo6RiKFSgxhjBJxcRImHEIoUgh2odkSQOybbTNSzlFPpf
+        DBwXOHVG25GB9a5urlmWdbXecCe70bTRppd3Z//kFUuuEbmYWpLDVDPViuxqhOgV2PApvMIH8Ooe
+        G69YBcVktD5FlxqSOOfAZWwcADA/KV5ztK4lV5lTbMw+ScHIkVJhL8FS0nfroIKlBrr5WkypnJVX
+        9CGINw/PKxtKktlzTsaJviFrczVS9akkKxU/ilddB+DU5Pt4PflY+9h4bXq94qNVQQ0uGFsgoie9
+        RJN8ACpPiteWKKh6lqJwJkyiUkqmODJZLEb9yQ1dtEayVZ0zForN6JynZGxj+B/0VbNbsxUCY9GE
+        xjEzKK+QRaqKraRP4TV+AK/msfEq1EIIqTZSVbVGawBMXE0U71oGDk+KV0Z0OYNvmnw13UbVU7ZM
+        TTSpQChcko/5mG6kaDpu3CRmsNlLCxRzcg/Pq+BRw6vXKsU5klYAVXFbaeyRoH1M/RouFURteE89
+        cOfzyOqBMOGEnDIIayHnmmZCWxMUstx8E01JT4pXFKjGKau1WixYs+po9jkXrdSJvdooRggJfPWt
+        6bGkXKtoHcuZOFB5AF5/PRutqF9u951e+NBdy7u/AAAA//8DAPQqbs2NDQAA
     headers:
       cache-control:
       - no-cache, no-store
@@ -45,7 +45,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"61080dcb77c2106ffe8f5e8682ce3bab"
+      - W/"3dcb8ef5658eb2c5b7dd35c985583755"
       expires:
       - '0'
       pragma:
@@ -58,26 +58,27 @@ interactions:
       - chunked
       x-backend:
       - easypost
+      x-canary:
+      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - c758e50b6233b3b5ff0304a4002a68f0
+      - d574d6bf6234e01ae002b2a70020d199
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb7nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq 3e97db20d4
-      - intlb1wdc 3e97db20d4
-      - extlb1wdc 3e97db20d4
+      - intlb2nuq 3e97db20d4
+      - extlb2nuq 3e97db20d4
       x-runtime:
-      - '0.042917'
+      - '0.040021'
       x-version-label:
-      - easypost-202203171927-d8d87a16dd-master
+      - easypost-202203181824-5959608622-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_report_retrieve_tracker_report.yaml
+++ b/tests/cassettes/test_report_retrieve_tracker_report.yaml
@@ -23,15 +23,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RS227UMBD9l0jwRDbOOHYuUoSiAtoKEJesVLYvkeOZdEOzSbC9tCzi33G62woh
-        eLHG55yZMzP2z6DHoAicuTU0NwqFlAoARa6TlCiXQHmiu1yDxBzb4EUwtV9JO5+yMUrfkvlM82Sc
-        J7Qh5QgbtZDAAELGwxg2wIoYCoBrrznM+A9NugEo4qyAdNFYp4xrFt0fGhZ7hkb8G48XfD/hgjmy
-        7pTvDtbf1XfVD6odaDE2g0d2zs22iCJS9sc8WRd2/UB2ZfnqYMM7nx7CSu3VcRrVnV3paR89CCJ3
-        GrUxD7NGiznjcRoJmfOOOsa6TCZ5rBUyRN21PMME8zxbHfv55Zew2h/DariZTO92+7K6qpNw/b66
-        COt1BUI+PwkuDCGNrldDWb29rLaQvvsgt59qUX/cbq4un8GbR1sfPrXrY8v94ftNfHvfDh49F3zl
-        N1U+5vgNxxnk12fu9f3cG7IlZ2eg7m9GwjUpJGPL3fRUZSH8Pg2VLBYatZAxkxpbmQnNmVJtCsQg
-        yTrWUsJbxiUnoRJoWYZdGiviQqQZ8ladXqGhk/V/voDIly/Qj3o4IDV61w9oaAyKTg2Wfv0GAAD/
-        /wMAaEfgGa0CAAA=
+        H4sIAAAAAAAAA4SOyw4CIQxF/4W1JjAPFD7DuHJDEEocRWZSOtHE+O/CzMa4cdeee27aFxs804zw
+        hjCZvve2gyCCOsuul1ypHQgb9rzlspFBsg0bz1dwVCpHtO4GeIBpRCqBQ7AE3tgaNrxptrzdiv1R
+        KN0qzbtTcebJ/3UyWSRTvS+Hi5JA8r9cVH4ffWUEmdY+zbnsCR71JEam0xzjMhp4TgNCXj5Y6ZBc
+        nD0YdxmiR0hMBxszvD8AAAD//wMAAj1RfRoBAAA=
     headers:
       cache-control:
       - no-cache, no-store
@@ -40,7 +35,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"e18f8a5f80dd7db21c71b219cc23ae93"
+      - W/"424865d42017ee9424a677c5e7140832"
       expires:
       - '0'
       pragma:
@@ -53,28 +48,25 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - c758e5076233b3b5ff0304a3002a68d3
+      - d574d6c06234dfd8e019445e0020b904
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7nuq
+      - bigweb9nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq 3e97db20d4
-      - intlb1wdc 3e97db20d4
-      - extlb1wdc 3e97db20d4
+      - extlb2nuq 3e97db20d4
       x-runtime:
-      - '0.045677'
+      - '0.053016'
       x-version-label:
-      - easypost-202203171927-d8d87a16dd-master
+      - easypost-202203181824-5959608622-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -98,19 +90,14 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: GET
-    uri: https://api.easypost.com/v2/reports/trkrep_ad566a22d59c47ee962e94cf9c26d9db
+    uri: https://api.easypost.com/v2/reports/trkrep_55da4ef1f9b64560997e1af8030626f6
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RS227UMBD9l0jwRDbOOHYuUoSiAtoKEJesVLYvkeOZdEOzSbC9tCzi33G62woh
-        eLHG55yZMzP2z6DHoAicuTU0NwqFlAoARa6TlCiXQHmiu1yDxBzb4EUwtV9JO5+yMUrfkvlM82Sc
-        J7Qh5QgbtZDAAELGwxg2wIoYCoBrrznM+A9NugEo4qyAdNFYp4xrFt0fGhZ7hkb8G48XfD/hgjmy
-        7pTvDtbf1XfVD6odaDE2g0d2zs22iCJS9sc8WRd2/UB2ZfnqYMM7nx7CSu3VcRrVnV3paR89CCJ3
-        GrUxD7NGiznjcRoJmfOOOsa6TCZ5rBUyRN21PMME8zxbHfv55Zew2h/DariZTO92+7K6qpNw/b66
-        COt1BUI+PwkuDCGNrldDWb29rLaQvvsgt59qUX/cbq4un8GbR1sfPrXrY8v94ftNfHvfDh49F3zl
-        N1U+5vgNxxnk12fu9f3cG7IlZ2eg7m9GwjUpJGPL3fRUZSH8Pg2VLBYatZAxkxpbmQnNmVJtCsQg
-        yTrWUsJbxiUnoRJoWYZdGiviQqQZ8ladXqGhk/V/voDIly/Qj3o4IDV61w9oaAyKTg2Wfv0GAAD/
-        /wMAaEfgGa0CAAA=
+        H4sIAAAAAAAAA4SOyw4CIQxF/4W1JjAPFD7DuHJDEEocRWZSOtHE+O/CzMa4cdeee27aFxs804zw
+        hjCZvve2gyCCOsuul1ypHQgb9rzlspFBsg0bz1dwVCpHtO4GeIBpRCqBQ7AE3tgaNrxptrzdiv1R
+        KN0qzbtTcebJ/3UyWSRTvS+Hi5JA8r9cVH4ffWUEmdY+zbnsCR71JEam0xzjMhp4TgNCXj5Y6ZBc
+        nD0YdxmiR0hMBxszvD8AAAD//wMAAj1RfRoBAAA=
     headers:
       cache-control:
       - no-cache, no-store
@@ -119,7 +106,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"e18f8a5f80dd7db21c71b219cc23ae93"
+      - W/"424865d42017ee9424a677c5e7140832"
       expires:
       - '0'
       pragma:
@@ -137,21 +124,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - c758e5076233b3b5ff0304a3002a68e7
+      - d574d6c06234dfd8e019445e0020b90a
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb4nuq
+      - bigweb8nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq 3e97db20d4
-      - intlb2wdc 3e97db20d4
-      - extlb1wdc 3e97db20d4
+      - intlb1nuq 3e97db20d4
+      - extlb2nuq 3e97db20d4
       x-runtime:
-      - '0.030468'
+      - '0.029672'
       x-version-label:
-      - easypost-202203171927-d8d87a16dd-master
+      - easypost-202203181824-5959608622-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,11 +13,11 @@ def pytest_sessionstart(session):
     # this is for local unit testing with google appengine, otherwise you get a
     # 'No api proxy found for service "urlfetch"' response
     try:
-        from google.appengine.ext import testbed
+        from google.appengine.ext import testbed  # type: ignore
 
-        session.appengine_testbed = testbed.Testbed()
-        session.appengine_testbed.activate()
-        session.appengine_testbed.init_urlfetch_stub()
+        session.appengine_testbed = testbed.Testbed()  # type: ignore
+        session.appengine_testbed.activate()  # type: ignore
+        session.appengine_testbed.init_urlfetch_stub()  # type: ignore
     except ImportError:
         # if the import fails then we're not using the appengine sdk, so just
         # keep going without initializing the testbed stub
@@ -26,7 +26,7 @@ def pytest_sessionstart(session):
 
 def pytest_sessionfinish(session, exitstatus):
     if hasattr(session, "appengine_testbed"):
-        session.appengine_testbed.deactivate()
+        session.appengine_testbed.deactivate()  # type: ignore
 
 
 # this fixture is auto-loaded by all tests; it sets up the api key

--- a/tests/test_refund.py
+++ b/tests/test_refund.py
@@ -8,7 +8,7 @@ def test_refund_create(one_call_buy_shipment, usps):
     shipment = easypost.Shipment.create(**one_call_buy_shipment)
 
     # We need to retrieve the shipment so that the tracking_code has time to populate
-    retrieved_shipment = easypost.Shipment.retrieve(shipment)
+    retrieved_shipment = easypost.Shipment.retrieve(shipment["id"])
 
     refund = easypost.Refund.create(
         carrier=usps,
@@ -34,7 +34,7 @@ def test_refund_all(page_size):
 def test_refund_retrieve(page_size):
     refunds = easypost.Refund.all(page_size=page_size)
 
-    retrieved_refund = easypost.Refund.retrieve(refunds["refunds"][0])
+    retrieved_refund = easypost.Refund.retrieve(refunds["refunds"][0]["id"])
 
     assert isinstance(retrieved_refund, easypost.Refund)
     assert retrieved_refund.id == refunds["refunds"][0].id


### PR DESCRIPTION
By providing type hints, we can make it our code semi-self-documenting, and a lot friendlier to those using IDEs (or really anyone). Users will now know what type each parameter of a function is supposed to be, as well as the final type that the function will return.

This PR includes:
- Parameter and return type hints for all functions (passed `MyPy` analysis)
- Explicit parameter assignment (i.e. `my_function(parameter=this, number=that)`). This makes it clear what parameter each  value is being mapped to when a function is called, and greatly improves the readability of our code base.
- A few minor tweaks to functions to improve bad logic, make naming/structure consistent, and fix loosely-typed functions