### PR TITLE
add github pull request template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# Pull Request Type
+
+Please select the option(s) that are relevant to this PR.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
+
+# Description
+
+<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->
+
+# Testing
+
+<!-- 
+Please provide details on how you tested this code. See below.
+
+- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
+- New features must get a new unit test
+- Bug fixes/refactors must re-record existing cassettes 
+-->


### PR DESCRIPTION
This PR adds a template for future pull requests.

Link to the PR template view:https://github.com/EasyPost/easypost-python/blob/pr_template/.github/PULL_REQUEST_TEMPLATE.md