### PR TITLE
chore: ignore cassette diffs via gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
-/tests/cassettes/*.yaml binary
+* text=auto
+
+tests/cassettes/* -diff
+tests/cassettes/* linguist-generated


### PR DESCRIPTION
Ignore cassette diffs locally (line 1) and collapse on GitHub (line 2) for easier review.