### PR TITLE
collect python_implementation in easypost-python user-agent

### DIFF
--- a/easypost/requestor.py
+++ b/easypost/requestor.py
@@ -60,6 +60,7 @@ class Requestor:
             ("lang_version", platform.python_version),
             ("platform", platform.platform),
             ("uname", lambda: " ".join(platform.uname())),
+            ("implementation", platform.python_implementation),
         ):
             try:
                 val = func()


### PR DESCRIPTION
This should be backported to all previous series (3.x, 4.x, 5.x, etc).