### PR TITLE
fix: import util.convert_to_easypost_object directly

### DIFF
--- a/easypost/address.py
+++ b/easypost/address.py
@@ -1,4 +1,4 @@
-import easypost.easypost_object as util
+from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource
 
@@ -18,7 +18,7 @@ class Address(AllResource, CreateResource):
             wrapped_params[key] = value
 
         response, api_key = requestor.request("post", url, wrapped_params)
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)
 
     @classmethod
     def create_and_verify(cls, api_key=None, carrier=None, **params):
@@ -32,13 +32,13 @@ class Address(AllResource, CreateResource):
         response_message = response.get("message", None)
 
         if response_address is not None:
-            verified_address = util.convert_to_easypost_object(response_address, api_key)
+            verified_address = convert_to_easypost_object(response_address, api_key)
             if response_message is not None:
                 verified_address.message = response_message
                 verified_address._immutable_values.update("message")
             return verified_address
         else:
-            return util.convert_to_easypost_object(response, api_key)
+            return convert_to_easypost_object(response, api_key)
 
     def verify(self, carrier=None):
         requestor = Requestor(self._api_key)
@@ -50,10 +50,10 @@ class Address(AllResource, CreateResource):
         response_message = response.get("message", None)
 
         if response_address is not None:
-            verified_address = util.convert_to_easypost_object(response_address, api_key)
+            verified_address = convert_to_easypost_object(response_address, api_key)
             if response_message is not None:
                 verified_address.message = response_message
                 verified_address._immutable_values.update("message")
             return verified_address
         else:
-            return util.convert_to_easypost_object(response, api_key)
+            return convert_to_easypost_object(response, api_key)

--- a/easypost/batch.py
+++ b/easypost/batch.py
@@ -1,4 +1,4 @@
-import easypost.easypost_object as util
+from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource
 
@@ -10,7 +10,7 @@ class Batch(AllResource, CreateResource):
         url = "%s/%s" % (cls.class_url(), "create_and_buy")
         wrapped_params = {cls.snakecase_name(): params}
         response, api_key = requestor.request("post", url, wrapped_params)
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)
 
     def buy(self, **params):
         requestor = Requestor(self._api_key)

--- a/easypost/carrier_account.py
+++ b/easypost/carrier_account.py
@@ -1,4 +1,4 @@
-import easypost.easypost_object as util
+from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import (
     AllResource,
@@ -13,4 +13,4 @@ class CarrierAccount(AllResource, CreateResource, UpdateResource, DeleteResource
     def types(cls, api_key=None):
         requestor = Requestor(api_key)
         response, api_key = requestor.request("get", "/carrier_types")
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)

--- a/easypost/event.py
+++ b/easypost/event.py
@@ -1,11 +1,11 @@
 import json
 
 import easypost
-import easypost.easypost_object as util
+from easypost.easypost_object import convert_to_easypost_object
 from easypost.resource import AllResource, Resource
 
 
 class Event(AllResource, Resource):
     @classmethod
     def receive(cls, values):
-        return util.convert_to_easypost_object(json.loads(values), easypost.api_key)
+        return convert_to_easypost_object(json.loads(values), easypost.api_key)

--- a/easypost/report.py
+++ b/easypost/report.py
@@ -1,4 +1,4 @@
-import easypost.easypost_object as util
+from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource
 
@@ -9,11 +9,11 @@ class Report(AllResource, CreateResource):
         requestor = Requestor(api_key)
         url = "%s/%s" % (cls.class_url(), params["type"])
         response, api_key = requestor.request("post", url, params, False)
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)
 
     @classmethod
     def all(cls, api_key=None, **params):
         requestor = Requestor(api_key)
         url = "%s/%s" % (cls.class_url(), params["type"])
         response, api_key = requestor.request("get", url, params)
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)

--- a/easypost/resource.py
+++ b/easypost/resource.py
@@ -1,7 +1,6 @@
 import re
 
-import easypost.easypost_object as util
-from easypost.easypost_object import EasyPostObject
+from easypost.easypost_object import EasyPostObject, convert_to_easypost_object
 from easypost.error import Error
 from easypost.requestor import Requestor
 
@@ -55,7 +54,7 @@ class AllResource(Resource):
         requestor = Requestor(api_key)
         url = cls.class_url()
         response, api_key = requestor.request("get", url, params)
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)
 
 
 class CreateResource(Resource):
@@ -65,7 +64,7 @@ class CreateResource(Resource):
         url = cls.class_url()
         wrapped_params = {cls.snakecase_name(): params}
         response, api_key = requestor.request("post", url, wrapped_params)
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)
 
 
 class UpdateResource(Resource):

--- a/easypost/scanform.py
+++ b/easypost/scanform.py
@@ -1,4 +1,4 @@
-import easypost.easypost_object as util
+from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import AllResource, CreateResource
 
@@ -9,4 +9,4 @@ class ScanForm(AllResource, CreateResource):
         requestor = Requestor(api_key)
         url = cls.class_url()
         response, api_key = requestor.request("post", url, params)
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)

--- a/easypost/user.py
+++ b/easypost/user.py
@@ -1,4 +1,4 @@
-import easypost.easypost_object as util
+from easypost.easypost_object import convert_to_easypost_object
 from easypost.requestor import Requestor
 from easypost.resource import CreateResource, DeleteResource, UpdateResource
 
@@ -10,7 +10,7 @@ class User(CreateResource, UpdateResource, DeleteResource):
         url = cls.class_url()
         wrapped_params = {cls.snakecase_name(): params}
         response, api_key = requestor.request("post", url, wrapped_params, False)
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)
 
     @classmethod
     def retrieve(cls, easypost_id="", api_key=None, **params):
@@ -22,7 +22,7 @@ class User(CreateResource, UpdateResource, DeleteResource):
         if easypost_id == "":
             requestor = Requestor(api_key)
             response, api_key = requestor.request("get", cls.class_url())
-            return util.convert_to_easypost_object(response, api_key)
+            return convert_to_easypost_object(response, api_key)
         else:
             instance = cls(easypost_id, api_key, **params)
             instance.refresh()
@@ -32,14 +32,14 @@ class User(CreateResource, UpdateResource, DeleteResource):
     def retrieve_me(cls, api_key=None, **params):
         requestor = Requestor(api_key)
         response, api_key = requestor.request("get", cls.class_url())
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)
 
     @classmethod
     def all_api_keys(cls, api_key=None):
         requestor = Requestor(api_key)
         url = "/api_keys"
         response, api_key = requestor.request("get", url)
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)
 
     def api_keys(self):
         api_keys = self.all_api_keys()
@@ -57,4 +57,4 @@ class User(CreateResource, UpdateResource, DeleteResource):
     def update_brand(self, api_key=None, **params):
         requestor = Requestor(api_key)
         response, api_key = requestor.request("put", self.instance_url() + "/brand", params)
-        return util.convert_to_easypost_object(response, api_key)
+        return convert_to_easypost_object(response, api_key)


### PR DESCRIPTION
There is no need to wrap `convert_to_easypost_object` in `util` as it provides no value and is confusing; instead, we should just import the function directly.