### PR TITLE
Block query parameters in non-GET/DELETE requests

### DIFF
--- a/easypost/address.py
+++ b/easypost/address.py
@@ -5,7 +5,10 @@ from typing import (
 )
 
 from easypost.easypost_object import convert_to_easypost_object
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import (
     AllResource,
     CreateResource,
@@ -33,7 +36,7 @@ class Address(AllResource, CreateResource):
                 value = [value]
             wrapped_params[key] = value
 
-        response, api_key = requestor.request(method="post", url=url, params=wrapped_params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=wrapped_params)
         return convert_to_easypost_object(response=response, api_key=api_key)
 
     @classmethod
@@ -43,7 +46,7 @@ class Address(AllResource, CreateResource):
         url = "%s/%s" % (cls.class_url(), "create_and_verify")
 
         wrapped_params = {cls.snakecase_name(): params}
-        response, api_key = requestor.request(method="post", url=url, params=wrapped_params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=wrapped_params)
 
         response_address = response.get("address", None)
 
@@ -58,7 +61,7 @@ class Address(AllResource, CreateResource):
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "verify")
         params = {"carrier": carrier}
-        response, api_key = requestor.request(method="get", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.GET, url=url, params=params)
 
         response_address = response.get("address", None)
         response_message = response.get("message", None)

--- a/easypost/batch.py
+++ b/easypost/batch.py
@@ -1,7 +1,10 @@
 from typing import Optional
 
 from easypost.easypost_object import convert_to_easypost_object
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import (
     AllResource,
     CreateResource,
@@ -15,14 +18,14 @@ class Batch(AllResource, CreateResource):
         requestor = Requestor(local_api_key=api_key)
         url = "%s/%s" % (cls.class_url(), "create_and_buy")
         wrapped_params = {cls.snakecase_name(): params}
-        response, api_key = requestor.request(method="post", url=url, params=wrapped_params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=wrapped_params)
         return convert_to_easypost_object(response=response, api_key=api_key)
 
     def buy(self, **params) -> "Batch":
         """Buy a batch."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -30,7 +33,7 @@ class Batch(AllResource, CreateResource):
         """Create a batch label."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "label")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -38,7 +41,7 @@ class Batch(AllResource, CreateResource):
         """Remove shipments from a batch."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "remove_shipments")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -46,7 +49,7 @@ class Batch(AllResource, CreateResource):
         """Add shipments from a batch."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "add_shipments")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -54,6 +57,6 @@ class Batch(AllResource, CreateResource):
         """Create a scanform for a batch."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "scan_form")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self

--- a/easypost/carrier_account.py
+++ b/easypost/carrier_account.py
@@ -4,7 +4,10 @@ from typing import (
 )
 
 from easypost.easypost_object import convert_to_easypost_object
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import (
     AllResource,
     CreateResource,
@@ -18,5 +21,5 @@ class CarrierAccount(AllResource, CreateResource, UpdateResource, DeleteResource
     def types(cls, api_key: Optional[str] = None) -> List[str]:
         """Get the types of carrier accounts available to the user."""
         requestor = Requestor(local_api_key=api_key)
-        response, api_key = requestor.request(method="get", url="/carrier_types")
+        response, api_key = requestor.request(method=RequestMethod.GET, url="/carrier_types")
         return convert_to_easypost_object(response=response, api_key=api_key)

--- a/easypost/order.py
+++ b/easypost/order.py
@@ -1,4 +1,7 @@
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import CreateResource
 
 
@@ -7,7 +10,7 @@ class Order(CreateResource):
         """Get rates for an order."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "rates")
-        response, api_key = requestor.request(method="get", url=url)
+        response, api_key = requestor.request(method=RequestMethod.GET, url=url)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -15,6 +18,6 @@ class Order(CreateResource):
         """Buy an order."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self

--- a/easypost/pickup.py
+++ b/easypost/pickup.py
@@ -1,4 +1,7 @@
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import CreateResource
 
 
@@ -7,7 +10,7 @@ class Pickup(CreateResource):
         """Buy a pickup."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -15,6 +18,6 @@ class Pickup(CreateResource):
         """Cancel a pickup."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "cancel")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self

--- a/easypost/report.py
+++ b/easypost/report.py
@@ -1,7 +1,10 @@
 from typing import Optional
 
 from easypost.easypost_object import convert_to_easypost_object
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import (
     AllResource,
     CreateResource,
@@ -14,7 +17,7 @@ class Report(AllResource, CreateResource):
         """Create a report."""
         requestor = Requestor(local_api_key=api_key)
         url = f"{cls.class_url()}/{params.get('type')}"
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         return convert_to_easypost_object(response=response, api_key=api_key)
 
     @classmethod
@@ -22,5 +25,5 @@ class Report(AllResource, CreateResource):
         """Retrieve all reports."""
         requestor = Requestor(local_api_key=api_key)
         url = f"{cls.class_url()}/{params.get('type')}"
-        response, api_key = requestor.request(method="get", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.GET, url=url, params=params)
         return convert_to_easypost_object(response=response, api_key=api_key)

--- a/easypost/resource.py
+++ b/easypost/resource.py
@@ -10,7 +10,10 @@ from easypost.easypost_object import (
     convert_to_easypost_object,
 )
 from easypost.error import Error
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 
 
 class Resource(EasyPostObject):
@@ -28,7 +31,7 @@ class Resource(EasyPostObject):
         """Refresh the local object from the API response."""
         requestor = Requestor(local_api_key=self._api_key)
         url = self.instance_url()
-        response, api_key = requestor.request(method="get", url=url, params=self._retrieve_params)
+        response, api_key = requestor.request(method=RequestMethod.GET, url=url, params=self._retrieve_params)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -61,7 +64,7 @@ class AllResource(Resource):
         """Retrieve a list of records from the API."""
         requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
-        response, api_key = requestor.request(method="get", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.GET, url=url, params=params)
         return convert_to_easypost_object(response=response, api_key=api_key)
 
 
@@ -72,7 +75,7 @@ class CreateResource(Resource):
         requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
         wrapped_params = {cls.snakecase_name(): params}
-        response, api_key = requestor.request(method="post", url=url, params=wrapped_params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=wrapped_params)
         return convert_to_easypost_object(response=response, api_key=api_key)
 
 
@@ -88,7 +91,7 @@ class UpdateResource(Resource):
                     params[k] = params[k].flatten_unsaved()
             params = {self.snakecase_name(): params}
             url = self.instance_url()
-            response, api_key = requestor.request(method="put", url=url, params=params)
+            response, api_key = requestor.request(method=RequestMethod.PUT, url=url, params=params)
             self.refresh_from(values=response, api_key=api_key)
 
         return self
@@ -99,6 +102,6 @@ class DeleteResource(Resource):
         """Delete an EasyPost object."""
         requestor = Requestor(local_api_key=self._api_key)
         url = self.instance_url()
-        response, api_key = requestor.request(method="delete", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.DELETE, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self

--- a/easypost/scanform.py
+++ b/easypost/scanform.py
@@ -1,7 +1,10 @@
 from typing import Optional
 
 from easypost.easypost_object import convert_to_easypost_object
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import (
     AllResource,
     CreateResource,
@@ -14,5 +17,5 @@ class ScanForm(AllResource, CreateResource):
         """Create a scanform."""
         requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         return convert_to_easypost_object(response=response, api_key=api_key)

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -2,7 +2,10 @@ from typing import List
 
 from easypost import Rate
 from easypost.error import Error
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import (
     AllResource,
     CreateResource,
@@ -14,7 +17,7 @@ class Shipment(AllResource, CreateResource):
         """Regenerate rates for a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "rerate")
-        response, api_key = requestor.request(method="post", url=url)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -22,14 +25,14 @@ class Shipment(AllResource, CreateResource):
         """Get smartrates for a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "smartrate")
-        response, api_key = requestor.request(method="get", url=url)
+        response, api_key = requestor.request(method=RequestMethod.GET, url=url)
         return response.get("result", [])
 
     def buy(self, **params) -> "Shipment":
         """Buy a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -37,7 +40,7 @@ class Shipment(AllResource, CreateResource):
         """Refund a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "refund")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -45,7 +48,7 @@ class Shipment(AllResource, CreateResource):
         """Insure a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "insure")
-        response, api_key = requestor.request(method="post", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
 
@@ -53,7 +56,7 @@ class Shipment(AllResource, CreateResource):
         """Convert the label format of a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "label")
-        response, api_key = requestor.request(method="get", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.GET, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
 

--- a/easypost/tracker.py
+++ b/easypost/tracker.py
@@ -5,7 +5,10 @@ from typing import (
     Optional,
 )
 
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import (
     AllResource,
     CreateResource,
@@ -19,5 +22,5 @@ class Tracker(AllResource, CreateResource):
         requestor = Requestor(local_api_key=api_key)
         url = "%s/%s" % (cls.class_url(), "create_list")
         new_params = {"trackers": trackers}
-        _, _ = requestor.request(method="post", url=url, params=new_params)
+        _, _ = requestor.request(method=RequestMethod.POST, url=url, params=new_params)
         return True

--- a/easypost/user.py
+++ b/easypost/user.py
@@ -4,7 +4,10 @@ from typing import (
 )
 
 from easypost.easypost_object import convert_to_easypost_object
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import (
     CreateResource,
     DeleteResource,
@@ -19,7 +22,9 @@ class User(CreateResource, UpdateResource, DeleteResource):
         requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
         wrapped_params = {cls.snakecase_name(): params}
-        response, api_key = requestor.request(method="post", url=url, params=wrapped_params, api_key_required=False)
+        response, api_key = requestor.request(
+            method=RequestMethod.POST, url=url, params=wrapped_params, api_key_required=False
+        )
         return convert_to_easypost_object(response=response, api_key=api_key)
 
     @classmethod
@@ -27,7 +32,7 @@ class User(CreateResource, UpdateResource, DeleteResource):
         """Retrieve a user."""
         if not easypost_id:
             requestor = Requestor(local_api_key=api_key)
-            response, api_key = requestor.request(method="get", url=cls.class_url())
+            response, api_key = requestor.request(method=RequestMethod.GET, url=cls.class_url())
             return convert_to_easypost_object(response=response, api_key=api_key)
         else:
             instance = cls(easypost_id=easypost_id, api_key=api_key, **params)
@@ -38,7 +43,7 @@ class User(CreateResource, UpdateResource, DeleteResource):
     def retrieve_me(cls, api_key: Optional[str] = None, **params) -> "User":
         """Retrieve the authenticated user."""
         requestor = Requestor(local_api_key=api_key)
-        response, api_key = requestor.request(method="get", url=cls.class_url())
+        response, api_key = requestor.request(method=RequestMethod.GET, url=cls.class_url())
         return convert_to_easypost_object(response=response, api_key=api_key)
 
     @classmethod
@@ -46,7 +51,7 @@ class User(CreateResource, UpdateResource, DeleteResource):
         """Get all API keys including child user keys."""
         requestor = Requestor(local_api_key=api_key)
         url = "/api_keys"
-        response, api_key = requestor.request(method="get", url=url)
+        response, api_key = requestor.request(method=RequestMethod.GET, url=url)
         return convert_to_easypost_object(response=response, api_key=api_key)
 
     def api_keys(self) -> List[str]:
@@ -65,5 +70,7 @@ class User(CreateResource, UpdateResource, DeleteResource):
     def update_brand(self, api_key: Optional[str] = None, **params) -> "User":
         """Update the User's Brand."""
         requestor = Requestor(local_api_key=api_key)
-        response, api_key = requestor.request(method="put", url=self.instance_url() + "/brand", params=params)
+        response, api_key = requestor.request(
+            method=RequestMethod.PUT, url=self.instance_url() + "/brand", params=params
+        )
         return convert_to_easypost_object(response=response, api_key=api_key)

--- a/easypost/webhook.py
+++ b/easypost/webhook.py
@@ -1,4 +1,7 @@
-from easypost.requestor import Requestor
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
 from easypost.resource import (
     AllResource,
     CreateResource,
@@ -11,6 +14,6 @@ class Webhook(AllResource, CreateResource, DeleteResource):
         """Update a webhook."""
         requestor = Requestor(local_api_key=self._api_key)
         url = self.instance_url()
-        response, api_key = requestor.request(method="put", url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.PUT, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self


### PR DESCRIPTION
# Description

We should not be sending query parameters in POST or PUT requests.

This PR:
- Adds safeguards against sending query parameters in POST or PUT requests
- Replaces method strings with RequestMethod enum to lock down request types

# Testing

Re-ran all cassettes, all passed.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
