### PR TITLE
feat: adds validate webhook function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+- Adds `validate_webhook` function that returns your webhook or raises an error if there is a `webhook_secret` mismatch
+
 ## v7.3.0 (2022-07-18)
 
 - Adds ability to generate forms for shipments via `generate_form()` function

--- a/easypost/webhook.py
+++ b/easypost/webhook.py
@@ -1,3 +1,13 @@
+import hashlib
+import hmac
+import json
+import unicodedata
+from typing import (
+    Any,
+    Dict,
+)
+
+from easypost.error import Error
 from easypost.requestor import (
     RequestMethod,
     Requestor,
@@ -17,3 +27,35 @@ class Webhook(AllResource, CreateResource, DeleteResource):
         response, api_key = requestor.request(method=RequestMethod.PATCH, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
+
+    @staticmethod
+    def validate_webhook(event_body: bytes, headers: Dict[str, Any], webhook_secret: str) -> Dict[str, Any]:
+        """Validate a webhook by comparing the HMAC signature header sent from EasyPost to your shared secret.
+        If the signatures do not match, an error will be raised signifying the webhook either did not originate
+        from EasyPost or the secrets do not match. If the signatures do match, the `event_body` will be returned
+        as JSON.
+        """
+        easypost_hmac_signature = headers.get("X-Hmac-Signature")
+
+        if easypost_hmac_signature:
+            normalized_secret = unicodedata.normalize("NFKD", webhook_secret)
+            encoded_secret = bytes(normalized_secret, "utf8")
+
+            expected_signature = hmac.new(
+                key=encoded_secret,
+                msg=event_body,
+                digestmod=hashlib.sha256,
+            )
+
+            digest = "hmac-sha256-hex=" + expected_signature.hexdigest()
+
+            if hmac.compare_digest(digest, easypost_hmac_signature):
+                webhook_body = json.loads(event_body)
+            else:
+                raise Error(
+                    message="Webhook received did not originate from EasyPost or had a webhook secret mismatch."
+                )
+        else:
+            raise Error(message="Webhook received does not contain an HMAC signature.")
+
+        return webhook_body

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -401,3 +401,40 @@ def rma_form_options():
             },
         ],
     }
+
+
+@pytest.fixture
+def event_body():
+    data = {
+        "result": {
+            "id": "batch_123...",
+            "object": "Batch",
+            "mode": "test",
+            "state": "created",
+            "num_shipments": 0,
+            "reference": None,
+            "created_at": "2022-07-26T17:22:32Z",
+            "updated_at": "2022-07-26T17:22:32Z",
+            "scan_form": None,
+            "shipments": [],
+            "status": {
+                "created": 0,
+                "queued_for_purchase": 0,
+                "creation_failed": 0,
+                "postage_purchased": 0,
+                "postage_purchase_failed": 0,
+            },
+            "pickup": None,
+            "label_url": None,
+        },
+        "description": "batch.created",
+        "mode": "test",
+        "previous_attributes": None,
+        "completed_urls": None,
+        "user_id": "user_123...",
+        "status": "pending",
+        "object": "Event",
+        "id": "evt_123...",
+    }
+
+    return json.dumps(data, separators=(",", ":")).encode()


### PR DESCRIPTION
# Description

Adds a new function to validate if a webhook originated from EasyPost with the stored Webhook secret, if they do the function will return True, otherwise False.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Adds a unit test to ensure this works by checking that the dummy webhook and secret match the expected hash for that same data.

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
