### PR TITLE
refactor: cassette scrubbing logic cleanup

### DIFF
--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,4 +1,6 @@
-# import time
+import inspect
+import os
+import time
 
 import pytest
 
@@ -63,13 +65,14 @@ def test_batch_buy(one_call_buy_shipment):
 
 @pytest.mark.vcr()
 def test_batch_create_scanform(one_call_buy_shipment):
+    function_name = inspect.stack()[0][3]
     shipment_data = one_call_buy_shipment
 
     batch = easypost.Batch.create(shipments=[shipment_data])
     batch.buy()
 
-    # Uncomment the following line if you need to re-record the cassette
-    # time.sleep(5)  # Wait enough time for the batch to process buying the shipment
+    if not os.path.exists(os.path.join("tests", "cassettes", f"{function_name}.yaml")):
+        time.sleep(5)  # Wait enough time for the batch to process buying the shipment
 
     batch.create_scan_form()
 
@@ -95,11 +98,13 @@ def test_batch_add_remove_shipment(one_call_buy_shipment):
 
 @pytest.mark.vcr()
 def test_batch_label(one_call_buy_shipment):
+    function_name = inspect.stack()[0][3]
+
     batch = easypost.Batch.create(shipments=[one_call_buy_shipment])
     batch.buy()
 
-    # Uncomment the following line if you need to re-record the cassette
-    # time.sleep(5)  # Wait enough time for the batch to process buying the shipment
+    if not os.path.exists(os.path.join("tests", "cassettes", f"{function_name}.yaml")):
+        time.sleep(5)  # Wait enough time for the batch to process buying the shipment
 
     batch.label(file_format="ZPL")
 

--- a/tests/test_referral.py
+++ b/tests/test_referral.py
@@ -53,21 +53,16 @@ def test_referral_user_all(prod_api_key, page_size):
         "uri",
     ]
 )
-def test_referral_add_credit_card(prod_api_key):
-    """The credit card details below are for a valid proxy card usable
-    for tests only and cannot be used for real transactions.
-
-    DO NOT alter these details with real credit card information.
-
-    This test requires a partner user's production API key via EASYPOST_PROD_API_KEY
+def test_referral_add_credit_card(prod_api_key, credit_card_details):
+    """This test requires a partner user's production API key via EASYPOST_PROD_API_KEY
     as well as one of that user's referral's production API keys via REFERRAL_USER_PROD_API_KEY.
     """
     added_credit_card = easypost.beta.Referral.add_credit_card(
         referral_api_key=REFERRAL_USER_PROD_API_KEY,
-        number="4536410136126170",
-        expiration_month="05",
-        expiration_year="2028",
-        cvc="778",
+        number=credit_card_details["number"],
+        expiration_month=credit_card_details["expiration_month"],
+        expiration_year=credit_card_details["expiration_year"],
+        cvc=credit_card_details["cvc"],
     )
 
     assert str.startswith(added_credit_card.id, "card_")

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -69,8 +69,7 @@ def test_user_api_keys(prod_api_key):
     user = easypost.User.retrieve_me()
     api_keys = user.api_keys()
 
-    # This function returns a list of API keys and not an EasyPost object
-    assert type(api_keys) == list
+    assert api_keys
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
# Description

Cleans up the scrubbing logic for cassettes a bit to match that of the Ruby lib. Also properly dynamically waits for batch tests to finish if there is not yet a cassette.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- [x] Re-tested everything

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
