### PR TITLE
chore: remove carrier verify param and dead address message code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+- Removes the unusable `carrier` param from `Address.verify()` along with the dead `message` conditional check that was missed in v7.0.0
+
 ## v7.1.1 (2022-05-09)
 
 - Fixes the inclusion of the new `beta` module

--- a/easypost/address.py
+++ b/easypost/address.py
@@ -56,21 +56,16 @@ class Address(AllResource, CreateResource):
         else:
             return convert_to_easypost_object(response=response, api_key=api_key)
 
-    def verify(self, carrier: Optional[str] = None) -> "Address":
+    def verify(self) -> "Address":
         """Verify an address."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "verify")
-        params = {"carrier": carrier}
-        response, api_key = requestor.request(method=RequestMethod.GET, url=url, params=params)
+        response, api_key = requestor.request(method=RequestMethod.GET, url=url)
 
         response_address = response.get("address", None)
-        response_message = response.get("message", None)
 
         if response_address is not None:
             verified_address = convert_to_easypost_object(response=response_address, api_key=api_key)
-            if response_message is not None:
-                verified_address.message = response_message
-                verified_address._immutable_values.update("message")
             return verified_address
         else:
             return convert_to_easypost_object(response=response, api_key=api_key)


### PR DESCRIPTION
# Description

Removes the unusable `carrier` param from `Address.verify()` along with the dead `message` conditional check that was missed in v7.0.0
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

NA
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
