### PR TITLE
feat: adds lowest_rate to more objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## NEXT RELEASE
 
-- Adds `lowest_rate` functions to Orders and Pickups
-- Adds a `get_lowest_smartrate` function
+- Adds a `lowest_rate` function to Orders and Pickups
+- Adds a `Shipment.get_lowest_smartrate` function and a `shipment.lowest_smartrate()` function
 
 ## v7.0.0 (2022-04-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+- Adds `lowest_rate` functions to Orders and Pickups
+- Adds a `get_lowest_smartrate` function
+
 ## v7.0.0 (2022-04-14)
 
 Upgrading major versions of this project? Refer to the [Upgrade Guide](UPGRADE_GUIDE.md).

--- a/easypost/order.py
+++ b/easypost/order.py
@@ -26,7 +26,7 @@ class Order(CreateResource):
         return self
 
     def lowest_rate(self, carriers: List[str] = None, services: List[str] = None):
-        """Get the lowest rate of a order."""
-        lowest_rate = Util.get_lowest_object_rate(self, carriers, services)
+        """Get the lowest rate of an order."""
+        lowest_rate = Util._get_lowest_object_rate(self, carriers, services)
 
         return lowest_rate

--- a/easypost/order.py
+++ b/easypost/order.py
@@ -5,7 +5,7 @@ from easypost.requestor import (
     Requestor,
 )
 from easypost.resource import CreateResource
-from easypost.util import Util
+from easypost.util import get_lowest_object_rate
 
 
 class Order(CreateResource):
@@ -27,6 +27,6 @@ class Order(CreateResource):
 
     def lowest_rate(self, carriers: List[str] = None, services: List[str] = None):
         """Get the lowest rate of an order."""
-        lowest_rate = Util._get_lowest_object_rate(self, carriers, services)
+        lowest_rate = get_lowest_object_rate(self, carriers, services)
 
         return lowest_rate

--- a/easypost/order.py
+++ b/easypost/order.py
@@ -26,7 +26,7 @@ class Order(CreateResource):
         return self
 
     def lowest_rate(self, carriers: List[str] = None, services: List[str] = None):
-        """Get the lowest rate of an order."""
+        """Get the lowest rate of this order."""
         lowest_rate = get_lowest_object_rate(self, carriers, services)
 
         return lowest_rate

--- a/easypost/order.py
+++ b/easypost/order.py
@@ -1,8 +1,11 @@
+from typing import List
+
 from easypost.requestor import (
     RequestMethod,
     Requestor,
 )
 from easypost.resource import CreateResource
+from easypost.util import Util
 
 
 class Order(CreateResource):
@@ -21,3 +24,9 @@ class Order(CreateResource):
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
+
+    def lowest_rate(self, carriers: List[str] = None, services: List[str] = None):
+        """Get the lowest rate of a order."""
+        lowest_rate = Util.get_lowest_object_rate(self, carriers, services)
+
+        return lowest_rate

--- a/easypost/pickup.py
+++ b/easypost/pickup.py
@@ -26,7 +26,7 @@ class Pickup(CreateResource):
         return self
 
     def lowest_rate(self, carriers: List[str] = None, services: List[str] = None):
-        """Get the lowest rate of a pickup."""
+        """Get the lowest rate of this pickup."""
         lowest_rate = get_lowest_object_rate(self, carriers, services, "pickup_rates")
 
         return lowest_rate

--- a/easypost/pickup.py
+++ b/easypost/pickup.py
@@ -27,6 +27,6 @@ class Pickup(CreateResource):
 
     def lowest_rate(self, carriers: List[str] = None, services: List[str] = None):
         """Get the lowest rate of a pickup."""
-        lowest_rate = Util.get_lowest_object_rate(self, carriers, services, "pickup_rates")
+        lowest_rate = Util._get_lowest_object_rate(self, carriers, services, "pickup_rates")
 
         return lowest_rate

--- a/easypost/pickup.py
+++ b/easypost/pickup.py
@@ -5,7 +5,7 @@ from easypost.requestor import (
     Requestor,
 )
 from easypost.resource import CreateResource
-from easypost.util import Util
+from easypost.util import get_lowest_object_rate
 
 
 class Pickup(CreateResource):
@@ -27,6 +27,6 @@ class Pickup(CreateResource):
 
     def lowest_rate(self, carriers: List[str] = None, services: List[str] = None):
         """Get the lowest rate of a pickup."""
-        lowest_rate = Util._get_lowest_object_rate(self, carriers, services, "pickup_rates")
+        lowest_rate = get_lowest_object_rate(self, carriers, services, "pickup_rates")
 
         return lowest_rate

--- a/easypost/pickup.py
+++ b/easypost/pickup.py
@@ -1,8 +1,11 @@
+from typing import List
+
 from easypost.requestor import (
     RequestMethod,
     Requestor,
 )
 from easypost.resource import CreateResource
+from easypost.util import Util
 
 
 class Pickup(CreateResource):
@@ -21,3 +24,9 @@ class Pickup(CreateResource):
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
+
+    def lowest_rate(self, carriers: List[str] = None, services: List[str] = None):
+        """Get the lowest rate of a pickup."""
+        lowest_rate = Util.get_lowest_object_rate(self, carriers, services, "pickup_rates")
+
+        return lowest_rate

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -13,7 +13,7 @@ from easypost.resource import (
     AllResource,
     CreateResource,
 )
-from easypost.util import Util
+from easypost.util import get_lowest_object_rate
 
 
 class Shipment(AllResource, CreateResource):
@@ -66,7 +66,7 @@ class Shipment(AllResource, CreateResource):
 
     def lowest_rate(self, carriers: List[str] = None, services: List[str] = None) -> Rate:
         """Get the lowest rate of a shipment."""
-        lowest_rate = Util._get_lowest_object_rate(self, carriers, services)
+        lowest_rate = get_lowest_object_rate(self, carriers, services)
 
         return lowest_rate
 

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -1,7 +1,4 @@
-from typing import (
-    List,
-    Optional,
-)
+from typing import List
 
 from easypost import Rate
 from easypost.error import Error
@@ -70,7 +67,7 @@ class Shipment(AllResource, CreateResource):
 
         return lowest_rate
 
-    def lowest_smartrate(self, delivery_days: Optional[int] = None, delivery_accuracy: Optional[str] = None) -> Rate:
+    def lowest_smartrate(self, delivery_days: int, delivery_accuracy: str) -> Rate:
         """Get the lowest smartrate of this shipment."""
         smartrates = self.get_smartrates()
         lowest_smartrate = self.get_lowest_smartrate(smartrates, delivery_days, delivery_accuracy)
@@ -78,9 +75,7 @@ class Shipment(AllResource, CreateResource):
         return lowest_smartrate
 
     @staticmethod
-    def get_lowest_smartrate(
-        smartrates, delivery_days: Optional[int] = None, delivery_accuracy: Optional[str] = None
-    ) -> Rate:
+    def get_lowest_smartrate(smartrates, delivery_days: int, delivery_accuracy: str) -> Rate:
         """Get the lowest smartrate from a list of smartrates."""
         valid_delivery_accuracy_values = {
             "percentile_50",
@@ -93,15 +88,13 @@ class Shipment(AllResource, CreateResource):
         }
         lowest_smartrate = None
 
-        if delivery_accuracy and delivery_accuracy not in valid_delivery_accuracy_values:
+        if delivery_accuracy.lower() not in valid_delivery_accuracy_values:
             raise Error(message=f"Invalid delivery_accuracy value, must be one of: {valid_delivery_accuracy_values}")
 
         for rate in smartrates:
-            if delivery_days and delivery_accuracy:
-                if rate["time_in_transit"][delivery_accuracy] > delivery_days:
-                    continue
-
-            if lowest_smartrate is None or float(rate["rate"]) < float(lowest_smartrate["rate"]):
+            if rate["time_in_transit"][delivery_accuracy] > delivery_days:
+                continue
+            elif lowest_smartrate is None or float(rate["rate"]) < float(lowest_smartrate["rate"]):
                 lowest_smartrate = rate
 
         if lowest_smartrate is None:

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -65,13 +65,13 @@ class Shipment(AllResource, CreateResource):
         return self
 
     def lowest_rate(self, carriers: List[str] = None, services: List[str] = None) -> Rate:
-        """Get the lowest rate of a shipment."""
+        """Get the lowest rate of this shipment."""
         lowest_rate = get_lowest_object_rate(self, carriers, services)
 
         return lowest_rate
 
     def lowest_smartrate(self, delivery_days: Optional[int] = None, delivery_accuracy: Optional[str] = None) -> Rate:
-        """Get the lowest smartrate of a shipment."""
+        """Get the lowest smartrate of this shipment."""
         smartrates = self.get_smartrates()
         lowest_smartrate = self.get_lowest_smartrate(smartrates, delivery_days, delivery_accuracy)
 
@@ -93,13 +93,12 @@ class Shipment(AllResource, CreateResource):
         }
         lowest_smartrate = None
 
+        if delivery_accuracy and delivery_accuracy not in valid_delivery_accuracy_values:
+            raise Error(message=f"Invalid delivery_accuracy value, must be one of: {valid_delivery_accuracy_values}")
+
         for rate in smartrates:
             if delivery_days and delivery_accuracy:
-                if delivery_accuracy not in valid_delivery_accuracy_values:
-                    raise Error(
-                        message=f"Invalid delivery_accuracy value, must be one of: {valid_delivery_accuracy_values}"
-                    )
-                elif rate["time_in_transit"][delivery_accuracy] > delivery_days:
+                if rate["time_in_transit"][delivery_accuracy] > delivery_days:
                     continue
 
             if lowest_smartrate is None or float(rate["rate"]) < float(lowest_smartrate["rate"]):

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -29,7 +29,7 @@ class Shipment(AllResource, CreateResource):
         """Get smartrates for a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "smartrate")
-        response, api_key = requestor.request(method=RequestMethod.GET, url=url)
+        response, _ = requestor.request(method=RequestMethod.GET, url=url)
         return response.get("result", [])
 
     def buy(self, **params) -> "Shipment":
@@ -66,15 +66,22 @@ class Shipment(AllResource, CreateResource):
 
     def lowest_rate(self, carriers: List[str] = None, services: List[str] = None) -> Rate:
         """Get the lowest rate of a shipment."""
-        lowest_rate = Util.get_lowest_object_rate(self, carriers, services)
+        lowest_rate = Util._get_lowest_object_rate(self, carriers, services)
 
         return lowest_rate
+
+    def lowest_smartrate(self, delivery_days: Optional[int] = None, delivery_accuracy: Optional[str] = None) -> Rate:
+        """Get the lowest smartrate of a shipment."""
+        smartrates = self.get_smartrates()
+        lowest_smartrate = self.get_lowest_smartrate(smartrates, delivery_days, delivery_accuracy)
+
+        return lowest_smartrate
 
     @staticmethod
     def get_lowest_smartrate(
         smartrates, delivery_days: Optional[int] = None, delivery_accuracy: Optional[str] = None
     ) -> Rate:
-        """Get the lowest smartrate."""
+        """Get the lowest smartrate from a list of smartrates."""
         valid_delivery_accuracy_values = {
             "percentile_50",
             "percentile_75",

--- a/easypost/util.py
+++ b/easypost/util.py
@@ -4,33 +4,31 @@ from easypost.easypost_object import EasyPostObject
 from easypost.error import Error
 
 
-class Util:
-    @staticmethod
-    def _get_lowest_object_rate(
-        easypost_object: EasyPostObject,
-        carriers: List[str] = None,
-        services: List[str] = None,
-        rates_key: str = "rates",
-    ):
-        """Gets the lowest rate of an EasyPost object such as a Shipment, Order, or Pickup."""
-        carriers = carriers or []
-        services = services or []
-        lowest_rate = None
+def get_lowest_object_rate(
+    easypost_object: EasyPostObject,
+    carriers: List[str] = None,
+    services: List[str] = None,
+    rates_key: str = "rates",
+):
+    """Gets the lowest rate of an EasyPost object such as a Shipment, Order, or Pickup."""
+    carriers = carriers or []
+    services = services or []
+    lowest_rate = None
 
-        carriers = [carrier.lower() for carrier in carriers]
-        services = [service.lower() for service in services]
+    carriers = [carrier.lower() for carrier in carriers]
+    services = [service.lower() for service in services]
 
-        for rate in easypost_object[rates_key]:
-            if len(carriers) > 0 and rate.carrier.lower() not in carriers:
-                continue
+    for rate in easypost_object[rates_key]:
+        if len(carriers) > 0 and rate.carrier.lower() not in carriers:
+            continue
 
-            if len(services) > 0 and rate.service.lower() not in services:
-                continue
+        if len(services) > 0 and rate.service.lower() not in services:
+            continue
 
-            if lowest_rate is None or float(rate.rate) < float(lowest_rate.rate):
-                lowest_rate = rate
+        if lowest_rate is None or float(rate.rate) < float(lowest_rate.rate):
+            lowest_rate = rate
 
-        if lowest_rate is None:
-            raise Error(message="No rates found.")
+    if lowest_rate is None:
+        raise Error(message="No rates found.")
 
-        return lowest_rate
+    return lowest_rate

--- a/easypost/util.py
+++ b/easypost/util.py
@@ -21,11 +21,9 @@ def get_lowest_object_rate(
     for rate in easypost_object.get(rates_key, []):
         if carriers and rate.carrier.lower() not in carriers:
             continue
-
-        if services and rate.service.lower() not in services:
+        elif services and rate.service.lower() not in services:
             continue
-
-        if lowest_rate is None or float(rate.rate) < float(lowest_rate.rate):
+        elif lowest_rate is None or float(rate.rate) < float(lowest_rate.rate):
             lowest_rate = rate
 
     if lowest_rate is None:

--- a/easypost/util.py
+++ b/easypost/util.py
@@ -18,11 +18,11 @@ def get_lowest_object_rate(
     carriers = [carrier.lower() for carrier in carriers]
     services = [service.lower() for service in services]
 
-    for rate in easypost_object[rates_key]:
-        if len(carriers) > 0 and rate.carrier.lower() not in carriers:
+    for rate in easypost_object.get(rates_key, []):
+        if carriers and rate.carrier.lower() not in carriers:
             continue
 
-        if len(services) > 0 and rate.service.lower() not in services:
+        if services and rate.service.lower() not in services:
             continue
 
         if lowest_rate is None or float(rate.rate) < float(lowest_rate.rate):

--- a/easypost/util.py
+++ b/easypost/util.py
@@ -19,11 +19,10 @@ def get_lowest_object_rate(
     services = [service.lower() for service in services]
 
     for rate in easypost_object.get(rates_key, []):
-        if carriers and rate.carrier.lower() not in carriers:
+        if (carriers and rate.carrier.lower() not in carriers) or (services and rate.service.lower() not in services):
             continue
-        elif services and rate.service.lower() not in services:
-            continue
-        elif lowest_rate is None or float(rate.rate) < float(lowest_rate.rate):
+
+        if lowest_rate is None or float(rate.rate) < float(lowest_rate.rate):
             lowest_rate = rate
 
     if lowest_rate is None:

--- a/easypost/util.py
+++ b/easypost/util.py
@@ -1,0 +1,31 @@
+from typing import List
+
+from easypost.error import Error
+
+
+class Util:
+    def get_lowest_object_rate(
+        easypost_object=object, carriers: List[str] = None, services: List[str] = None, rates_key: str = "rates"
+    ):
+        """Gets the lowest rate of an EasyPost object."""
+        carriers = carriers or []
+        services = services or []
+        lowest_rate = None
+
+        carriers = [carrier.lower() for carrier in carriers]
+        services = [service.lower() for service in services]
+
+        for rate in easypost_object[rates_key]:
+            if len(carriers) > 0 and rate.carrier.lower() not in carriers:
+                continue
+
+            if len(services) > 0 and rate.service.lower() not in services:
+                continue
+
+            if lowest_rate is None or float(rate.rate) < float(lowest_rate.rate):
+                lowest_rate = rate
+
+        if lowest_rate is None:
+            raise Error(message="No rates found.")
+
+        return lowest_rate

--- a/easypost/util.py
+++ b/easypost/util.py
@@ -1,13 +1,18 @@
 from typing import List
 
+from easypost.easypost_object import EasyPostObject
 from easypost.error import Error
 
 
 class Util:
-    def get_lowest_object_rate(
-        easypost_object=object, carriers: List[str] = None, services: List[str] = None, rates_key: str = "rates"
+    @staticmethod
+    def _get_lowest_object_rate(
+        easypost_object: EasyPostObject,
+        carriers: List[str] = None,
+        services: List[str] = None,
+        rates_key: str = "rates",
     ):
-        """Gets the lowest rate of an EasyPost object."""
+        """Gets the lowest rate of an EasyPost object such as a Shipment, Order, or Pickup."""
         carriers = carriers or []
         services = services or []
         lowest_rate = None

--- a/tests/cassettes/test_order_lowest_rate.yaml
+++ b/tests/cassettes/test_order_lowest_rate.yaml
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    body: '{"order": {"to_address": {"name": "Jack Sparrow", "company": "EasyPost",
+      "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
+      "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+      "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
+      "shipments": [{"to_address": {"name": "Jack Sparrow", "company": "EasyPost",
+      "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
+      "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+      "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
+      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '879'
+      Content-Type:
+      - application/json
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: POST
+    uri: https://api.easypost.com/v2/orders
+  response:
+    body:
+      string: '{"mode":"test","reference":null,"is_return":false,"options":{"currency":"USD","payment":{"type":"SENDER"}},"messages":[],"created_at":"2022-04-26T19:14:57Z","updated_at":"2022-04-26T19:14:57Z","customs_info":null,"from_address":{"id":"adr_29560690c59511ec94a4ac1f6bc72124","object":"Address","created_at":"2022-04-26T19:14:57+00:00","updated_at":"2022-04-26T19:14:57+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"to_address":{"id":"adr_2954c591c59511ec8d08ac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T19:14:57+00:00","updated_at":"2022-04-26T19:14:57+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_2954c591c59511ec8d08ac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T19:14:57+00:00","updated_at":"2022-04-26T19:14:57+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"return_address":{"id":"adr_29560690c59511ec94a4ac1f6bc72124","object":"Address","created_at":"2022-04-26T19:14:57+00:00","updated_at":"2022-04-26T19:14:57+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"shipments":[{"created_at":"2022-04-26T19:14:57Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-26T19:14:57Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_29560690c59511ec94a4ac1f6bc72124","object":"Address","created_at":"2022-04-26T19:14:57+00:00","updated_at":"2022-04-26T19:14:57+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":"order_3f6767396e5e45e895679f713d745142","parcel":{"id":"prcl_81cacdf634ad4ffdac356a73eee507ec","object":"Parcel","created_at":"2022-04-26T19:14:57Z","updated_at":"2022-04-26T19:14:57Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_f235e57648f84209915b7a2b0b7f8f51","object":"Rate","created_at":"2022-04-26T19:14:57Z","updated_at":"2022-04-26T19:14:57Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_7979e47f925f4997adc29812f3bbd5fe","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_0fd5ba2c326043bc8083a4a5c823e3aa","object":"Rate","created_at":"2022-04-26T19:14:57Z","updated_at":"2022-04-26T19:14:57Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_7979e47f925f4997adc29812f3bbd5fe","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_84298e25072e4d5fa9c9c9a526d0405f","object":"Rate","created_at":"2022-04-26T19:14:57Z","updated_at":"2022-04-26T19:14:57Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_7979e47f925f4997adc29812f3bbd5fe","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_cc44a41eec2e491fb277c9281f5af7fd","object":"Rate","created_at":"2022-04-26T19:14:57Z","updated_at":"2022-04-26T19:14:57Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_7979e47f925f4997adc29812f3bbd5fe","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_2954c591c59511ec8d08ac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T19:14:57+00:00","updated_at":"2022-04-26T19:14:57+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_29560690c59511ec94a4ac1f6bc72124","object":"Address","created_at":"2022-04-26T19:14:57+00:00","updated_at":"2022-04-26T19:14:57+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_2954c591c59511ec8d08ac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T19:14:57+00:00","updated_at":"2022-04-26T19:14:57+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_7979e47f925f4997adc29812f3bbd5fe","object":"Shipment"}],"rates":[{"id":"rate_f235e57648f84209915b7a2b0b7f8f51","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_7979e47f925f4997adc29812f3bbd5fe","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_0fd5ba2c326043bc8083a4a5c823e3aa","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_7979e47f925f4997adc29812f3bbd5fe","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_84298e25072e4d5fa9c9c9a526d0405f","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_7979e47f925f4997adc29812f3bbd5fe","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_cc44a41eec2e491fb277c9281f5af7fd","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_7979e47f925f4997adc29812f3bbd5fe","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"id":"order_3f6767396e5e45e895679f713d745142","object":"Order"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '8848'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"08f13259eb090769023ad12115db1aa2"
+      expires:
+      - '0'
+      location:
+      - /api/v2/orders/order_3f6767396e5e45e895679f713d745142
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 19bdb4bf626844b1e786c5c30023ebb1
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb1nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq fde591f008
+      - extlb2nuq fde591f008
+      x-runtime:
+      - '0.249067'
+      x-version-label:
+      - easypost-202204251804-93ddab36b5-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/cassettes/test_pickup_buy.yaml
+++ b/tests/cassettes/test_pickup_buy.yaml
@@ -29,49 +29,28 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xYbW/bNhD+K4a+LrHFF735m5Em27olceMMXToUAkVSNlNZEiiqiV3kv+8oyY5f
-        2sZAi2ZYYwSxeTyeyHse3fHuk8O1ZEaKmBln6GAX42OXHiN8jfwhokOM3zlHjqpiLU2tc2eYsqyS
-        R85cVhWbysoZ/vMeRoWQsNrIyoB2URpV5DD1yeG11jLnC5j8a/IK5kq2mMvc2DmzKO2iyenFq9Mr
-        5+HIEbCPmImPLOcw4YJEy1Ta9TDM6yw7cirDTA2WnTr/kBd3OVg0mvEPKp/GvN1ERF0X2b+I+Agh
-        6oc0CiNQrEvxtYMSe9CEGT6LlVg9rx2vnrop6xywEvK6MsW8ilWeFitZqos5nEdoULUHtmYdJnQc
-        iSiKkEcSFiQISc4IIYyj1E94kBAfWx8mt5LbjY669UdPAvWL6w5d9+mDPirmbG499hoc2JuUTOvi
-        zj6nmJcst5CdsmoxLhpMK6OlNAiEJAx71+D6SuaiN3mcw3azpelha5krYw1MWN4704CnqnjhtPDZ
-        J56MYLBUZQMXcoPmqXVudEsUy5NZkVtNb/0BoZwzla28u805DrtXUscp4yprHt5qge+UAMIptl6Y
-        SiE1y2LD7jeQbra2I/sotUoVZys6PwAlVV7Vmm1QstBgbmMR+JHLbI13qXkWk0gQ3/V5yn1EUy4j
-        lwSIBThKKU8SnG4CPm7XP433uwOgtjqZzKdm5gyR23ePnDsl7CC0v2dSTWewktpBqcEvqcrBWgmE
-        2OD2XaeGvD7d9jv4owR+gG6csaQ99eNB2pk/m4mjzhtZzKLEx26QSg+lFCPEfE9wTJknLfslevrk
-        5ICTNzo7AcWCZ+RUN+vSQs9hZW5pBj6ym4xFy84vWGt1gFBFVltGOEPiuitxpZZ2Kb3315pdfAOn
-        sjoza3GqMrmaU3Nw0KDMp+vZWoMTnZkxZTUcDCS8gNbBx3ZR1a9Iv66O78Dzx7jP5mxZ5Oyu6sML
-        O2gUBltgDOw5XIrwQAosPOIlMiGCoiRKPEITN4FY46UilUl/cwelSNtdtOC3wmWZ7QtlmeF9qd1J
-        K7EBHDxqc0T3MthhDBgLTDgiXsCppGGUSOG6UvoyCX0v3XoZriwi348Q2zGjkvqjssxwxloV2kaN
-        dSBp4tDYRiLdkiLokyZM7SY0yIsQlOJOK+wH7qNwTzlTlYm3DTaiPUUhMwXRZwGUXID/0JbErN/M
-        LWE8rRlEJiOlWKdpOGi8b6uaqdJm4SZqwaiMQ+KxKGApCQNBBeEsRZz7FIU4EgFmfCPCMt6E6nYt
-        Z3GCPd8LJORYX1LhQyILkYcYJ9RnnCIJQWITfZqmNIqIFyZIUOYSgD9iJEkSwoQrif8M6J8pvZlD
-        9qCHsBc9DX2ndQj0nepB0OPvCD1+XuiDJPBDlHDsQ96jGKJRJL0QQdqRAcKheAboT+/L1e3qC+Bj
-        0g+8p9HHQZ8e+uavTB6E/2fQ/hYKdJed52SBCCHfAwOkTCmhhEHaDyEfcRIR7ifyOcJ/c+WayMw+
-        9WspAOOnmdBpHZYCGtWfIA68b2q5Ohc7tVTFWd5dxTpBAwLg2LroJXP8tJmjLeytUzsSGP0hdgn2
-        KfzDzE8oQVA8RSmCClKgNEoDf4sD1936XfgObhh8ptnQisA7pqlEN2a+F9UqNbUlWLLYrb7a0Q42
-        j6h+CzyPvF37pj1h195J5arRs8Jz5YCu5K2TTPGd2qUx1V9VME2RIm5PffHba/33crQ8v71xz1+d
-        L87np/jm9s3y/O2FurnN5ufXb+7Pf31z/w5+XyxvcMOE4kttlID5vrfRRkE/ro1C9tooo5M/epPx
-        6Orq8u12G2U0uRlfTq732yiXby9s+6s3ue6Nxtdt62TdTekaS10nZXTRO7saXZz8Pjm5/Eon5Rj5
-        TQXyI9opRtfyW9opdt/Uflc15w24rUWpdaE7wq152BWUK+4fuuwTVKVGmdoejgT9IPA8KICyIp92
-        QkAU90nkRwHwTM1lvGw9NZrDbjkb/FlU8SifQlqqnIcH2wGqq7LqtFATtWudv7T5/mdtvqRe2LT1
-        EnVeos5/I+rYS/J2Ot5otZ5Je9vtmopNw7WVsLkFBGRu37Uf6+MZ01N72Wu3397K15c/W6p93mrX
-        zd2xa++jB9l93zWAD7yYrPcw6a41zsO/AAAA//8DAHePFDeqGgAA
+      string: '{"created_at":"2022-04-26T17:15:43Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361116713366","updated_at":"2022-04-26T17:15:44Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_81223095c58411ecb510ac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T17:15:43+00:00","updated_at":"2022-04-26T17:15:43+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_559a6c461ed346bfbc27022fce21b430","object":"Parcel","created_at":"2022-04-26T17:15:43Z","updated_at":"2022-04-26T17:15:43Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_fd99864fd9c9464eba4226cfe2b29cc5","created_at":"2022-04-26T17:15:44Z","updated_at":"2022-04-26T17:15:44Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-26T17:15:44Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220426/b0511b1264a74bd2847700fcdcafe032.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_899c2e0ad443444e8e24b27c58b5d4a7","object":"Rate","created_at":"2022-04-26T17:15:43Z","updated_at":"2022-04-26T17:15:43Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8146653a7f76451795e16e3276e853a4","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7ad4e7b6b1544d7ab9b977cf94cd813c","object":"Rate","created_at":"2022-04-26T17:15:43Z","updated_at":"2022-04-26T17:15:43Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_8146653a7f76451795e16e3276e853a4","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_74ae2550e9fd4c25a964c52db1f7c373","object":"Rate","created_at":"2022-04-26T17:15:43Z","updated_at":"2022-04-26T17:15:43Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_8146653a7f76451795e16e3276e853a4","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_d835d99f17474a028435e63b28ab2df6","object":"Rate","created_at":"2022-04-26T17:15:43Z","updated_at":"2022-04-26T17:15:43Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8146653a7f76451795e16e3276e853a4","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_d835d99f17474a028435e63b28ab2df6","object":"Rate","created_at":"2022-04-26T17:15:44Z","updated_at":"2022-04-26T17:15:44Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8146653a7f76451795e16e3276e853a4","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_a47ad0688f9049edbcf14c9f0dea5082","object":"Tracker","mode":"test","tracking_code":"9400100109361116713366","status":"unknown","status_detail":"unknown","created_at":"2022-04-26T17:15:44Z","updated_at":"2022-04-26T17:15:44Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_8146653a7f76451795e16e3276e853a4","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2E0N2FkMDY4OGY5MDQ5ZWRiY2YxNGM5ZjBkZWE1MDgy"},"to_address":{"id":"adr_81206515c58411ecb439ac1f6bc7b362","object":"Address","created_at":"2022-04-26T17:15:43+00:00","updated_at":"2022-04-26T17:15:43+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_81223095c58411ecb510ac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T17:15:43+00:00","updated_at":"2022-04-26T17:15:43+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_81206515c58411ecb439ac1f6bc7b362","object":"Address","created_at":"2022-04-26T17:15:43+00:00","updated_at":"2022-04-26T17:15:43+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_8146653a7f76451795e16e3276e853a4","object":"Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '6826'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"3a90490c54f8ea4b2d98cfeda71a3ff2"
+      - W/"918250658b993b0b2689700dabae02c5"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_835a97af387d4d3caf1cc641829d72ac
+      - /api/v2/shipments/shp_8146653a7f76451795e16e3276e853a4
       pragma:
       - no-cache
       referrer-policy:
@@ -82,27 +61,25 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42efa6255a55ee77997cd00312a3c
+      - 19bdb4ba626828bfe786b8a5001a6418
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7nuq
+      - bigweb1nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.945639'
+      - '1.285625'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -111,9 +88,9 @@ interactions:
 - request:
     body: '{"pickup": {"address": {"name": "Jack Sparrow", "company": "EasyPost",
       "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
-      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-04-13",
-      "max_datetime": "2022-04-13", "instructions": "Pickup at front door", "shipment":
-      {"id": "shp_835a97af387d4d3caf1cc641829d72ac"}}}'
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-04-27",
+      "max_datetime": "2022-04-27", "instructions": "Pickup at front door", "shipment":
+      {"id": "shp_8146653a7f76451795e16e3276e853a4"}}}'
     headers:
       Accept:
       - '*/*'
@@ -135,26 +112,19 @@ interactions:
     uri: https://api.easypost.com/v2/pickups
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA6xUTY/TMBD9K1Gu7KLYSfPR24qFAwdU0XIBraKJPV5MUztynN0tVf874yS0u8uh
-        IBHlkBm/+XrznEOsZbyMOy22Q1eXKk0XeSpKYE1WJaxalGkpK5EVCvJEYXwV2+YHCk8hqzGEPMIh
-        eJQ1BC9POL9OsmvGNyxfsmzJs6+EGTp5EbOzEunUY+/J6j34oSd7MFtjHw25HCp0aAShzNC2FKFN
-        HfJ6vcPnedNNkizHd8wLT3+B0n0NQtjB+BqkdNhTbQVtj3Rkeu8G4bU1/WnwCHyknDU+kta6UIZC
-        4B4J8e2OSLFGabeDEPS73VPew0Q6SFdXmPKcC9lA0TCGAiTLQDCVNwkkkr1g/GaOv0h5+mYc6zLv
-        Z6CBkZyPILbRugPn7GOoY3cdmD0dvId+v7LzZhyiZ+RMyzLa0G56NDJan894aLbzEQ+ZhfYhwRpM
-        9MGBEboXdt5vqPjuhoyfuqPPKmNJMValLbgQ9GVNZvfdmoBcnB5y4g50e9LBC+UI6l6jqxUI3Y7F
-        JxRxpyUar+EUqFCig7b2JJGwksk7tvbK94BOKy1gFsHheDwXmnUzb36+So5yBM/hta7RPegg4fgT
-        Pvlb2AdhT1Qkb8dViMEFlU/z3/7HCzb3O+ZdjcxOrf7jH+AZPDRep42sqobnRb5YZKnkFWdFluZZ
-        pTjIIqn+/Gl8DvMe746/AAAA//8DAN1K0Mt9BAAA
+      string: '{"id":"pickup_500fd7e639b44b9289bf8960f45f6828","object":"Pickup","created_at":"2022-04-26T17:15:45Z","updated_at":"2022-04-26T17:15:45Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-27T00:00:00Z","max_datetime":"2022-04-27T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_82007e9ac58411ecb9a2ac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T17:15:44+00:00","updated_at":"2022-04-26T17:15:44+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-26T17:15:45Z","updated_at":"2022-04-26T17:15:45Z","carrier":"USPS","pickup_id":"pickup_500fd7e639b44b9289bf8960f45f6828","id":"pickuprate_637cac11bb6949e5b5b874e73b079ef0","object":"PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '1149'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"3229faef107f92a6f4c16af3265b1206"
+      - W/"6a219f69d6a1bc66eaa1057f8648a2fd"
       expires:
       - '0'
       pragma:
@@ -174,7 +144,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42efa6255a55fe77997cd00312a9f
+      - 19bdb4ba626828c0e786b8a5001a647f
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -182,12 +152,12 @@ interactions:
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.743600'
+      - '0.873564'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -213,29 +183,22 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: POST
-    uri: https://api.easypost.com/v2/pickups/pickup_8f33563c8a1b490195838d9c47fa60fe/buy
+    uri: https://api.easypost.com/v2/pickups/pickup_500fd7e639b44b9289bf8960f45f6828/buy
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA6xU227UMBD9lSivUGQ7932rWnjgAa3YRUhUVTSxJ9Q0a0eO0wur/XfGSbTbFomC
-        RJSHzPicuR5nH2sVr+Jey9uxr8s2SbI8kSXwJq0Yr7IyKVUl06KFnLUYv41t8wOlJ8p6opBHOgSP
-        qobgFUyIM5aecbHl+YqnK5F+I8zYqz9hsoDZWYV06nHwZA0e/DiQPcgbVGOHipwOW3RoJOHM2HXE
-        0aYOkb3e4dPIyZax1fROkeHhL1B6qEFKOxpfg1IOB8reQjcgHZnBu1F6bc1wbD0CH7XOGh8pa11I
-        QxT4joS4uqaxWNNqt4NAIs7X7UXOiyJjlSDoMcF+nj8oV1eYiFxI1UDRcI4SFE9B8jZvGDDFnw3/
-        fOG/Ov3kzdTf6ys4AQ1MU/oI8jba9OCcvQ957K4H80gH72F4XNtlSQ7Rc3ImZRlt7b0Z0KhoczoT
-        odjeRyJEltqHABsw0QcHRupB2mXVIePFORk/dU+fVcpZMWWldbhA+rIhs7+xJiCz40NO3IHujoJ4
-        JiJJ1Wt0dQtSd1PyGUWz0wqN13AktqjQQVd70kpYyeydSnvhu0OnWy1hUcP+cDglWgS0SGC5VY5i
-        BM/+pcTR3emg5fgTPvhLeAwKn0fB3k2rkKMLcp/7v/w/d23CLPVOcdfTZOdS//Fn8AQeCq+TRlVV
-        I/Iiz7I0UaISvEiTPK1aAapg1e//j8+h38P14RcAAAD//wMAT0o5BYgEAAA=
+      string: '{"id":"pickup_500fd7e639b44b9289bf8960f45f6828","object":"Pickup","created_at":"2022-04-26T17:15:45Z","updated_at":"2022-04-26T17:15:47Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-04-27T00:00:00Z","max_datetime":"2022-04-27T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":"WTC61776434","address":{"id":"adr_82007e9ac58411ecb9a2ac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T17:15:44+00:00","updated_at":"2022-04-26T17:15:44+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-26T17:15:45Z","updated_at":"2022-04-26T17:15:45Z","carrier":"USPS","pickup_id":"pickup_500fd7e639b44b9289bf8960f45f6828","id":"pickuprate_637cac11bb6949e5b5b874e73b079ef0","object":"PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '1160'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"c207cbb0de332151c31529d9fa86ed97"
+      - W/"64f50cc83ff8cfb71f71c6408489dbe0"
       expires:
       - '0'
       pragma:
@@ -253,20 +216,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42efa6255a560e77997cd00312af7
+      - 19bdb4ba626828c1e786b8a5001a64df
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb4nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '1.254850'
+      - '1.507143'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_pickup_cancel.yaml
+++ b/tests/cassettes/test_pickup_cancel.yaml
@@ -29,49 +29,28 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xYbW/bNhD+K4a+LnFI6oWSv3l5wdotL4u9ds1QCBRfbKWyJFBUXbvIf99Rkh3H
-        SRMDzZphi5E44fF4Iu95dLy7rw7XkhkpYmacgUMQIfvI28dkjIMB9gYkuHL2nLSKtTS1zp2BYlkl
-        95yZrCo2kZUz+OsjjAohYbWRlQHtojRpkcPUV4fXWsucL2Dyj9ERzJVsMZO5sXNmUdpFo+Ozo+NL
-        52bPEbCPmInPLOcwgUCipZJ2PQzzOsv2nMowU4Nlp84/5cU8B4tGM/4pzScxbzcReQhh+xO5AcbY
-        C0If4QAU61I8dlBqD5oww6dxKlbPa8erp27KOgeshLyuTDGr4jRXxUqmdDGD8wgNqvbA1qzDhI4j
-        xaRUvkgYTTCWnHlJxDhWQcJp4gbE+jC5ltxudNit33sSqJ8QGiD09EFvFXM2sx57Cw7sjUqmdTG3
-        zylmJcstZMesWlwUDaaV0VIaDEI3DHtjcH0lc9Eb3c4Ru9nS9Ii1zFNjDYxY3jvRgGda8cJp4bNP
-        PBzCYJmWDVwY0eapdW50SxTLk2mRW01//QGhnLE0W3n3Luc47D6VOlaMp1nz8FYLfJcKIFzK1guV
-        FFKzLDbsywbSzda2ZJ+lTlXK2YrON0DJNK9qzTYoWWgwt7EI/Mhltsa71DyLkSsTEUgfhYnypBtG
-        KnDdEL44SYgv8SbgF+36p/G+2gFqq5PJfGKmzgCjPtpz5qmwg9D+P5XpZAorPTsoNfhFpTlYK4EQ
-        G9yed2rY73t3/Q7+KIEfoBtnLGlPfXuQdua3ZmKv80YWE5d6oYj80PdDj0aESVdFnsddnBDhuf7T
-        J6c7nLzR2QooFjwjJ7pZpwo9g5W5pRn4yG4yFi07v2Gt1QFCFVltGeEMXIRW4ipd2qXel2Ct2cU3
-        cCqrM7MWqzSTq7l0Bg46KPPJerbW4ERnakxZDQ4OJLyA1sH7dlHVr9x+Xe3PwfP7pM9mbFnkbF71
-        4YU9aBQO7oBxYM+BPEwOfEp8IggKMQs8TCHYUEwjyX1XSJd7rL+5g1Kodhct+K1wWWb3hbLMyH2p
-        3UkrsQEcPGrviO5lsMNYRVEUwC8TCntEhIx6DJMokAFn2PfV5stwaRF5vlfhbsyopP6cWmY4x1/K
-        VZBt40gThi5sINIdJ9w+bai5faHBvQhBKV6p0b6HbqX3tLO0MvGWyUZ2T1PILIX4swBSLtZXz4bQ
-        yAeF8aRmEJ6MlGJ9V8Np4wfNVdO0tLdxE71gVMbMjXAoEkkVh3uUJZFyKYkQp35IgijAG5GW8SZk
-        t2s5iyGQBT6VUQhIeiJwGQ+xjxl3vYBxD0sIFpssoIkiAQ4izFzXQ36UcCUgBigPKQVxgL8AC9rI
-        O5KZfeq3qUD7hDzNhE5rFyJ0qjvxgDwjCcjLMgAHyqeRxxPhMk/4XoRdlCjhS0jXeMTxSzBAp4W2
-        2cNj6Lv0afTDPt01DHQGd0IfPyP6+GXR97EfCBwmvsLU41SGIaZEqjBCVEGKkLwA+ieprh578SH9
-        iZ6GvtPaBfpO9X/w4n9sark6F1u1VMVZ3qVinaCJvgBg66J/ljE7J5KvjPnxwaIt7K1TOxIY/Sn2
-        OSEB1M4yCJAXScRo5BIUEDdEAaIJ2uTAuFu/Dd/ODYMHmg2tCLxjmkp0Y+a5qFalE1uCJYvt6qsd
-        bWFzi+r3wHPL27Vv2hN27R0lV42eFZ4rB3Qlb51kKd+qXRpT/VUF0xQp4vo4EL+81X8u312fXr8h
-        V+/fza7GH8jp0e/+1fjn6dny0/L0ekhOr0+906MP8zPyZt4wofhWG4UrBTX1qo0SUX/dRhE8+NFt
-        lOHhr73RxfDy8vz93TbKcPTh4nw0vt9GOX9/ZttfvdG4N7wYt62TdTelayx1nZThWe/kcnh2+GZ0
-        eP5IJ2UfB03m8SPaKUbX8nvaKXbfnv1b1Zw34LYWpdaF7gi35mFXUK64v+uyr1CVmtTU9nAu7VPq
-        +5D4ZEU+6YSAKOm7UJBS4Fk6k/Gy9dRwBrvl7OC3ooqH+QSupcq5ubEdoLoqq04LN1G71vlrm+8/
-        1uZL6oW9tl6jzmvU+XdEHZsk372ON1qtJ9Jmu11TsWm4thI2s4CADPWR/VgfT5me2GSv3X6bla+T
-        P1ujPWy16+Zu2bX56E52P3YN4B0Tk/UeRl1a49z8DQAA//8DAHaBm2OqGgAA
+      string: '{"created_at":"2022-04-26T17:15:47Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361116713380","updated_at":"2022-04-26T17:15:48Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_838ceff8c58411ecb52dac1f6bc7b362","object":"Address","created_at":"2022-04-26T17:15:47+00:00","updated_at":"2022-04-26T17:15:47+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_0d54f16ee2a945d785e2b75a08940802","object":"Parcel","created_at":"2022-04-26T17:15:47Z","updated_at":"2022-04-26T17:15:47Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_22ca7eb29a554e148d42e5ea17b2fe23","created_at":"2022-04-26T17:15:47Z","updated_at":"2022-04-26T17:15:48Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-26T17:15:47Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220426/a2b14fe6583b4406bca04478dcd384f4.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_139aee8983d74f12aa8cfbc0c15ac8fe","object":"Rate","created_at":"2022-04-26T17:15:47Z","updated_at":"2022-04-26T17:15:47Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_cf59de7d37a74eba91acbe849d45dcf3","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_92c1b126bc7942e084da358f1a3f98b2","object":"Rate","created_at":"2022-04-26T17:15:47Z","updated_at":"2022-04-26T17:15:47Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cf59de7d37a74eba91acbe849d45dcf3","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e4fb20d9476641ffbba12385eb1d19b5","object":"Rate","created_at":"2022-04-26T17:15:47Z","updated_at":"2022-04-26T17:15:47Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cf59de7d37a74eba91acbe849d45dcf3","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_88f8c37969a84c16960f41acee001af8","object":"Rate","created_at":"2022-04-26T17:15:47Z","updated_at":"2022-04-26T17:15:47Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_cf59de7d37a74eba91acbe849d45dcf3","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_e4fb20d9476641ffbba12385eb1d19b5","object":"Rate","created_at":"2022-04-26T17:15:48Z","updated_at":"2022-04-26T17:15:48Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cf59de7d37a74eba91acbe849d45dcf3","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_3ee0d86790614780af72eb0c11dd489f","object":"Tracker","mode":"test","tracking_code":"9400100109361116713380","status":"unknown","status_detail":"unknown","created_at":"2022-04-26T17:15:48Z","updated_at":"2022-04-26T17:15:48Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_cf59de7d37a74eba91acbe849d45dcf3","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzNlZTBkODY3OTA2MTQ3ODBhZjcyZWIwYzExZGQ0ODlm"},"to_address":{"id":"adr_838af3dac58411ecb52bac1f6bc7b362","object":"Address","created_at":"2022-04-26T17:15:47+00:00","updated_at":"2022-04-26T17:15:47+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_838ceff8c58411ecb52dac1f6bc7b362","object":"Address","created_at":"2022-04-26T17:15:47+00:00","updated_at":"2022-04-26T17:15:47+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_838af3dac58411ecb52bac1f6bc7b362","object":"Address","created_at":"2022-04-26T17:15:47+00:00","updated_at":"2022-04-26T17:15:47+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_cf59de7d37a74eba91acbe849d45dcf3","object":"Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '6826'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"dda6d899ed74e0985f312f5bea3013de"
+      - W/"104dba766c35d91bff7c9dbd157ecee3"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_a3918dbe7fc940ab9f37290c75826961
+      - /api/v2/shipments/shp_cf59de7d37a74eba91acbe849d45dcf3
       pragma:
       - no-cache
       referrer-policy:
@@ -87,20 +66,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42ef76255a562e77997ce00312ba3
+      - 19bdb4be626828c3e786b8bf001a657c
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb9nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb2nuq fde591f008
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '1.189328'
+      - '0.895327'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -109,9 +88,9 @@ interactions:
 - request:
     body: '{"pickup": {"address": {"name": "Jack Sparrow", "company": "EasyPost",
       "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
-      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-04-13",
-      "max_datetime": "2022-04-13", "instructions": "Pickup at front door", "shipment":
-      {"id": "shp_a3918dbe7fc940ab9f37290c75826961"}}}'
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-04-27",
+      "max_datetime": "2022-04-27", "instructions": "Pickup at front door", "shipment":
+      {"id": "shp_cf59de7d37a74eba91acbe849d45dcf3"}}}'
     headers:
       Accept:
       - '*/*'
@@ -133,26 +112,19 @@ interactions:
     uri: https://api.easypost.com/v2/pickups
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5RUTY/TMBD9K1GusChxPur2tmLhwAFVtFxAq2hiT8A0tSPH2d1S9b8zdrLZshxa
-        ohwy4zdfb55zjJWMV3GnxG7oqpylTVawZVEUMm9ALOsskazmjLMaWAbx29jUv1A4ClmHEPIIi+BQ
-        VuC9LGHsJslvUrZNy1War9jiG2GGTl7E7I1EOnXYO7J6B27oyR70TptHTS6LDVrUglB6aFuKULry
-        eZ3a43nebJskq/CGvPB0BUr1FQhhBu0qkNJiT7UbaHukI907OwinjO7nwSNwUWONdpE0xvoyFAI/
-        kBDf74kUoxtl9+CDntud8x5H0kHaCpJScJ5hDYs6TVFAkTMQaVPWYlFnJTtn/HaKv0z5mzDWFbzP
-        QA2BnE8gdtGmA2vNo69j9h3oAx18gP6wNtNmLKJLyZlxHm1pNz1qGW1ezphvtnMR85mFcj7BBnT0
-        0YIWqhdm2q+v+P6WjN+qo89lniaLUJW2YH3Q1w2Z3U+jPbKYH3LiHlQ76+Av5QjqXqGtSL+qDcVH
-        FHGnJGqnYA5sUKKFtnIkEb+S0Rtae+V7QKsaJWASwfF0eik06Wba/HSVLOXwnuNrXaN9UF7C8Wd8
-        cndw8MIeqUjehVWIwXqVj/PfXd42v+KCBczUb8i7DsyOrf7nH+AM7huvaplx5Is051zkZclhyXlZ
-        A0dIkkW6zP/9aXzx857uT38AAAD//wMAhY0o430EAAA=
+      string: '{"id":"pickup_059b8da147d043bab9a8f02ef1c66788","object":"Pickup","created_at":"2022-04-26T17:15:48Z","updated_at":"2022-04-26T17:15:48Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-27T00:00:00Z","max_datetime":"2022-04-27T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_841fa910c58411ec84faac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:48+00:00","updated_at":"2022-04-26T17:15:48+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-26T17:15:49Z","updated_at":"2022-04-26T17:15:49Z","carrier":"USPS","pickup_id":"pickup_059b8da147d043bab9a8f02ef1c66788","id":"pickuprate_75119de949484faea0de029735ff5b93","object":"PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '1149'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"98b8e484fb24c6dc474279df65f4c0ae"
+      - W/"fefbd3990675a53d20e243a54b4f45e3"
       expires:
       - '0'
       pragma:
@@ -170,20 +142,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42ef76255a563e77997ce00312c21
+      - 19bdb4be626828c4e786b8bf001a65de
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb3nuq
+      - bigweb2nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.771665'
+      - '0.663174'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -209,29 +181,22 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: POST
-    uri: https://api.easypost.com/v2/pickups/pickup_421f3529555d4fac9b30d2b8282ba23a/buy
+    uri: https://api.easypost.com/v2/pickups/pickup_059b8da147d043bab9a8f02ef1c66788/buy
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5RUXW/TMBT9K1FfYShxvpy+TRs88IAqWoQEmqIb+4aZpXZkO9tK1f/OdRK1ZUh0
-        RHnIvT7nfh5nv1BysVz0SjwMfZ2xpE1zVuV5LrMWRNWksWQNZ5w1wFJYvF2Y5icKT5TVSCGPsAge
-        ZQ3By2LGruLsKmGbpFgm2ZKV3wgz9PJfmCpgtkYinXp0niznwQ+ObCfuUQ4dSnJabNGiFoTTQ9cR
-        R+k6RPZqi+eR000cL8d3jAzPr0ApV4MQZtC+BiktOsreQueQjrTzdhBeGe2OrUfgo9Ya7SNpjA1p
-        iAI/kBDf72gsRrfKbiGQiPN1c1MkZZnHJSPoMcF+mj9IW0NcCM5TbKBskgQF5BkDkbRFI8omLdj5
-        8K9n/uXpvxn7u7yCE1DDOKWPIB6idQ/WmqeQx2x70Ds6eA9utzLzkiyiT8iZch5tzJN2qGW0Pp2x
-        UGzvIxYiC+VDgDXo6IMFLZQTZl51yHhzTcYv1dNnlSVxOWalddhA+rIms783OiDz40NO3ILqjoL4
-        Q0SCqldoa5Ky6sbkE4pmpyRqr+BIbFGiha72pJWwksk7lvbC94hWtUrArIb94XBKNAtolsB8qyzF
-        CJ79S4mjfVRBy4tP+OxvYRcUPo0ifjeuQgw2yH3q//bytvkr7tqImesd467GyU6l/ufP4AweCq8b
-        mXLkZZJxLrKi4FBxXjTAEeK4TKrs7//H59Dv4e7wGwAA//8DAK37wUGIBAAA
+      string: '{"id":"pickup_059b8da147d043bab9a8f02ef1c66788","object":"Pickup","created_at":"2022-04-26T17:15:48Z","updated_at":"2022-04-26T17:15:50Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-04-27T00:00:00Z","max_datetime":"2022-04-27T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":"WTC61776436","address":{"id":"adr_841fa910c58411ec84faac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:48+00:00","updated_at":"2022-04-26T17:15:48+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-26T17:15:49Z","updated_at":"2022-04-26T17:15:49Z","carrier":"USPS","pickup_id":"pickup_059b8da147d043bab9a8f02ef1c66788","id":"pickuprate_75119de949484faea0de029735ff5b93","object":"PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '1160'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"2d174db45c57c09e78af01517ae1be9b"
+      - W/"1ead5e24f003e64596fd8de461b03da6"
       expires:
       - '0'
       pragma:
@@ -249,20 +214,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42ef76255a564e77997ce00312c6a
+      - 19bdb4be626828c5e786b8bf001a662d
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb2nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '1.052135'
+      - '1.329403'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -288,29 +253,22 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: POST
-    uri: https://api.easypost.com/v2/pickups/pickup_421f3529555d4fac9b30d2b8282ba23a/cancel
+    uri: https://api.easypost.com/v2/pickups/pickup_059b8da147d043bab9a8f02ef1c66788/cancel
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5RU247TMBD9lSivsMh2bm7fVrvwwANa0SIk0Cqa2BMwm9qR4+yFqv/OOIm6ZZEo
-        RHnIjM+Z63H2qdHpOu2Nuhv7Ohe8zQqxKopC5y2oVZMxLRoppGhAZJC+Tl3zA1Ugys1EIY/yCAF1
-        DdErmBAXLL/gYsvLNc/XovpCmLHXf8FkLGJ2TiOdBhwCWUOAMA5kK7AKO9Tk89iiRzLTtR27jijG
-        1jFwMDs8DZxtGVtP7xQYHv8BZYYalHKjDTVo7XGg5C10A9KRHYIfVTDODsfOEwhJ650NiXbOxzRE
-        gW9IiK+3NBVnW+N3EEnE+by9KnlVFawSBD0m2M/jB+1rYKWSMsMGqoZzVFDkAhRvy0ZVTVaK09lf
-        Lvzzw3819Xd2AydAC9OU3oO6SzY9eO8eYh6368E+0cFbGJ5u3LIjjxg4OTMpk617sANanWyez0Qs
-        tg+JiJGVCTHABmzyztNWzaDcsumY8eqSjJ+mp89Vzlk1ZaV1+Ej6tCGz/+5sRBbHh5y4A9MdBfGb
-        hhRVb9DXpGTTTclnFM3OaLTBwJHYokYPXR1IK3Els3cq7YXvHr1pjYJFDfvD4TnRIqBFAsul8hQj
-        evYvFY7+3kQtpx/wMVzDU1T4PAr2ZlqFGn2U+9z/9flty/NXbcYs9U5xb6bJzqX+57/gBB4Lrxud
-        SZQVz6VUeVlKWElZNiARGKv4Kv/z9/Ex9nu4PfwCAAD//wMAUfhW04cEAAA=
+      string: '{"id":"pickup_059b8da147d043bab9a8f02ef1c66788","object":"Pickup","created_at":"2022-04-26T17:15:48Z","updated_at":"2022-04-26T17:15:51Z","mode":"test","status":"canceled","reference":null,"min_datetime":"2022-04-27T00:00:00Z","max_datetime":"2022-04-27T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":"WTC61776436","address":{"id":"adr_841fa910c58411ec84faac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:48+00:00","updated_at":"2022-04-26T17:15:48+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-26T17:15:49Z","updated_at":"2022-04-26T17:15:49Z","carrier":"USPS","pickup_id":"pickup_059b8da147d043bab9a8f02ef1c66788","id":"pickuprate_75119de949484faea0de029735ff5b93","object":"PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '1159'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"643aa0d9211757ebb79ab16c1f99e412"
+      - W/"332c888058cd55feed180964de354a55"
       expires:
       - '0'
       pragma:
@@ -328,20 +286,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42ef76255a565e77997ce00312d08
+      - 19bdb4be626828c6e786b8bf001a6697
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.875738'
+      - '0.851089'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_pickup_create.yaml
+++ b/tests/cassettes/test_pickup_create.yaml
@@ -29,49 +29,28 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xYbW/bNhD+K4a+zrFFinrzNyNNsHbLS2MPXTIUAt9ks5UlgaKa2kX++46S7NhO
-        mxho0QxrDBsJj8cjec9zR/K+OFxLaqRIqHFGDnYxPnLJEcJTFIwQGaHwxuk7qkq0NLXOnVFKs0r2
-        nYWsKjqTlTP65z20CiFhtJGVAe2iNKrIoeuLw2utZc6X0PnX5BX0lXS5kLmxfWZZ2kGTk/NXJ1fO
-        Xd8RsI6Eik8059DhgkTLVNrx0MzrLOs7laGmBstOnX/Mi9scLBpN+UeVzxLeLiImrovsN/YChBAJ
-        IhL7ESjWpXhso5HdKKOGzxMl1vO17fWs27LOAWshrytTLKpE5WmxlqW6WMB+hAZVu2Fr1qFCJzH1
-        YXrhMxoyhCSPUOpSjtKA8RAjTKwP2QfJ7ULH3fj+k0D95roj1316o/eKOV1Yj70BB/YmJdW6uLXz
-        FIuS5hayE1otL4sG08poKQ0CoRdFvSm4vpK56E3u+7BdbGl62FrmylgDE5r3TjXgqSpeOC18dsbj
-        MTRWqmzgQm7YzFrnRrdEsTyZF7nV9DcfEMoFVdnau7uc47B6JXWSUq6yZvJWC3ynBBBO0c3AVAqp
-        aZYY+nkL6WZpe7JPUqtUcbqm8x1QUuVVrekWJQsN5rYGgR+5zDZ4l5pnCY8DhAFtEsNPxC5DjBCC
-        UxxjnobU3wb8sh3/NN43B0BtdTKZz8zcGSF34PadWyVsI7L/z6WazWEksY1Sg19SlYO1Egixxe3b
-        Tg35A7Lrd/BHCfwA3SSjrN31/Ubanj+bjn7njSxJPd+nAfNSjwaEeTSSnAUh4kHM3DBqePkDdt5E
-        815CseAZOdPNuLTQCxiZW5qBj+wiE9Gy81t+bHSAUEVWW0Y4I8911+JKrexQ8jnYaHb5DZxK68xs
-        xKnK5LpPLcBBwzKfbXprDU505saU1Wg4lBCA1sFHdlA1qLxBXR3dgueP8IAu6KrI6W01gIAdNgrD
-        HTCGdh8uQXjIcIQCGQR+GALvAvA3TmkIcceoT/wgGGyvoBRpu4oW/Fa4KrOHQllm+KHUrqSV2AQO
-        HrVnRBcMtpkQFiKY2QvjQBIPY+YHGJJgGAiGBQ3T7WC4soj8uFDYzRmV1J+UZUYXcxOZ2Vk3yaTJ
-        RZc2G+mWGOEAY9u9f6jB2QiJKdnV6oQPlDNVmT3VRvRAUchMQQZaAi2X4EO8IzGb6NwRJrOaQnYy
-        UorNUQ2bTR7aquaqtCdxk7mgVSYoFhCAFAnEIiJSEQWcM+bLIBY0clm0lWUpb9J1O5bThGEfyCXj
-        yEIqAo/CkeYjyj0SUE6QhESxwwAvdVkAsHNOCUEelZThGPmp53KJA/kcDNCq0PbceAx9L3wa/WgQ
-        ugej3xg8CH30A9FHz4t+yLEnaOyHEPoklF4sY4otI1IuOI+eA/1TpavHAh8Ovvhp6DutQ6DvVH+1
-        wPdE5MKBQ2jIY+J5mKWu5wVYuhSHlDeB87OhP/lcru/X3wAfe4PQfxp9HA7IoZG/NnkQ/l9B+3so
-        0F13fy4L3jdvuToXe2+pitO8u4p1guYMBixbT73kjV82b7QPe+vUjgRGf0wAduaH3JM45SR2vQgL
-        OykVLKSM7t4cpt34ffgOLhh8pdjQisA7pnmJbvU8QbXo0DdLpWb2CcaW+6+vtrWHzT2q3wPPPW83
-        vml32JV3Urku9KzxXDuge/LWLFN87+3SmBqsXzDNI0V8OAnE72/03yuRneHX6ByfrW6mbxbXq7f+
-        2aszcrZ4i6/xubp+d6XO8am6nt5kDROKb5RRiLSJ4L6MIsVzllHGx3/0Jpfjq6uLd7tllPHk+vJi
-        Mn1YRrl4d27LX73JtDe+nLalk001pSssdZWU8Xnv9Gp8fvx6cnzxSCXlCAXNMfozyilG1/J7yil2
-        3cT+rWrOG3Bbi1LrQneE2/Cwe1CuuX/osC/wKjXK1HZzXjgIQ9+H629W5LNOCIjigRcHcQg8UwuZ
-        rFpPjRewWk6HfxZVMs5ncCxVzt2drQDVVVl1WqjJ2rXOX8p8/7MyH6uX9th6yTovWee/kXXsJXn3
-        ON4qtZ5Ke/PpiopNwbWV0IUFBGTuwLUf6+M51TN72WuX397KN5c/+1z7utWumrtn195HD7L7visA
-        H3gx2axh0l1rnLt/AQAA//8DALWn6giqGgAA
+      string: '{"created_at":"2022-04-26T17:15:37Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361116713274","updated_at":"2022-04-26T17:15:38Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_7d6c90bac58411ec8255ac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:37+00:00","updated_at":"2022-04-26T17:15:37+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_6499f3168c554c4c9c9fcdbe9304b6a4","object":"Parcel","created_at":"2022-04-26T17:15:37Z","updated_at":"2022-04-26T17:15:37Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_535d4b3b49194277a57e42bcef40bee8","created_at":"2022-04-26T17:15:37Z","updated_at":"2022-04-26T17:15:37Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-26T17:15:37Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220426/9734130073b04211868a666be9908bd2.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_de25a43b5a7942dba00fcce5e76bb38c","object":"Rate","created_at":"2022-04-26T17:15:37Z","updated_at":"2022-04-26T17:15:37Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_f5d76ab9047e443e9d0911dfa2d3b0b7","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_be3c525a132c4e3a9cfdc8d0e44881e9","object":"Rate","created_at":"2022-04-26T17:15:37Z","updated_at":"2022-04-26T17:15:37Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_f5d76ab9047e443e9d0911dfa2d3b0b7","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_42172733d4f343f78493fd1052542f3f","object":"Rate","created_at":"2022-04-26T17:15:37Z","updated_at":"2022-04-26T17:15:37Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f5d76ab9047e443e9d0911dfa2d3b0b7","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7470661824f840a0815299dbfc0635b9","object":"Rate","created_at":"2022-04-26T17:15:37Z","updated_at":"2022-04-26T17:15:37Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f5d76ab9047e443e9d0911dfa2d3b0b7","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_42172733d4f343f78493fd1052542f3f","object":"Rate","created_at":"2022-04-26T17:15:37Z","updated_at":"2022-04-26T17:15:37Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f5d76ab9047e443e9d0911dfa2d3b0b7","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_173417fbda7b4cafa549f15e67c78134","object":"Tracker","mode":"test","tracking_code":"9400100109361116713274","status":"unknown","status_detail":"unknown","created_at":"2022-04-26T17:15:38Z","updated_at":"2022-04-26T17:15:38Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_f5d76ab9047e443e9d0911dfa2d3b0b7","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzE3MzQxN2ZiZGE3YjRjYWZhNTQ5ZjE1ZTY3Yzc4MTM0"},"to_address":{"id":"adr_7d6a578dc58411ec8254ac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:37+00:00","updated_at":"2022-04-26T17:15:37+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_7d6c90bac58411ec8255ac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:37+00:00","updated_at":"2022-04-26T17:15:37+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_7d6a578dc58411ec8254ac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:37+00:00","updated_at":"2022-04-26T17:15:37+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_f5d76ab9047e443e9d0911dfa2d3b0b7","object":"Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '6826'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"41533977596346b2393d8a7db12ce2e2"
+      - W/"c5717fd29ed06f623cf42f220636d4ff"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_19d078a1d1b84dfd86ccbb5e69da80b8
+      - /api/v2/shipments/shp_f5d76ab9047e443e9d0911dfa2d3b0b7
       pragma:
       - no-cache
       referrer-policy:
@@ -82,27 +61,25 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42efc6255a559e77997cb0031281a
+      - 19bdb4c1626828b9e786b8a1001a622c
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7nuq
+      - bigweb8nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq fde591f008
+      - intlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.864864'
+      - '0.996982'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -111,9 +88,9 @@ interactions:
 - request:
     body: '{"pickup": {"address": {"name": "Jack Sparrow", "company": "EasyPost",
       "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
-      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-04-13",
-      "max_datetime": "2022-04-13", "instructions": "Pickup at front door", "shipment":
-      {"id": "shp_19d078a1d1b84dfd86ccbb5e69da80b8"}}}'
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-04-27",
+      "max_datetime": "2022-04-27", "instructions": "Pickup at front door", "shipment":
+      {"id": "shp_f5d76ab9047e443e9d0911dfa2d3b0b7"}}}'
     headers:
       Accept:
       - '*/*'
@@ -135,26 +112,19 @@ interactions:
     uri: https://api.easypost.com/v2/pickups
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5RUTY+bMBD9K4hru5XtQIDcVt320EMVNeml1QoN9rh1k9jImP1olP/eMbBsuj1k
-        izgw4zdfb545pkalq7Q1cte3NSx1JjKlSszyjDHd4ELmChpeIecaMH2buuYXykAh6yGEPNIjBFQ1
-        RK9gQlyx7IqLLV+ueLbi5TfC9K26iDk4hXQasAtkdQFC35Hd251195ZcHjV6tJJQtt/vKcLYOuYN
-        5oDneRdbxlbDO+SFh1egTFeDlK63oQalPHZUW8O+QzqyXfC9DMbZbh48gZBo72xIlHM+lqEQ+IGE
-        +H5LpDirjT9ADHpqd857HEkH5esKFMKC8waKhnOUpSgYSK6XjSwEF9k549dT/GXK3wxjvYL3GWhh
-        IOcTyF2yacF7dx/ruEML9pEOPkD3uHbTZjxi4ORclGWypd10aFWyeT4Tsdk2JCJmlibEBBuwyUcP
-        VppOumm/seL7azJ+m5Y+q4yzYqhKW/Ax6OuGzPansxGZzw858QBmP+vgL+VI6t6grzVIsx+Kjyji
-        zii0wcAcqFGhh30dSCJxJaN3aO2F7w690UbCJILj6fRcaNLNtPnpKnnKET3Hl7pGf2eihNPP+BBu
-        4DEKe6SCvRtWIXsfVT7Of3Nx24JdvmAjZup3yLsemB1b/c8/wBk8Nl4rlss8h1JDybMyX5bVsiyK
-        ii0aIbHMq39/Gl/ivKfb0x8AAAD//wMAsi3yun0EAAA=
+      string: '{"id":"pickup_22029bc17d0b40d0bb139b61edb30dbd","object":"Pickup","created_at":"2022-04-26T17:15:38Z","updated_at":"2022-04-26T17:15:38Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-27T00:00:00Z","max_datetime":"2022-04-27T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_7e0e7089c58411ecb81dac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T17:15:38+00:00","updated_at":"2022-04-26T17:15:38+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-26T17:15:39Z","updated_at":"2022-04-26T17:15:39Z","carrier":"USPS","pickup_id":"pickup_22029bc17d0b40d0bb139b61edb30dbd","id":"pickuprate_b4840e1163e643c7a14185e9850f1666","object":"PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '1149'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"f4962a6e100261e55ea0331413b49693"
+      - W/"f2eea40f8e9c8e2c091cab21fa21f227"
       expires:
       - '0'
       pragma:
@@ -172,20 +142,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42efc6255a55ae77997cb00312885
+      - 19bdb4c1626828bae786b8a1001a6278
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '1.712122'
+      - '1.633757'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_pickup_lowest_rate.yaml
+++ b/tests/cassettes/test_pickup_lowest_rate.yaml
@@ -1,0 +1,164 @@
+interactions:
+- request:
+    body: '{"shipment": {"to_address": {"name": "Jack Sparrow", "company": "EasyPost",
+      "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
+      "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+      "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
+      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
+      "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
+      "USPS"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '577'
+      Content-Type:
+      - application/json
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: POST
+    uri: https://api.easypost.com/v2/shipments
+  response:
+    body:
+      string: '{"created_at":"2022-04-26T17:15:51Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361116713403","updated_at":"2022-04-26T17:15:52Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_862c8457c58411ecb621ac1f6bc7b362","object":"Address","created_at":"2022-04-26T17:15:51+00:00","updated_at":"2022-04-26T17:15:51+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_3eb2cd466d504d1cb39271d2c21d82d5","object":"Parcel","created_at":"2022-04-26T17:15:51Z","updated_at":"2022-04-26T17:15:51Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_54ef9db03f8f4704910e40644b78d8c0","created_at":"2022-04-26T17:15:52Z","updated_at":"2022-04-26T17:15:52Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-26T17:15:52Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220426/971fb63038704d9faa96817ee47f5088.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_7af50a4525ce4938a84cb5c092e03add","object":"Rate","created_at":"2022-04-26T17:15:52Z","updated_at":"2022-04-26T17:15:52Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e28d6f27b30145b39d9aab745f0ed331","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e4765b3f9f444db2ab595943ed104bba","object":"Rate","created_at":"2022-04-26T17:15:52Z","updated_at":"2022-04-26T17:15:52Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_e28d6f27b30145b39d9aab745f0ed331","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_335a8754b6d541c6b0a37d71f942dd20","object":"Rate","created_at":"2022-04-26T17:15:52Z","updated_at":"2022-04-26T17:15:52Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e28d6f27b30145b39d9aab745f0ed331","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_1cb0952a552842fdad1a4d7d70fa6d2e","object":"Rate","created_at":"2022-04-26T17:15:52Z","updated_at":"2022-04-26T17:15:52Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e28d6f27b30145b39d9aab745f0ed331","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_1cb0952a552842fdad1a4d7d70fa6d2e","object":"Rate","created_at":"2022-04-26T17:15:52Z","updated_at":"2022-04-26T17:15:52Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e28d6f27b30145b39d9aab745f0ed331","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_2dad63a3160a41f9a036c381d7a99ec6","object":"Tracker","mode":"test","tracking_code":"9400100109361116713403","status":"unknown","status_detail":"unknown","created_at":"2022-04-26T17:15:52Z","updated_at":"2022-04-26T17:15:52Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_e28d6f27b30145b39d9aab745f0ed331","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzJkYWQ2M2EzMTYwYTQxZjlhMDM2YzM4MWQ3YTk5ZWM2"},"to_address":{"id":"adr_8628abe6c58411ec85ceac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:51+00:00","updated_at":"2022-04-26T17:15:52+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_862c8457c58411ecb621ac1f6bc7b362","object":"Address","created_at":"2022-04-26T17:15:51+00:00","updated_at":"2022-04-26T17:15:51+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_8628abe6c58411ec85ceac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:51+00:00","updated_at":"2022-04-26T17:15:52+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_e28d6f27b30145b39d9aab745f0ed331","object":"Shipment"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '6826'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"e7b6ccdb556d5ee9f04bd64e7fd33e3b"
+      expires:
+      - '0'
+      location:
+      - /api/v2/shipments/shp_e28d6f27b30145b39d9aab745f0ed331
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 19bdb4bb626828c7e786b8c0001a66eb
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb3nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
+      x-runtime:
+      - '1.103883'
+      x-version-label:
+      - easypost-202204251804-93ddab36b5-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"pickup": {"address": {"name": "Jack Sparrow", "company": "EasyPost",
+      "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-04-27",
+      "max_datetime": "2022-04-27", "instructions": "Pickup at front door", "shipment":
+      {"id": "shp_e28d6f27b30145b39d9aab745f0ed331"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: POST
+    uri: https://api.easypost.com/v2/pickups
+  response:
+    body:
+      string: '{"id":"pickup_c45a353170c0419db92e7e671f1fb566","object":"Pickup","created_at":"2022-04-26T17:15:53Z","updated_at":"2022-04-26T17:15:53Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-27T00:00:00Z","max_datetime":"2022-04-27T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_86e0e18ac58411ec8613ac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:53+00:00","updated_at":"2022-04-26T17:15:53+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-26T17:15:53Z","updated_at":"2022-04-26T17:15:53Z","carrier":"USPS","pickup_id":"pickup_c45a353170c0419db92e7e671f1fb566","id":"pickuprate_8106d46e5c544fd7a8c22f5885f9fac7","object":"PickupRate"}]}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '1149'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"b04121266c69a8e6128a941c7d1b4387"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 19bdb4bb626828c9e786b8c0001a674b
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb4nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq fde591f008
+      - extlb2nuq fde591f008
+      x-runtime:
+      - '0.854531'
+      x-version-label:
+      - easypost-202204251804-93ddab36b5-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_pickup_retrieve.yaml
+++ b/tests/cassettes/test_pickup_retrieve.yaml
@@ -29,49 +29,28 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xYbW/bNhD+K4a+znFIinrzNyMvWLs2yWKvXTIUAkVSNhtZEiiprl3kv++oF8d2
-        2sRAs2TYEgRIeLw7kfc8PPLum8W1ZKUUISutoUUQIQeIHmAywe4Q0yFB11bfUkWoZVnp1BrGLClk
-        35rLomBTWVjDvz7BKBMSrEtZlKCd5aXKUpj6ZvFKa5nyJUz+MT6GuZwt5zItzVy5zI3R+OTs+OTS
-        uu1bAtYRMvGFpRwmEEi0jKWxh2FaJUnfKkpWVuDZqtKbNFuk4LHUjN+odBryZhEBRQib38B2McbU
-        9WngEVCscvHQRrHZaMRKPguV6L7XjLuvbsraAHRCXhVlNi9ClcZZJ4t1Nof9CA2qZsPGrcWEDgOO
-        XFeKIGJehLHkLGKIcRy7EWJIYGliGH2W3Cx01Nr3HwXqF4SGCD2+0TvFlM1NxN5CAHvjnGmdLcx3
-        snnOUgPZCSuWF1mNaVFqKUsMQtv3exMIfSFT0RvfzRGz2LzsEeOZq9I4GLO0d6oBT1XwzGrgM188
-        GsFgpfIaLoy8+qtVWuqGKIYnsyw1ms76B4RyzlTSRXebcxxWr6QOY8ZVUn+80YLYKQGEU2xtGEsh
-        NUvCkn3dQLpe2o7si9QqVpx1dL4FSqq0qDTboGSmwd2GEcSRy2SNd655AiRA1KUejn0cUepGQWwH
-        nm37ro2EH+F4E/CLxv5xvK/3gNroJDKdljNriNEA9a2FEmbgm/9nUk1nYEnNINcQl1il4C0HQmxw
-        e9GqYWdAt+MO8ciBH6AbJixqdn23kWbmXT3Rb6ORhALiz7lAiEtMkRQR9zliPmWceC4W7Gl2Xp/m
-        nYRiwCvlVNd2cabnYJkamkGMzCJD0bDzR3GsdYBQWVIZRlhDG6FOXKiVMaVf3bVmm98gqKxKyrU4
-        Vons5tQcAnSYp9P1bKUhiNasLPNieHgo4QCaAB8Yo2JQ2IOqOFhA5A/IgM3ZKkvZohjAgT2sFQ63
-        wDg0+0AUk0PJhUOkoJLHLo2kHZHYtaNAeshGNPajweYKchE3q2jAb4SrPLkvlHlC7kvNShqJSeAQ
-        UXNHtIfBDEMXOxGLhC8jn1HHjRlyPeHACfEcDwnhbR6GS4PI0x2F7ZxRSP1FGWZYF1pl2mSNdSKp
-        89CFyUS6IYU3sOs0tXuhwb0ISSlstfyBh+6E95QTVZThtsNadE9RyERB9lkCJZcQP7wlKdcnc0sY
-        TisGmamUUqyvadhoeN9XMVO5uYXrrAWjPPR8LoDN0o0Ipy6xGeEkINhGMQYOxfFGhmW8TtWNLWdh
-        RBzX8WTgB66kwrUZ97GDGbepyziFy+y2v4k+JgEisSQkxjHlse17ARZOJBiL3IB68UugX2fcsUzM
-        Vx9iACGPM6DV2o8BtepeDCBPyADysgwIAgzQB/ANGlAHiUDYPHYi16aUOgyRF2DAqdLFQ9DDxRc8
-        Dn2rtQ/0rer/DXrXQ1hiT/gCwMdUBD4W8EyPMSWuE2P8AtCffM279/UPwCf2wHMeR594A7pv7u9c
-        7oX/d9D+GQq0z93nZcGnuparUrFTSxWcpe1TrBXUWRiwbCL1z+YNvO9D8jVvPH/eaAp7E9SWBKW+
-        CT14vFLuRfBikFRKGkQudTniAaKOiJi9yYFJa78L394Ng+80GxoRRKesK9GNmaeiWqGmpgSLlrvV
-        VzPaweYO1Z+B546369g0O2zbO7HsGj0dnl0A2pK3ihLFd2qX2tWgq2DqIkV8PnHFr2/1nyuRvCdv
-        0NVKqOvjD+p6cplcT353rj5fobP5+8XV6mZxdvzh5mp+sqqZkP2ojUIFCkTXRvFJzJs2CvcIJvS5
-        2yijo99644vR5eX5x+02ymh8dXE+ntxvo5x/PDPtr9540htdTJrWybqb0jaW2k7K6Kx3ejk6O3oz
-        Pjp/oJNygN26AnmOdkqpK/kz7RSzbmr+FhXnNbiNR6l1plvCrXnYFpQd9/c1+wZVaanKymzO9gae
-        5zhQACVZOm2FgCgZ2IEbeMAzNZfhqonUaA6r5ezwXVaEo3QK11Jh3d6aDlBV5EWrheusXen0tc33
-        H2vzRdXSXFuvWec16/w7so55JG9fxxut1lNpkknbVKwbro2EzQ0gIEMDZH5MjGdMT81jr1l+8ypf
-        P/5MufZ9r203d8eveY/u5fdT2wDe82GyXsO4fdZYt38DAAD//wMAmNLVhaoaAAA=
+      string: '{"created_at":"2022-04-26T17:15:40Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361116713342","updated_at":"2022-04-26T17:15:40Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_7f2907f6c58411ec8302ac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:40+00:00","updated_at":"2022-04-26T17:15:40+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_f20fd439f1e24904a0fce18cc4ee689c","object":"Parcel","created_at":"2022-04-26T17:15:40Z","updated_at":"2022-04-26T17:15:40Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_dcda71a1ae1e48babd304081793f31dc","created_at":"2022-04-26T17:15:40Z","updated_at":"2022-04-26T17:15:40Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-26T17:15:40Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220426/192dd5c5388c48f0abe1eba1bad038ec.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_a5c147f4c7ee4e27a19185f94a2d9474","object":"Rate","created_at":"2022-04-26T17:15:40Z","updated_at":"2022-04-26T17:15:40Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_386bc0886ef84189816a0e4ec4b2588b","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e3f26db8364242ff9b8acb03ce9185cb","object":"Rate","created_at":"2022-04-26T17:15:40Z","updated_at":"2022-04-26T17:15:40Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_386bc0886ef84189816a0e4ec4b2588b","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_a8c44b7442f446d0b48334cd05c394d3","object":"Rate","created_at":"2022-04-26T17:15:40Z","updated_at":"2022-04-26T17:15:40Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_386bc0886ef84189816a0e4ec4b2588b","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_9133c5f533124e1d99ab2ee54bff0ecf","object":"Rate","created_at":"2022-04-26T17:15:40Z","updated_at":"2022-04-26T17:15:40Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_386bc0886ef84189816a0e4ec4b2588b","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_a8c44b7442f446d0b48334cd05c394d3","object":"Rate","created_at":"2022-04-26T17:15:40Z","updated_at":"2022-04-26T17:15:40Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_386bc0886ef84189816a0e4ec4b2588b","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_2fcb53c0891e44dcbb8d2497647ab20a","object":"Tracker","mode":"test","tracking_code":"9400100109361116713342","status":"unknown","status_detail":"unknown","created_at":"2022-04-26T17:15:40Z","updated_at":"2022-04-26T17:15:40Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_386bc0886ef84189816a0e4ec4b2588b","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzJmY2I1M2MwODkxZTQ0ZGNiYjhkMjQ5NzY0N2FiMjBh"},"to_address":{"id":"adr_7f27187dc58411ecb49cac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T17:15:40+00:00","updated_at":"2022-04-26T17:15:40+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_7f2907f6c58411ec8302ac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:40+00:00","updated_at":"2022-04-26T17:15:40+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_7f27187dc58411ecb49cac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T17:15:40+00:00","updated_at":"2022-04-26T17:15:40+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_386bc0886ef84189816a0e4ec4b2588b","object":"Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '6826'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"c5a6e0d6aa2c2d4946019135bba29979"
+      - W/"01a310072ed75ef6986e0c416546733e"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_78cd300e6b2c4623a2c292130f1220ff
+      - /api/v2/shipments/shp_386bc0886ef84189816a0e4ec4b2588b
       pragma:
       - no-cache
       referrer-policy:
@@ -87,20 +66,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42efa6255a55ce77997cc00312936
+      - 19bdb4bd626828bce786b8a4001a6329
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '1.160977'
+      - '0.909961'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -109,9 +88,9 @@ interactions:
 - request:
     body: '{"pickup": {"address": {"name": "Jack Sparrow", "company": "EasyPost",
       "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
-      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-04-13",
-      "max_datetime": "2022-04-13", "instructions": "Pickup at front door", "shipment":
-      {"id": "shp_78cd300e6b2c4623a2c292130f1220ff"}}}'
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-04-27",
+      "max_datetime": "2022-04-27", "instructions": "Pickup at front door", "shipment":
+      {"id": "shp_386bc0886ef84189816a0e4ec4b2588b"}}}'
     headers:
       Accept:
       - '*/*'
@@ -133,26 +112,19 @@ interactions:
     uri: https://api.easypost.com/v2/pickups
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5RUTY+bMBD9K4hruxU2EEJuq2576KGKmvTSaoUGe2jdEBsZs7tplP/esWHZdHtI
-        ijgw4zdfb545xkrGq7hTYjd0FYck5/USlwXKrEmLktdFjhlyxssmW5Tx29jUv1A4ClmHEPIIi+BQ
-        VuC9POH8JsluGN+yxYplK86+EWbo5EXM3kikU4e9I6t34Iae7EHvtHnU5LLYoEUtCKWHtqUIpSuf
-        16k9nudNt0myCm/IC09XoFRfgRBm0K4CKS32VLuBtkc60r2zg3DK6H4ePAIXNdZoF0ljrC9DIfAD
-        CfH9nkgxulF2Dz7oud0573EkHaStSiFYBqyuoagZQwG8TECwZlGLok4X/Jzx2yn+MuVvwlhX8D4D
-        NQRyPoHYRZsOrDWPvo7Zd6APdPAB+sPaTJuxiI6RM10uoy3tpkcto83LGffNdi7iPrNQzifYgI4+
-        WtBC9cJM+/UV39+S8Vt19FlmLClCVdqC9UFfN2R2P432yHx+yIl7UO2sg7+UI6h7hbZqQKg2FB9R
-        xJ2SqJ2CObBBiRbaypFE/EpGb2jtle8BrWqUgEkEx9PppdCkm2nz01WylMN7jq91jfZBeQnHn/HJ
-        3cHBC3ukInkXViEG61U+zn93edv8igsWMFO/Ie86MDu2+p9/gDO4b7xKy3RRiCxfNmmT1QgAeZ5y
-        AWmWYoKZ/Pen8cXPe7o//QEAAP//AwDnOrCifQQAAA==
+      string: '{"id":"pickup_0a9143ce4ad84dd9bf8962323379ff7d","object":"Pickup","created_at":"2022-04-26T17:15:41Z","updated_at":"2022-04-26T17:15:41Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-27T00:00:00Z","max_datetime":"2022-04-27T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_7fbc64a0c58411ec832aac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:41+00:00","updated_at":"2022-04-26T17:15:41+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-26T17:15:42Z","updated_at":"2022-04-26T17:15:42Z","carrier":"USPS","pickup_id":"pickup_0a9143ce4ad84dd9bf8962323379ff7d","id":"pickuprate_b967c9d8b222498f9fdbdd24f1c9b8c9","object":"PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '1149'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"d7f9aab57ebac8c006d68708ce9cc42c"
+      - W/"2663a16abcedfab862b9ba3af4aba7f3"
       expires:
       - '0'
       pragma:
@@ -165,25 +137,27 @@ interactions:
       - chunked
       x-backend:
       - easypost
+      x-canary:
+      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42efa6255a55de77997cc003129c1
+      - 19bdb4bd626828bde786b8a4001a6365
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb7nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb2nuq fde591f008
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.876281'
+      - '1.823778'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -205,29 +179,22 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: GET
-    uri: https://api.easypost.com/v2/pickups/pickup_2a052b8e87ed4f3792b75e4e2129f469
+    uri: https://api.easypost.com/v2/pickups/pickup_0a9143ce4ad84dd9bf8962323379ff7d
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5RUTY+bMBD9K4hruxU2EEJuq2576KGKmvTSaoUGe2jdEBsZs7tplP/esWHZdHtI
-        ijgw4zdfb545xkrGq7hTYjd0FYck5/USlwXKrEmLktdFjhlyxssmW5Tx29jUv1A4ClmHEPIIi+BQ
-        VuC9POH8JsluGN+yxYplK86+EWbo5EXM3kikU4e9I6t34Iae7EHvtHnU5LLYoEUtCKWHtqUIpSuf
-        16k9nudNt0myCm/IC09XoFRfgRBm0K4CKS32VLuBtkc60r2zg3DK6H4ePAIXNdZoF0ljrC9DIfAD
-        CfH9nkgxulF2Dz7oud0573EkHaStSiFYBqyuoagZQwG8TECwZlGLok4X/Jzx2yn+MuVvwlhX8D4D
-        NQRyPoHYRZsOrDWPvo7Zd6APdPAB+sPaTJuxiI6RM10uoy3tpkcto83LGffNdi7iPrNQzifYgI4+
-        WtBC9cJM+/UV39+S8Vt19FlmLClCVdqC9UFfN2R2P432yHx+yIl7UO2sg7+UI6h7hbZqQKg2FB9R
-        xJ2SqJ2CObBBiRbaypFE/EpGb2jtle8BrWqUgEkEx9PppdCkm2nz01WylMN7jq91jfZBeQnHn/HJ
-        3cHBC3ukInkXViEG61U+zn93edv8igsWMFO/Ie86MDu2+p9/gDO4b7xKy3RRiCxfNmmT1QgAeZ5y
-        AWmWYoKZ/Pen8cXPe7o//QEAAP//AwDnOrCifQQAAA==
+      string: '{"id":"pickup_0a9143ce4ad84dd9bf8962323379ff7d","object":"Pickup","created_at":"2022-04-26T17:15:41Z","updated_at":"2022-04-26T17:15:41Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-27T00:00:00Z","max_datetime":"2022-04-27T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_7fbc64a0c58411ec832aac1f6bc72124","object":"Address","created_at":"2022-04-26T17:15:41+00:00","updated_at":"2022-04-26T17:15:41+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-26T17:15:42Z","updated_at":"2022-04-26T17:15:42Z","carrier":"USPS","pickup_id":"pickup_0a9143ce4ad84dd9bf8962323379ff7d","id":"pickuprate_b967c9d8b222498f9fdbdd24f1c9b8c9","object":"PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
-      content-encoding:
-      - gzip
+      content-length:
+      - '1149'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"d7f9aab57ebac8c006d68708ce9cc42c"
+      - W/"2663a16abcedfab862b9ba3af4aba7f3"
       expires:
       - '0'
       pragma:
@@ -245,20 +212,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bcd42efa6255a55ee77997cc00312a24
+      - 19bdb4bd626828bee786b8a4001a63f8
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb4nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.071052'
+      - '0.044855'
       x-version-label:
-      - easypost-202204112244-205415e174-master
+      - easypost-202204251804-93ddab36b5-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_get_lowest_smartrate.yaml
+++ b/tests/cassettes/test_shipment_get_lowest_smartrate.yaml
@@ -27,15 +27,15 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-04-26T19:57:19Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-26T19:57:19Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_142e8c22c59b11ec960dac1f6bc72124","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+      string: '{"created_at":"2022-04-28T18:59:21Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-28T18:59:21Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_50039c8bc72511ec879dac1f6b0a0d1e","object":"Address","created_at":"2022-04-28T18:59:21+00:00","updated_at":"2022-04-28T18:59:21+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_b93f91096b2d42c99ea677df58341e77","object":"Parcel","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_5f96248829b948e787ac62d8d315552a","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7fd10920fa114cc282fa28f58070fe8d","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_bd317f3ad5984191aef6aed802cac91e","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7cbc73bf40a0494f9515d8484e570ecd","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_142cdc2dc59b11ec9ee6ac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_17345230780f4d678c9238bddd58a352","object":"Parcel","created_at":"2022-04-28T18:59:21Z","updated_at":"2022-04-28T18:59:21Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_076a98d189974521aa38e589a7f56ebe","object":"Rate","created_at":"2022-04-28T18:59:21Z","updated_at":"2022-04-28T18:59:21Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e984ef2c29b6496da5b8f285a7a7a611","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_40b1192ce3d8411da5a24dd9ea3a9d44","object":"Rate","created_at":"2022-04-28T18:59:21Z","updated_at":"2022-04-28T18:59:21Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e984ef2c29b6496da5b8f285a7a7a611","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_788645615e2040f8a369a60b1786491d","object":"Rate","created_at":"2022-04-28T18:59:21Z","updated_at":"2022-04-28T18:59:21Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e984ef2c29b6496da5b8f285a7a7a611","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_2241d0fec79846f8b19d9f4b163db825","object":"Rate","created_at":"2022-04-28T18:59:21Z","updated_at":"2022-04-28T18:59:21Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_e984ef2c29b6496da5b8f285a7a7a611","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_50021074c72511ec879cac1f6b0a0d1e","object":"Address","created_at":"2022-04-28T18:59:21+00:00","updated_at":"2022-04-28T18:59:21+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_142e8c22c59b11ec960dac1f6bc72124","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_50039c8bc72511ec879dac1f6b0a0d1e","object":"Address","created_at":"2022-04-28T18:59:21+00:00","updated_at":"2022-04-28T18:59:21+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_142cdc2dc59b11ec9ee6ac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_50021074c72511ec879cac1f6b0a0d1e","object":"Address","created_at":"2022-04-28T18:59:21+00:00","updated_at":"2022-04-28T18:59:21+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_dd320061245b49638c4154f250a0fddd","object":"Shipment"}'
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_e984ef2c29b6496da5b8f285a7a7a611","object":"Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -44,11 +44,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"e35bdf92a7b0f68cf82a7b16e8865529"
+      - W/"6e0dc254ebb4eadba7870cc2c82258c9"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_dd320061245b49638c4154f250a0fddd
+      - /api/v2/shipments/shp_e984ef2c29b6496da5b8f285a7a7a611
       pragma:
       - no-cache
       referrer-policy:
@@ -66,7 +66,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 50938b4862684e9fe7872f9d00259e6c
+      - f1b599b4626ae409e7873002000ce710
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -75,11 +75,11 @@ interactions:
       - none
       x-proxied:
       - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.239187'
+      - '0.270848'
       x-version-label:
-      - easypost-202204261846-08e93d28b2-master
+      - easypost-202204281816-b5dc9c446b-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -101,10 +101,10 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_dd320061245b49638c4154f250a0fddd/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_e984ef2c29b6496da5b8f285a7a7a611/smartrate
   response:
     body:
-      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_5f96248829b948e787ac62d8d315552a","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_7fd10920fa114cc282fa28f58070fe8d","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_bd317f3ad5984191aef6aed802cac91e","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_7cbc73bf40a0494f9515d8484e570ecd","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-26T19:57:19Z"}]}'
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T18:59:21Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_076a98d189974521aa38e589a7f56ebe","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_e984ef2c29b6496da5b8f285a7a7a611","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-28T18:59:21Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T18:59:21Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_40b1192ce3d8411da5a24dd9ea3a9d44","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_e984ef2c29b6496da5b8f285a7a7a611","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-28T18:59:21Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T18:59:21Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_788645615e2040f8a369a60b1786491d","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_e984ef2c29b6496da5b8f285a7a7a611","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-28T18:59:21Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T18:59:21Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_2241d0fec79846f8b19d9f4b163db825","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_e984ef2c29b6496da5b8f285a7a7a611","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-28T18:59:21Z"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -113,7 +113,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"74dfd7c78d669c155ffd1fd2dfe8e33a"
+      - W/"fe2fd8f33d9108258c405815a1041d90"
       expires:
       - '0'
       pragma:
@@ -131,20 +131,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 50938b4862684e9fe7872f9d00259e83
+      - f1b599b4626ae409e7873002000ce720
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb3nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb2nuq fde591f008
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.091166'
+      - '0.067815'
       x-version-label:
-      - easypost-202204261846-08e93d28b2-master
+      - easypost-202204281816-b5dc9c446b-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_get_lowest_smartrate.yaml
+++ b/tests/cassettes/test_shipment_get_lowest_smartrate.yaml
@@ -1,0 +1,153 @@
+interactions:
+- request:
+    body: '{"shipment": {"to_address": {"name": "Jack Sparrow", "company": "EasyPost",
+      "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
+      "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+      "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
+      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '477'
+      Content-Type:
+      - application/json
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: POST
+    uri: https://api.easypost.com/v2/shipments
+  response:
+    body:
+      string: '{"created_at":"2022-04-26T19:57:19Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-26T19:57:19Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_142e8c22c59b11ec960dac1f6bc72124","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_b93f91096b2d42c99ea677df58341e77","object":"Parcel","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_5f96248829b948e787ac62d8d315552a","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7fd10920fa114cc282fa28f58070fe8d","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_bd317f3ad5984191aef6aed802cac91e","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7cbc73bf40a0494f9515d8484e570ecd","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_142cdc2dc59b11ec9ee6ac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_142e8c22c59b11ec960dac1f6bc72124","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_142cdc2dc59b11ec9ee6ac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_dd320061245b49638c4154f250a0fddd","object":"Shipment"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4729'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"e35bdf92a7b0f68cf82a7b16e8865529"
+      expires:
+      - '0'
+      location:
+      - /api/v2/shipments/shp_dd320061245b49638c4154f250a0fddd
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-canary:
+      - direct
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 50938b4862684e9fe7872f9d00259e6c
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb7nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq fde591f008
+      - extlb1nuq fde591f008
+      x-runtime:
+      - '0.239187'
+      x-version-label:
+      - easypost-202204261846-08e93d28b2-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: GET
+    uri: https://api.easypost.com/v2/shipments/shp_dd320061245b49638c4154f250a0fddd/smartrate
+  response:
+    body:
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_5f96248829b948e787ac62d8d315552a","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_7fd10920fa114cc282fa28f58070fe8d","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_bd317f3ad5984191aef6aed802cac91e","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_7cbc73bf40a0494f9515d8484e570ecd","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-26T19:57:19Z"}]}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2619'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"74dfd7c78d669c155ffd1fd2dfe8e33a"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 50938b4862684e9fe7872f9d00259e83
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb3nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq fde591f008
+      - extlb1nuq fde591f008
+      x-runtime:
+      - '0.091166'
+      x-version-label:
+      - easypost-202204261846-08e93d28b2-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_shipment_lowest_rate.yaml
+++ b/tests/cassettes/test_shipment_lowest_rate.yaml
@@ -33,17 +33,17 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-04-26T16:59:14Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-04-26T16:59:14Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_85be9278977c4dc093c20654d6fb5bd3","object":"CustomsInfo","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_626bcf0b73024b6b852f8edcc3ea70c8","object":"CustomsItem","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_33bd430dc58211ec8394ac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T16:59:14+00:00","updated_at":"2022-04-26T16:59:14+00:00","name":"Jack
+      string: '{"created_at":"2022-04-28T18:57:34Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-04-28T18:57:34Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_2b0e819d57f44670a6c2b773091d6e46","object":"CustomsInfo","created_at":"2022-04-28T18:57:34Z","updated_at":"2022-04-28T18:57:34Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
+        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_25b0a95924f3436f8833dda24d887cf5","object":"CustomsItem","created_at":"2022-04-28T18:57:34Z","updated_at":"2022-04-28T18:57:34Z","description":"Sweet
+        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_103ed611c72511ec8613ac1f6bc72124","object":"Address","created_at":"2022-04-28T18:57:34+00:00","updated_at":"2022-04-28T18:57:34+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_1f6e582097cd400bb1d294ad99d19687","object":"Parcel","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_9871f093b9354f189753cadfbc8e97e2","object":"Rate","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9127354bd9cb4a568b84a272d4fbde8e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_9374d7bf72d44b69892d9d1f108b8f1a","object":"Rate","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9127354bd9cb4a568b84a272d4fbde8e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_cae2d2443ea941959d96419daa3ac8e2","object":"Rate","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9127354bd9cb4a568b84a272d4fbde8e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_777a2f51b0be4e9aa68505da20b96604","object":"Rate","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9127354bd9cb4a568b84a272d4fbde8e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_33bb7674c58211ec802bac1f6bc7b362","object":"Address","created_at":"2022-04-26T16:59:14+00:00","updated_at":"2022-04-26T16:59:14+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_8a439a1e8e8a4bc79be344a854a415ef","object":"Parcel","created_at":"2022-04-28T18:57:34Z","updated_at":"2022-04-28T18:57:34Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_ff3d6ffaee6c46ee8a5a0e8d394b38cc","object":"Rate","created_at":"2022-04-28T18:57:34Z","updated_at":"2022-04-28T18:57:34Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_efa76747ef7142ec91858b4c52ae9297","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_dad038bfeb844531972ea935cffb468a","object":"Rate","created_at":"2022-04-28T18:57:34Z","updated_at":"2022-04-28T18:57:34Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_efa76747ef7142ec91858b4c52ae9297","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_bd463d0e6b064dc8a2e41a0560192c2a","object":"Rate","created_at":"2022-04-28T18:57:34Z","updated_at":"2022-04-28T18:57:34Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_efa76747ef7142ec91858b4c52ae9297","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_b18ba7be0b1f43bcab6aefdb288f1d80","object":"Rate","created_at":"2022-04-28T18:57:34Z","updated_at":"2022-04-28T18:57:34Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_efa76747ef7142ec91858b4c52ae9297","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_103ccdf9c72511eca6c7ac1f6bc7b362","object":"Address","created_at":"2022-04-28T18:57:34+00:00","updated_at":"2022-04-28T18:57:34+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_33bd430dc58211ec8394ac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T16:59:14+00:00","updated_at":"2022-04-26T16:59:14+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_103ed611c72511ec8613ac1f6bc72124","object":"Address","created_at":"2022-04-28T18:57:34+00:00","updated_at":"2022-04-28T18:57:34+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_33bb7674c58211ec802bac1f6bc7b362","object":"Address","created_at":"2022-04-26T16:59:14+00:00","updated_at":"2022-04-26T16:59:14+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_103ccdf9c72511eca6c7ac1f6bc7b362","object":"Address","created_at":"2022-04-28T18:57:34+00:00","updated_at":"2022-04-28T18:57:34+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_9127354bd9cb4a568b84a272d4fbde8e","object":"Shipment"}'
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_efa76747ef7142ec91858b4c52ae9297","object":"Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -52,11 +52,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"2952f7fd65b2c510c571ecea609afe56"
+      - W/"91633abe966841fad14c77f99fcf1245"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_9127354bd9cb4a568b84a272d4fbde8e
+      - /api/v2/shipments/shp_efa76747ef7142ec91858b4c52ae9297
       pragma:
       - no-cache
       referrer-policy:
@@ -72,21 +72,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 86551bd2626824e2e786b41f0013d55e
+      - f1b599b4626ae39ee7872fc0000cc90c
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - intlb2wdc fde591f008
-      - extlb3wdc fde591f008
+      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.378448'
+      - '0.288933'
       x-version-label:
-      - easypost-202204251804-93ddab36b5-master
+      - easypost-202204281816-b5dc9c446b-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_lowest_rate.yaml
+++ b/tests/cassettes/test_shipment_lowest_rate.yaml
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    body: '{"shipment": {"to_address": {"name": "Jack Sparrow", "company": "EasyPost",
+      "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
+      "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+      "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
+      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "customs_info":
+      {"eel_pfc": "NOEEI 30.37(a)", "customs_certify": true, "customs_signer": "Steve
+      Brule", "contents_type": "merchandise", "contents_explanation": "", "restriction_type":
+      "none", "non_delivery_option": "return", "customs_items": [{"description": "Sweet
+      shirts", "quantity": 2, "weight": 11, "value": 23, "hs_tariff_number": "654321",
+      "origin_country": "US"}]}, "options": {"label_format": "PNG", "invoice_number":
+      "123"}, "reference": "123"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '932'
+      Content-Type:
+      - application/json
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: POST
+    uri: https://api.easypost.com/v2/shipments
+  response:
+    body:
+      string: '{"created_at":"2022-04-26T16:59:14Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-04-26T16:59:14Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_85be9278977c4dc093c20654d6fb5bd3","object":"CustomsInfo","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
+        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_626bcf0b73024b6b852f8edcc3ea70c8","object":"CustomsItem","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","description":"Sweet
+        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_33bd430dc58211ec8394ac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T16:59:14+00:00","updated_at":"2022-04-26T16:59:14+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_1f6e582097cd400bb1d294ad99d19687","object":"Parcel","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_9871f093b9354f189753cadfbc8e97e2","object":"Rate","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9127354bd9cb4a568b84a272d4fbde8e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_9374d7bf72d44b69892d9d1f108b8f1a","object":"Rate","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9127354bd9cb4a568b84a272d4fbde8e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_cae2d2443ea941959d96419daa3ac8e2","object":"Rate","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9127354bd9cb4a568b84a272d4fbde8e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_777a2f51b0be4e9aa68505da20b96604","object":"Rate","created_at":"2022-04-26T16:59:14Z","updated_at":"2022-04-26T16:59:14Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9127354bd9cb4a568b84a272d4fbde8e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_33bb7674c58211ec802bac1f6bc7b362","object":"Address","created_at":"2022-04-26T16:59:14+00:00","updated_at":"2022-04-26T16:59:14+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_33bd430dc58211ec8394ac1f6b0a0d1e","object":"Address","created_at":"2022-04-26T16:59:14+00:00","updated_at":"2022-04-26T16:59:14+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_33bb7674c58211ec802bac1f6bc7b362","object":"Address","created_at":"2022-04-26T16:59:14+00:00","updated_at":"2022-04-26T16:59:14+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_9127354bd9cb4a568b84a272d4fbde8e","object":"Shipment"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '5563'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"2952f7fd65b2c510c571ecea609afe56"
+      expires:
+      - '0'
+      location:
+      - /api/v2/shipments/shp_9127354bd9cb4a568b84a272d4fbde8e
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 86551bd2626824e2e786b41f0013d55e
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb6nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq fde591f008
+      - intlb2wdc fde591f008
+      - extlb3wdc fde591f008
+      x-runtime:
+      - '0.378448'
+      x-version-label:
+      - easypost-202204251804-93ddab36b5-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/cassettes/test_shipment_lowest_smartrate.yaml
+++ b/tests/cassettes/test_shipment_lowest_smartrate.yaml
@@ -27,15 +27,15 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-04-26T19:57:19Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-26T19:57:19Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_142e8c22c59b11ec960dac1f6bc72124","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+      string: '{"created_at":"2022-04-27T17:34:21Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-27T17:34:21Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_46288e5dc65011ecb281ac1f6bc7b362","object":"Address","created_at":"2022-04-27T17:34:21+00:00","updated_at":"2022-04-27T17:34:21+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_b93f91096b2d42c99ea677df58341e77","object":"Parcel","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_5f96248829b948e787ac62d8d315552a","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7fd10920fa114cc282fa28f58070fe8d","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_bd317f3ad5984191aef6aed802cac91e","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7cbc73bf40a0494f9515d8484e570ecd","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_142cdc2dc59b11ec9ee6ac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_7f7ec7395a734f39b35be4b2f72becd7","object":"Parcel","created_at":"2022-04-27T17:34:21Z","updated_at":"2022-04-27T17:34:21Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_ae07ed845b784357a514b6ace2733d37","object":"Rate","created_at":"2022-04-27T17:34:22Z","updated_at":"2022-04-27T17:34:22Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_2ce9d337d00b46e49040c30f890d9110","object":"Rate","created_at":"2022-04-27T17:34:22Z","updated_at":"2022-04-27T17:34:22Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7106f366c14347bca94a26c20f060274","object":"Rate","created_at":"2022-04-27T17:34:22Z","updated_at":"2022-04-27T17:34:22Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_ea7986c90db74b0a9d42b7209e76723f","object":"Rate","created_at":"2022-04-27T17:34:22Z","updated_at":"2022-04-27T17:34:22Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_4626da54c65011ec8a69ac1f6bc72124","object":"Address","created_at":"2022-04-27T17:34:21+00:00","updated_at":"2022-04-27T17:34:21+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_142e8c22c59b11ec960dac1f6bc72124","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_46288e5dc65011ecb281ac1f6bc7b362","object":"Address","created_at":"2022-04-27T17:34:21+00:00","updated_at":"2022-04-27T17:34:21+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_142cdc2dc59b11ec9ee6ac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_4626da54c65011ec8a69ac1f6bc72124","object":"Address","created_at":"2022-04-27T17:34:21+00:00","updated_at":"2022-04-27T17:34:21+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_dd320061245b49638c4154f250a0fddd","object":"Shipment"}'
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_a1ef858c63614243876c9be63bd5a899","object":"Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -44,11 +44,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"e35bdf92a7b0f68cf82a7b16e8865529"
+      - W/"9edebaafad92aa4f440e27b27931b580"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_dd320061245b49638c4154f250a0fddd
+      - /api/v2/shipments/shp_a1ef858c63614243876c9be63bd5a899
       pragma:
       - no-cache
       referrer-policy:
@@ -59,27 +59,25 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 50938b4862684e9fe7872f9d00259e6c
+      - 19bdb4bb62697e9de7873bbd007bb13f
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7nuq
+      - bigweb1nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq fde591f008
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.239187'
+      - '0.262978'
       x-version-label:
-      - easypost-202204261846-08e93d28b2-master
+      - easypost-202204262114-afef977f90-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -101,10 +99,10 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_dd320061245b49638c4154f250a0fddd/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_a1ef858c63614243876c9be63bd5a899/smartrate
   response:
     body:
-      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_5f96248829b948e787ac62d8d315552a","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_7fd10920fa114cc282fa28f58070fe8d","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_bd317f3ad5984191aef6aed802cac91e","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_7cbc73bf40a0494f9515d8484e570ecd","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-26T19:57:19Z"}]}'
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_ae07ed845b784357a514b6ace2733d37","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_2ce9d337d00b46e49040c30f890d9110","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_7106f366c14347bca94a26c20f060274","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_ea7986c90db74b0a9d42b7209e76723f","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-27T17:34:22Z"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -113,7 +111,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"74dfd7c78d669c155ffd1fd2dfe8e33a"
+      - W/"ce610950da599b74c0445da96bf4d3b8"
       expires:
       - '0'
       pragma:
@@ -131,7 +129,137 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 50938b4862684e9fe7872f9d00259e83
+      - 19bdb4bb62697e9ee7873bbd007bb15a
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb2nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
+      x-runtime:
+      - '0.093497'
+      x-version-label:
+      - easypost-202204262114-afef977f90-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: GET
+    uri: https://api.easypost.com/v2/shipments/shp_a1ef858c63614243876c9be63bd5a899/smartrate
+  response:
+    body:
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_ae07ed845b784357a514b6ace2733d37","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_2ce9d337d00b46e49040c30f890d9110","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_7106f366c14347bca94a26c20f060274","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_ea7986c90db74b0a9d42b7209e76723f","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-27T17:34:22Z"}]}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2619'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"ce610950da599b74c0445da96bf4d3b8"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 19bdb4bb62697e9ee7873bbd007bb182
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb4nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq fde591f008
+      - extlb2nuq fde591f008
+      x-runtime:
+      - '0.082547'
+      x-version-label:
+      - easypost-202204262114-afef977f90-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: GET
+    uri: https://api.easypost.com/v2/shipments/shp_a1ef858c63614243876c9be63bd5a899/smartrate
+  response:
+    body:
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_ae07ed845b784357a514b6ace2733d37","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_2ce9d337d00b46e49040c30f890d9110","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_7106f366c14347bca94a26c20f060274","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_ea7986c90db74b0a9d42b7209e76723f","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-27T17:34:22Z"}]}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2619'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"ce610950da599b74c0445da96bf4d3b8"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 19bdb4bb62697e9ee7873bbd007bb190
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -139,12 +267,12 @@ interactions:
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq fde591f008
+      - intlb1nuq fde591f008
+      - extlb2nuq fde591f008
       x-runtime:
-      - '0.091166'
+      - '0.096445'
       x-version-label:
-      - easypost-202204261846-08e93d28b2-master
+      - easypost-202204262114-afef977f90-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_lowest_smartrate.yaml
+++ b/tests/cassettes/test_shipment_lowest_smartrate.yaml
@@ -1,0 +1,153 @@
+interactions:
+- request:
+    body: '{"shipment": {"to_address": {"name": "Jack Sparrow", "company": "EasyPost",
+      "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
+      "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+      "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
+      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '477'
+      Content-Type:
+      - application/json
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: POST
+    uri: https://api.easypost.com/v2/shipments
+  response:
+    body:
+      string: '{"created_at":"2022-04-26T19:57:19Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-26T19:57:19Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_142e8c22c59b11ec960dac1f6bc72124","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_b93f91096b2d42c99ea677df58341e77","object":"Parcel","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_5f96248829b948e787ac62d8d315552a","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7fd10920fa114cc282fa28f58070fe8d","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_bd317f3ad5984191aef6aed802cac91e","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7cbc73bf40a0494f9515d8484e570ecd","object":"Rate","created_at":"2022-04-26T19:57:19Z","updated_at":"2022-04-26T19:57:19Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_dd320061245b49638c4154f250a0fddd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_142cdc2dc59b11ec9ee6ac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_142e8c22c59b11ec960dac1f6bc72124","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_142cdc2dc59b11ec9ee6ac1f6bc7bdc6","object":"Address","created_at":"2022-04-26T19:57:19+00:00","updated_at":"2022-04-26T19:57:19+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_dd320061245b49638c4154f250a0fddd","object":"Shipment"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4729'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"e35bdf92a7b0f68cf82a7b16e8865529"
+      expires:
+      - '0'
+      location:
+      - /api/v2/shipments/shp_dd320061245b49638c4154f250a0fddd
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-canary:
+      - direct
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 50938b4862684e9fe7872f9d00259e6c
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb7nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq fde591f008
+      - extlb1nuq fde591f008
+      x-runtime:
+      - '0.239187'
+      x-version-label:
+      - easypost-202204261846-08e93d28b2-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: GET
+    uri: https://api.easypost.com/v2/shipments/shp_dd320061245b49638c4154f250a0fddd/smartrate
+  response:
+    body:
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_5f96248829b948e787ac62d8d315552a","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_7fd10920fa114cc282fa28f58070fe8d","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_bd317f3ad5984191aef6aed802cac91e","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-26T19:57:19Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-26T19:57:19Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_7cbc73bf40a0494f9515d8484e570ecd","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_dd320061245b49638c4154f250a0fddd","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-26T19:57:19Z"}]}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2619'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"74dfd7c78d669c155ffd1fd2dfe8e33a"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 50938b4862684e9fe7872f9d00259e83
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb3nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq fde591f008
+      - extlb1nuq fde591f008
+      x-runtime:
+      - '0.091166'
+      x-version-label:
+      - easypost-202204261846-08e93d28b2-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_shipment_lowest_smartrate.yaml
+++ b/tests/cassettes/test_shipment_lowest_smartrate.yaml
@@ -27,15 +27,15 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-04-27T17:34:21Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-27T17:34:21Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_46288e5dc65011ecb281ac1f6bc7b362","object":"Address","created_at":"2022-04-27T17:34:21+00:00","updated_at":"2022-04-27T17:34:21+00:00","name":"Jack
+      string: '{"created_at":"2022-04-28T19:01:30Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-28T19:01:30Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_9cecadc6c72511eca837ac1f6bc72124","object":"Address","created_at":"2022-04-28T19:01:30+00:00","updated_at":"2022-04-28T19:01:30+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_7f7ec7395a734f39b35be4b2f72becd7","object":"Parcel","created_at":"2022-04-27T17:34:21Z","updated_at":"2022-04-27T17:34:21Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_ae07ed845b784357a514b6ace2733d37","object":"Rate","created_at":"2022-04-27T17:34:22Z","updated_at":"2022-04-27T17:34:22Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_2ce9d337d00b46e49040c30f890d9110","object":"Rate","created_at":"2022-04-27T17:34:22Z","updated_at":"2022-04-27T17:34:22Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7106f366c14347bca94a26c20f060274","object":"Rate","created_at":"2022-04-27T17:34:22Z","updated_at":"2022-04-27T17:34:22Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_ea7986c90db74b0a9d42b7209e76723f","object":"Rate","created_at":"2022-04-27T17:34:22Z","updated_at":"2022-04-27T17:34:22Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_4626da54c65011ec8a69ac1f6bc72124","object":"Address","created_at":"2022-04-27T17:34:21+00:00","updated_at":"2022-04-27T17:34:21+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_cde1dc99be6d405591bf81648dd01fd2","object":"Parcel","created_at":"2022-04-28T19:01:30Z","updated_at":"2022-04-28T19:01:30Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_eb4654fab59d4b46a55eb5a500c8729f","object":"Rate","created_at":"2022-04-28T19:01:30Z","updated_at":"2022-04-28T19:01:30Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_00a095c4c0da4f639ae00c0bb1187759","object":"Rate","created_at":"2022-04-28T19:01:30Z","updated_at":"2022-04-28T19:01:30Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_5518eb5014cc4ebc838b1c37a85680e2","object":"Rate","created_at":"2022-04-28T19:01:30Z","updated_at":"2022-04-28T19:01:30Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_f251402c3ed34f0abd73dad02afdc24d","object":"Rate","created_at":"2022-04-28T19:01:30Z","updated_at":"2022-04-28T19:01:30Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_9cea8d92c72511eca834ac1f6bc72124","object":"Address","created_at":"2022-04-28T19:01:30+00:00","updated_at":"2022-04-28T19:01:30+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_46288e5dc65011ecb281ac1f6bc7b362","object":"Address","created_at":"2022-04-27T17:34:21+00:00","updated_at":"2022-04-27T17:34:21+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_9cecadc6c72511eca837ac1f6bc72124","object":"Address","created_at":"2022-04-28T19:01:30+00:00","updated_at":"2022-04-28T19:01:30+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_4626da54c65011ec8a69ac1f6bc72124","object":"Address","created_at":"2022-04-27T17:34:21+00:00","updated_at":"2022-04-27T17:34:21+00:00","name":"Jack
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_9cea8d92c72511eca834ac1f6bc72124","object":"Address","created_at":"2022-04-28T19:01:30+00:00","updated_at":"2022-04-28T19:01:30+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_a1ef858c63614243876c9be63bd5a899","object":"Shipment"}'
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_09d34a4c766c4164b068a7aaf1921230","object":"Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -44,11 +44,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"9edebaafad92aa4f440e27b27931b580"
+      - W/"babb6f5875f0f46860b4c824e0351171"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_a1ef858c63614243876c9be63bd5a899
+      - /api/v2/shipments/shp_09d34a4c766c4164b068a7aaf1921230
       pragma:
       - no-cache
       referrer-policy:
@@ -64,20 +64,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 19bdb4bb62697e9de7873bbd007bb13f
+      - f1b599b7626ae48ae7873338000d1356
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
+      - intlb2nuq fde591f008
       - extlb2nuq fde591f008
       x-runtime:
-      - '0.262978'
+      - '0.308983'
       x-version-label:
-      - easypost-202204262114-afef977f90-master
+      - easypost-202204281816-b5dc9c446b-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -99,10 +99,10 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_a1ef858c63614243876c9be63bd5a899/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_09d34a4c766c4164b068a7aaf1921230/smartrate
   response:
     body:
-      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_ae07ed845b784357a514b6ace2733d37","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_2ce9d337d00b46e49040c30f890d9110","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_7106f366c14347bca94a26c20f060274","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_ea7986c90db74b0a9d42b7209e76723f","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-27T17:34:22Z"}]}'
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_eb4654fab59d4b46a55eb5a500c8729f","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-28T19:01:30Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_00a095c4c0da4f639ae00c0bb1187759","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-28T19:01:30Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_5518eb5014cc4ebc838b1c37a85680e2","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-28T19:01:30Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_f251402c3ed34f0abd73dad02afdc24d","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-28T19:01:30Z"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -111,7 +111,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"ce610950da599b74c0445da96bf4d3b8"
+      - W/"9cc7e2843d509c9c85a68cbe8f37a92d"
       expires:
       - '0'
       pragma:
@@ -129,72 +129,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 19bdb4bb62697e9ee7873bbd007bb15a
-      x-frame-options:
-      - SAMEORIGIN
-      x-node:
-      - bigweb2nuq
-      x-permitted-cross-domain-policies:
-      - none
-      x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq fde591f008
-      x-runtime:
-      - '0.093497'
-      x-version-label:
-      - easypost-202204262114-afef977f90-master
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      authorization:
-      - EZTK-NONE
-      user-agent:
-      - easypost/v2 pythonclient/suppressed
-      x-client-user-agent:
-      - suppressed
-    method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_a1ef858c63614243876c9be63bd5a899/smartrate
-  response:
-    body:
-      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_ae07ed845b784357a514b6ace2733d37","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_2ce9d337d00b46e49040c30f890d9110","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_7106f366c14347bca94a26c20f060274","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_ea7986c90db74b0a9d42b7209e76723f","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-27T17:34:22Z"}]}'
-    headers:
-      cache-control:
-      - no-cache, no-store
-      content-length:
-      - '2619'
-      content-type:
-      - application/json; charset=utf-8
-      etag:
-      - W/"ce610950da599b74c0445da96bf4d3b8"
-      expires:
-      - '0'
-      pragma:
-      - no-cache
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      transfer-encoding:
-      - chunked
-      x-backend:
-      - easypost
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-ep-request-uuid:
-      - 19bdb4bb62697e9ee7873bbd007bb182
+      - f1b599b7626ae48ae7873338000d1385
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -205,9 +140,9 @@ interactions:
       - intlb1nuq fde591f008
       - extlb2nuq fde591f008
       x-runtime:
-      - '0.082547'
+      - '0.066923'
       x-version-label:
-      - easypost-202204262114-afef977f90-master
+      - easypost-202204281816-b5dc9c446b-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -229,10 +164,10 @@ interactions:
       x-client-user-agent:
       - suppressed
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_a1ef858c63614243876c9be63bd5a899/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_09d34a4c766c4164b068a7aaf1921230/smartrate
   response:
     body:
-      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_ae07ed845b784357a514b6ace2733d37","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_2ce9d337d00b46e49040c30f890d9110","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_7106f366c14347bca94a26c20f060274","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-27T17:34:22Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-27T17:34:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_ea7986c90db74b0a9d42b7209e76723f","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_a1ef858c63614243876c9be63bd5a899","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-27T17:34:22Z"}]}'
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_eb4654fab59d4b46a55eb5a500c8729f","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-28T19:01:30Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_00a095c4c0da4f639ae00c0bb1187759","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-28T19:01:30Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_5518eb5014cc4ebc838b1c37a85680e2","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-28T19:01:30Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_f251402c3ed34f0abd73dad02afdc24d","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-28T19:01:30Z"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -241,7 +176,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"ce610950da599b74c0445da96bf4d3b8"
+      - W/"9cc7e2843d509c9c85a68cbe8f37a92d"
       expires:
       - '0'
       pragma:
@@ -259,20 +194,85 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 19bdb4bb62697e9ee7873bbd007bb190
+      - f1b599b7626ae48ae7873338000d1397
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb3nuq
+      - bigweb6nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
+      x-runtime:
+      - '0.078279'
+      x-version-label:
+      - easypost-202204281816-b5dc9c446b-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - EZTK-NONE
+      user-agent:
+      - easypost/v2 pythonclient/suppressed
+      x-client-user-agent:
+      - suppressed
+    method: GET
+    uri: https://api.easypost.com/v2/shipments/shp_09d34a4c766c4164b068a7aaf1921230/smartrate
+  response:
+    body:
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_eb4654fab59d4b46a55eb5a500c8729f","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-28T19:01:30Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_00a095c4c0da4f639ae00c0bb1187759","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-28T19:01:30Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_5518eb5014cc4ebc838b1c37a85680e2","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-28T19:01:30Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-04-28T19:01:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_f251402c3ed34f0abd73dad02afdc24d","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_09d34a4c766c4164b068a7aaf1921230","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-28T19:01:30Z"}]}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2619'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"9cc7e2843d509c9c85a68cbe8f37a92d"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - f1b599b7626ae48ae7873338000d13af
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb4nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq fde591f008
       - extlb2nuq fde591f008
       x-runtime:
-      - '0.096445'
+      - '0.084543'
       x-version-label:
-      - easypost-202204262114-afef977f90-master
+      - easypost-202204281816-b5dc9c446b-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,7 @@ def vcr_config():
             ("x-client-user-agent", "suppressed"),
             ("user-agent", "easypost/v2 pythonclient/suppressed"),
         ],
+        "decode_compressed_response": True,
     }
 
 
@@ -234,7 +235,7 @@ def one_call_buy_shipment(basic_address, basic_parcel, usps_service, usps_carrie
 # USPS only does "next-day" pickups including Saturday but not Sunday or Holidays.
 @pytest.fixture
 def basic_pickup(basic_address):
-    pickup_date = "2022-04-13"
+    pickup_date = "2022-04-27"
 
     return {
         "address": basic_address,


### PR DESCRIPTION
# Description

- Adds `lowest_rate` functions to Orders and Pickups
- Adds a `Shipment.get_lowest_smartrate` function and a `shipment.lowest_smartrate()` function

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- [x] Added various new unit tests to ensure all `lowest_rate` functions work

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
