### PR TITLE
add ability to create/buy a shipment that has carbon_offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## NEXT RELEASE
 
 - Adds `validate_webhook` function that returns your webhook or raises an error if there is a `webhook_secret` mismatch
+- Adds ability to create a shipment with carbon_offset
+- Adds ability to buy a shipment with carbon_offset
+- Adds ability to one-call-buy a shipment with carbon_offset
+- Adds ability to rerate a shipment with carbon_offset
 
 ## v7.3.0 (2022-07-18)
 

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -25,8 +25,7 @@ class Shipment(AllResource, CreateResource):
         """Create an Shipment object."""
         requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
-        wrapped_params = {cls.snakecase_name(): params}
-        wrapped_params["carbon_offset"] = carbon_offset  # type: ignore
+        wrapped_params = {cls.snakecase_name(): params, "carbon_offset": carbon_offset}
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=wrapped_params)
         return convert_to_easypost_object(response=response, api_key=api_key)
 

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -26,7 +26,7 @@ class Shipment(AllResource, CreateResource):
         requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
         wrapped_params = {cls.snakecase_name(): params}
-        wrapped_params["carbon_offset"] = carbon_offset
+        wrapped_params["carbon_offset"] = carbon_offset  # type: ignore
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=wrapped_params)
         return convert_to_easypost_object(response=response, api_key=api_key)
 

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -21,20 +21,23 @@ from easypost.util import get_lowest_object_rate
 
 class Shipment(AllResource, CreateResource):
     @classmethod
-    def create(cls, api_key: Optional[str] = None, carbon_offset: Optional[bool] = False, **params) -> "Shipment":
+    def create(cls, api_key: Optional[str] = None, with_carbon_offset: Optional[bool] = False, **params) -> "Shipment":
         """Create an Shipment object."""
         requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
-        wrapped_params = {cls.snakecase_name(): params, "carbon_offset": carbon_offset}
+        wrapped_params = {
+            cls.snakecase_name(): params,
+            "carbon_offset": with_carbon_offset,
+        }
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=wrapped_params)
         return convert_to_easypost_object(response=response, api_key=api_key)
 
-    def regenerate_rates(self, carbon_offset: Optional[bool] = False) -> "Shipment":
+    def regenerate_rates(self, with_carbon_offset: Optional[bool] = False) -> "Shipment":
         """Regenerate rates for a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "rerate")
         params = {
-            "carbon_offset": carbon_offset,
+            "carbon_offset": with_carbon_offset,
         }
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
@@ -47,11 +50,11 @@ class Shipment(AllResource, CreateResource):
         response, _ = requestor.request(method=RequestMethod.GET, url=url)
         return response.get("result", [])
 
-    def buy(self, carbon_offset: Optional[bool] = False, **params) -> "Shipment":
+    def buy(self, with_carbon_offset: Optional[bool] = False, **params) -> "Shipment":
         """Buy a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
-        params["carbon_offset"] = carbon_offset
+        params["carbon_offset"] = with_carbon_offset
 
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -21,25 +21,22 @@ from easypost.util import get_lowest_object_rate
 
 class Shipment(AllResource, CreateResource):
     @classmethod
-    def create(cls, api_key: Optional[str] = None, carbon_offset: bool = False, **params) -> Any:
+    def create(cls, api_key: Optional[str] = None, carbon_offset: Optional[bool] = False, **params) -> "Shipment":
         """Create an Shipment object."""
         requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
         wrapped_params = {cls.snakecase_name(): params}
-        if carbon_offset:
-            wrapped_params["carbon_offset"] = carbon_offset  # type: ignore
+        wrapped_params["carbon_offset"] = carbon_offset
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=wrapped_params)
         return convert_to_easypost_object(response=response, api_key=api_key)
 
-    def regenerate_rates(self, carbon_offset=False) -> "Shipment":
+    def regenerate_rates(self, carbon_offset: Optional[bool] = False) -> "Shipment":
         """Regenerate rates for a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "rerate")
-        params = {}
-        if carbon_offset:
-            params = {
-                "carbon_offset": carbon_offset,
-            }
+        params = {
+            "carbon_offset": carbon_offset,
+        }
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)
         return self
@@ -51,12 +48,11 @@ class Shipment(AllResource, CreateResource):
         response, _ = requestor.request(method=RequestMethod.GET, url=url)
         return response.get("result", [])
 
-    def buy(self, carbon_offset=False, **params) -> "Shipment":
+    def buy(self, carbon_offset: Optional[bool] = False, **params) -> "Shipment":
         """Buy a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
-        if carbon_offset:
-            params["carbon_offset"] = carbon_offset
+        params["carbon_offset"] = carbon_offset
 
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)

--- a/tests/cassettes/test_batch_add_remove_shipment.yaml
+++ b/tests/cassettes/test_batch_add_remove_shipment.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:25:27Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768693","updated_at":"2022-05-04T20:25:28Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_55eb7c3bcbe811ec9d29ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:27+00:00","updated_at":"2022-05-04T20:25:27+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_9920227c395a44b3bd0d15ef36f333ae","object":"Parcel","created_at":"2022-05-04T20:25:27Z","updated_at":"2022-05-04T20:25:27Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_c81e583b852d464897d9ed4d87554d77","created_at":"2022-05-04T20:25:28Z","updated_at":"2022-05-04T20:25:28Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:25:28Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/b33e3dc14e9a430aa46780fe6004f483.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_4acaf0482654416ea58e59193c9acc27","object":"Rate","created_at":"2022-05-04T20:25:27Z","updated_at":"2022-05-04T20:25:27Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_2bb42692d2044e18a3f954dd7c72dae5","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_cdc373747e8d4c518330d81ca3b0e367","object":"Rate","created_at":"2022-05-04T20:25:27Z","updated_at":"2022-05-04T20:25:27Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2bb42692d2044e18a3f954dd7c72dae5","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_201ef26cbef1468ea565e8bd14ae4cf4","object":"Rate","created_at":"2022-05-04T20:25:27Z","updated_at":"2022-05-04T20:25:27Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_2bb42692d2044e18a3f954dd7c72dae5","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_6050f74617f2411fa368c1e11ef339c3","object":"Rate","created_at":"2022-05-04T20:25:27Z","updated_at":"2022-05-04T20:25:27Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2bb42692d2044e18a3f954dd7c72dae5","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_6050f74617f2411fa368c1e11ef339c3","object":"Rate","created_at":"2022-05-04T20:25:28Z","updated_at":"2022-05-04T20:25:28Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2bb42692d2044e18a3f954dd7c72dae5","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_a969f0691caa45f2bd8feeef86dac771","object":"Tracker","mode":"test","tracking_code":"9400100109361117768693","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:25:28Z","updated_at":"2022-05-04T20:25:28Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_2bb42692d2044e18a3f954dd7c72dae5","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2E5NjlmMDY5MWNhYTQ1ZjJiZDhmZWVlZjg2ZGFjNzcx"},"to_address":{"id":"adr_55e9ab74cbe811ec8d80ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:27+00:00","updated_at":"2022-05-04T20:25:27+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_55eb7c3bcbe811ec9d29ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:27+00:00","updated_at":"2022-05-04T20:25:27+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_55e9ab74cbe811ec8d80ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:27+00:00","updated_at":"2022-05-04T20:25:27+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_2bb42692d2044e18a3f954dd7c72dae5","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:50:50Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130482668", "updated_at": "2022-07-28T19:50:51Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_9526a77b0eae11eda4a8ac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:50:50+00:00", "updated_at": "2022-07-28T19:50:50+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_5e34573b73fc4890bd34fb5c2f5128fc",
+        "object": "Parcel", "created_at": "2022-07-28T19:50:50Z", "updated_at": "2022-07-28T19:50:50Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_55fe71cc3ac04c8d9d9b42a9fb6311f9",
+        "created_at": "2022-07-28T19:50:51Z", "updated_at": "2022-07-28T19:50:51Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:50:51Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/f14126e3e61a445d9234e348d90fcd3f.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_3280f63930184aa5a31acaa5872cb806", "object":
+        "Rate", "created_at": "2022-07-28T19:50:50Z", "updated_at": "2022-07-28T19:50:50Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_fe0589c0270f4a1fa6ec8b62e272a4d5", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_8d589bb7389d4ce5afdf803ee0f791ba",
+        "object": "Rate", "created_at": "2022-07-28T19:50:50Z", "updated_at": "2022-07-28T19:50:50Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_fe0589c0270f4a1fa6ec8b62e272a4d5", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_2ee844ad63934882a2e4b0d7afac8a5d", "object": "Rate", "created_at":
+        "2022-07-28T19:50:50Z", "updated_at": "2022-07-28T19:50:50Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_fe0589c0270f4a1fa6ec8b62e272a4d5", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_8752d6d674464cbbb1219dc768cadb68", "object": "Rate", "created_at":
+        "2022-07-28T19:50:50Z", "updated_at": "2022-07-28T19:50:50Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_fe0589c0270f4a1fa6ec8b62e272a4d5", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_8d589bb7389d4ce5afdf803ee0f791ba",
+        "object": "Rate", "created_at": "2022-07-28T19:50:51Z", "updated_at": "2022-07-28T19:50:51Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_fe0589c0270f4a1fa6ec8b62e272a4d5", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_3317f6585f2d49398e1cc6f936f2d821", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130482668", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T19:50:51Z", "updated_at":
+        "2022-07-28T19:50:51Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_fe0589c0270f4a1fa6ec8b62e272a4d5", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzMzMTdmNjU4NWYyZDQ5Mzk4ZTFjYzZmOTM2ZjJkODIx"},
+        "to_address": {"id": "adr_9524eacb0eae11eda0d6ac1f6bc72124", "object": "Address",
+        "created_at": "2022-07-28T19:50:50+00:00", "updated_at": "2022-07-28T19:50:50+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_9526a77b0eae11eda4a8ac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:50:50+00:00", "updated_at": "2022-07-28T19:50:50+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_9524eacb0eae11eda0d6ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T19:50:50+00:00", "updated_at": "2022-07-28T19:50:50+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_fe0589c0270f4a1fa6ec8b62e272a4d5", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"120ddcf64d0c63e0ea085528581016ba"
+      - W/"5be54b7c47d4a870917d19b5a67da33f"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_2bb42692d2044e18a3f954dd7c72dae5
+      - /api/v2/shipments/shp_fe0589c0270f4a1fa6ec8b62e272a4d5
       pragma:
       - no-cache
       referrer-policy:
@@ -59,27 +140,25 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b86272e137e786b841001617c0
+      - ead09ab762e2e89aff23deff0038b73d
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - extlb1nuq 403f17ff97
       x-runtime:
-      - '0.836673'
+      - '0.944881'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -106,7 +185,12 @@ interactions:
     uri: https://api.easypost.com/v2/batches
   response:
     body:
-      string: '{"id":"batch_aee6ddc3bbb54138a18b03a358a9ecab","object":"Batch","mode":"test","state":"created","num_shipments":0,"reference":null,"created_at":"2022-05-04T20:25:28Z","updated_at":"2022-05-04T20:25:28Z","scan_form":null,"shipments":[],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
+      string: '{"id": "batch_c0e129a16d4042de8f408ee88c2a23e1", "object": "Batch",
+        "mode": "test", "state": "created", "num_shipments": 0, "reference": null,
+        "created_at": "2022-07-28T19:50:51Z", "updated_at": "2022-07-28T19:50:51Z",
+        "scan_form": null, "shipments": [], "status": {"created": 0, "queued_for_purchase":
+        0, "creation_failed": 0, "postage_purchased": 0, "postage_purchase_failed":
+        0}, "pickup": null, "label_url": null}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -115,7 +199,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"ce4b29ecd6c91f9c946b8bba6230e74f"
+      - W/"3fea7a46742bde2ec2cad14e5e7570f7"
       expires:
       - '0'
       pragma:
@@ -133,27 +217,27 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b86272e138e786b84100161834
+      - ead09ab762e2e89bff23deff0038b7c6
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - extlb1nuq 403f17ff97
       x-runtime:
-      - '0.030618'
+      - '0.043887'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"shipments": [{"id": "shp_2bb42692d2044e18a3f954dd7c72dae5"}]}'
+    body: '{"shipments": [{"id": "shp_fe0589c0270f4a1fa6ec8b62e272a4d5"}]}'
     headers:
       Accept:
       - '*/*'
@@ -170,10 +254,17 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/batches/batch_aee6ddc3bbb54138a18b03a358a9ecab/add_shipments
+    uri: https://api.easypost.com/v2/batches/batch_c0e129a16d4042de8f408ee88c2a23e1/add_shipments
   response:
     body:
-      string: '{"id":"batch_aee6ddc3bbb54138a18b03a358a9ecab","object":"Batch","mode":"test","state":"created","num_shipments":1,"reference":null,"created_at":"2022-05-04T20:25:28Z","updated_at":"2022-05-04T20:25:28Z","scan_form":null,"shipments":[{"batch_status":"postage_purchased","batch_message":null,"reference":null,"tracking_code":"9400100109361117768693","id":"shp_2bb42692d2044e18a3f954dd7c72dae5"}],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":1,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
+      string: '{"id": "batch_c0e129a16d4042de8f408ee88c2a23e1", "object": "Batch",
+        "mode": "test", "state": "created", "num_shipments": 1, "reference": null,
+        "created_at": "2022-07-28T19:50:51Z", "updated_at": "2022-07-28T19:50:51Z",
+        "scan_form": null, "shipments": [{"batch_status": "postage_purchased", "batch_message":
+        null, "reference": null, "tracking_code": "9400100109361130482668", "id":
+        "shp_fe0589c0270f4a1fa6ec8b62e272a4d5"}], "status": {"created": 0, "queued_for_purchase":
+        0, "creation_failed": 0, "postage_purchased": 1, "postage_purchase_failed":
+        0}, "pickup": null, "label_url": null}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -182,7 +273,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"01ea9728e1268fa2b4491fa859f48179"
+      - W/"345b54013da1d638d9e504d3c693b1fa"
       expires:
       - '0'
       pragma:
@@ -200,7 +291,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b86272e138e786b84100161840
+      - ead09ab762e2e89bff23deff0038b7dc
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -208,19 +299,19 @@ interactions:
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - extlb1nuq 403f17ff97
       x-runtime:
-      - '0.062622'
+      - '0.044899'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"shipments": [{"id": "shp_2bb42692d2044e18a3f954dd7c72dae5"}]}'
+    body: '{"shipments": [{"id": "shp_fe0589c0270f4a1fa6ec8b62e272a4d5"}]}'
     headers:
       Accept:
       - '*/*'
@@ -237,10 +328,15 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/batches/batch_aee6ddc3bbb54138a18b03a358a9ecab/remove_shipments
+    uri: https://api.easypost.com/v2/batches/batch_c0e129a16d4042de8f408ee88c2a23e1/remove_shipments
   response:
     body:
-      string: '{"id":"batch_aee6ddc3bbb54138a18b03a358a9ecab","object":"Batch","mode":"test","state":"purchased","num_shipments":0,"reference":null,"created_at":"2022-05-04T20:25:28Z","updated_at":"2022-05-04T20:25:28Z","scan_form":null,"shipments":[],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
+      string: '{"id": "batch_c0e129a16d4042de8f408ee88c2a23e1", "object": "Batch",
+        "mode": "test", "state": "purchased", "num_shipments": 0, "reference": null,
+        "created_at": "2022-07-28T19:50:51Z", "updated_at": "2022-07-28T19:50:51Z",
+        "scan_form": null, "shipments": [], "status": {"created": 0, "queued_for_purchase":
+        0, "creation_failed": 0, "postage_purchased": 0, "postage_purchase_failed":
+        0}, "pickup": null, "label_url": null}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -249,7 +345,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"f5fdfb60657e96bce6cce21d04acf493"
+      - W/"c8f68bb610232cf2664931941ab6f721"
       expires:
       - '0'
       pragma:
@@ -267,20 +363,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b86272e138e786b84100161856
+      - ead09ab762e2e89cff23deff0038b7f1
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - extlb1nuq 403f17ff97
       x-runtime:
-      - '0.039491'
+      - '0.061412'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_error.yaml
+++ b/tests/cassettes/test_error.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"shipment": {}}'
+    body: '{"shipment": {}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '16'
+      - '40'
       Content-Type:
       - application/json
       authorization:
@@ -20,9 +20,9 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"error":{"code":"SHIPMENT.INVALID_PARAMS","message":"Unable to create
-        shipment, one or more parameters were invalid.","errors":[{"to_address":"Required
-        and missing."},{"from_address":"Required and missing."}]}}'
+      string: '{"error": {"code": "SHIPMENT.INVALID_PARAMS", "message": "Unable to
+        create shipment, one or more parameters were invalid.", "errors": [{"to_address":
+        "Required and missing."}, {"from_address": "Required and missing."}]}}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -47,20 +47,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330ba6272e143e786b86400161cd7
+      - 3843703c62e2e9d7ff23e29a0034322b
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb9nuq
+      - bigweb4nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.016675'
+      - '0.018855'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_generate_form.yaml
+++ b/tests/cassettes/test_generate_form.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,70 +27,70 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at": "2022-07-11T18:48:24Z", "is_return": false, "messages":
+      string: '{"created_at": "2022-07-28T20:27:08Z", "is_return": false, "messages":
         [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
         "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        "9400100109361127612764", "updated_at": "2022-07-11T18:48:25Z", "batch_id":
+        "9400100109361130493961", "updated_at": "2022-07-28T20:27:09Z", "batch_id":
         null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
-        {"id": "adr_0b180d57014a11ed870eac1f6bc72124", "object": "Address", "created_at":
-        "2022-07-11T18:48:24+00:00", "updated_at": "2022-07-11T18:48:24+00:00", "name":
+        {"id": "adr_a7297c5d0eb311ed8945ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:27:08+00:00", "updated_at": "2022-07-28T20:27:08+00:00", "name":
         "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
         "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
         "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
         null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
-        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_ddb6dc3e9bb8459d893121d24502897e",
-        "object": "Parcel", "created_at": "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z",
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_c170dd1188f045f5b0f4b08dfc8cf7a0",
+        "object": "Parcel", "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:08Z",
         "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
-        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_89b973d63354426a91bdd3b16467bbf3",
-        "created_at": "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:25Z",
-        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-11T18:48:24Z",
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_073f5b537bab46568e93859525858995",
+        "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:09Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:27:08Z",
         "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
-        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220711/5120d81e954746b3bc02a2832b5c29c2.png",
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/895736f7712042719b9df028c9622500.png",
         "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
-        null}, "rates": [{"id": "rate_2cf1c88b893b495796a085b024bc700e", "object":
-        "Rate", "created_at": "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z",
+        null}, "rates": [{"id": "rate_53687088099f4bee98684cd9ed1cabf7", "object":
+        "Rate", "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:08Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_8f18add86eb24dfa99537e5db8323569", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_096044d7bf154612a0acc879af93bf51",
+        "object": "Rate", "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:08Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_8f18add86eb24dfa99537e5db8323569", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_044e55720c1c4513b7082d573050b649",
+        "object": "Rate", "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:08Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_8f18add86eb24dfa99537e5db8323569", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_768850098f694f04983fd5b68e94bc98",
+        "object": "Rate", "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:08Z",
         "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
         "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
         "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
         null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
-        "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
-        {"id": "rate_1c7976a658f7415cb991974bef339259", "object": "Rate", "created_at":
-        "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z", "mode": "test",
-        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
-        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
-        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
-        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
-        "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
-        {"id": "rate_a8ae9d1c9f6341a3ad366028ad8cfa3b", "object": "Rate", "created_at":
-        "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z", "mode": "test",
-        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
-        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
-        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
-        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
-        "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
-        {"id": "rate_a27fc9b42f97406390689e449c90fd8d", "object": "Rate", "created_at":
-        "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z", "mode": "test",
-        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
-        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
-        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
-        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
-        "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
-        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_2cf1c88b893b495796a085b024bc700e",
-        "object": "Rate", "created_at": "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z",
+        "shp_8f18add86eb24dfa99537e5db8323569", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_768850098f694f04983fd5b68e94bc98",
+        "object": "Rate", "created_at": "2022-07-28T20:27:09Z", "updated_at": "2022-07-28T20:27:09Z",
         "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
         "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
         "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
         null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
-        "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
-        "tracker": {"id": "trk_f5d4d7b0fed44c149d4f4de6404131e9", "object": "Tracker",
-        "mode": "test", "tracking_code": "9400100109361127612764", "status": "unknown",
-        "status_detail": "unknown", "created_at": "2022-07-11T18:48:25Z", "updated_at":
-        "2022-07-11T18:48:25Z", "signed_by": null, "weight": null, "est_delivery_date":
-        null, "shipment_id": "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier": "USPS",
+        "shp_8f18add86eb24dfa99537e5db8323569", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_6da098d899554145a1e18598745581ef", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493961", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T20:27:09Z", "updated_at":
+        "2022-07-28T20:27:09Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_8f18add86eb24dfa99537e5db8323569", "carrier": "USPS",
         "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
-        "https://track.easypost.com/djE6dHJrX2Y1ZDRkN2IwZmVkNDRjMTQ5ZDRmNGRlNjQwNDEzMWU5"},
-        "to_address": {"id": "adr_0b16803a014a11edb95bac1f6bc7b362", "object": "Address",
-        "created_at": "2022-07-11T18:48:24+00:00", "updated_at": "2022-07-11T18:48:24+00:00",
+        "https://track.easypost.com/djE6dHJrXzZkYTA5OGQ4OTk1NTQxNDVhMWUxODU5ODc0NTU4MWVm"},
+        "to_address": {"id": "adr_a727909c0eb311ed8e31ac1f6bc7bdc6", "object": "Address",
+        "created_at": "2022-07-28T20:27:08+00:00", "updated_at": "2022-07-28T20:27:08+00:00",
         "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
         APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
         "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
@@ -98,14 +98,14 @@ interactions:
         {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
         true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
         "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
-        {"id": "adr_0b180d57014a11ed870eac1f6bc72124", "object": "Address", "created_at":
-        "2022-07-11T18:48:24+00:00", "updated_at": "2022-07-11T18:48:24+00:00", "name":
+        {"id": "adr_a7297c5d0eb311ed8945ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:27:08+00:00", "updated_at": "2022-07-28T20:27:08+00:00", "name":
         "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
         "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
         "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
         null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
-        {}}, "buyer_address": {"id": "adr_0b16803a014a11edb95bac1f6bc7b362", "object":
-        "Address", "created_at": "2022-07-11T18:48:24+00:00", "updated_at": "2022-07-11T18:48:24+00:00",
+        {}}, "buyer_address": {"id": "adr_a727909c0eb311ed8e31ac1f6bc7bdc6", "object":
+        "Address", "created_at": "2022-07-28T20:27:08+00:00", "updated_at": "2022-07-28T20:27:08+00:00",
         "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
         APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
         "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
@@ -115,7 +115,7 @@ interactions:
         "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
         "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
         {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
-        "refunded": false}], "id": "shp_c6d79ad25e4949ab99c6115e0abc4654", "object":
+        "refunded": false}], "id": "shp_8f18add86eb24dfa99537e5db8323569", "object":
         "Shipment"}'
     headers:
       cache-control:
@@ -125,11 +125,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"21ab58f6d2932bdf3850674f69bbbc65"
+      - W/"bb8d1555f52885ada42c69afc907c1df"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_c6d79ad25e4949ab99c6115e0abc4654
+      - /api/v2/shipments/shp_8f18add86eb24dfa99537e5db8323569
       pragma:
       - no-cache
       referrer-policy:
@@ -145,20 +145,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 47e9152962cc7078e79b862200033f51
+      - efdf9dff62e2f11cff23eb230001e90e
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq 403f17ff97
-      - extlb1nuq 403f17ff97
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '1.000109'
+      - '0.878153'
       x-version-label:
-      - easypost-202207082122-f28717e31b-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -184,76 +185,76 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_c6d79ad25e4949ab99c6115e0abc4654/forms
+    uri: https://api.easypost.com/v2/shipments/shp_8f18add86eb24dfa99537e5db8323569/forms
   response:
     body:
-      string: '{"created_at": "2022-07-11T18:48:24Z", "is_return": false, "messages":
+      string: '{"created_at": "2022-07-28T20:27:08Z", "is_return": false, "messages":
         [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
         "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        "9400100109361127612764", "updated_at": "2022-07-11T18:48:25Z", "batch_id":
+        "9400100109361130493961", "updated_at": "2022-07-28T20:27:09Z", "batch_id":
         null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
-        {"id": "adr_0b180d57014a11ed870eac1f6bc72124", "object": "Address", "created_at":
-        "2022-07-11T18:48:24+00:00", "updated_at": "2022-07-11T18:48:24+00:00", "name":
+        {"id": "adr_a7297c5d0eb311ed8945ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:27:08+00:00", "updated_at": "2022-07-28T20:27:08+00:00", "name":
         "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
         "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
         "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
         null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
-        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_ddb6dc3e9bb8459d893121d24502897e",
-        "object": "Parcel", "created_at": "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z",
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_c170dd1188f045f5b0f4b08dfc8cf7a0",
+        "object": "Parcel", "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:08Z",
         "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
-        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_89b973d63354426a91bdd3b16467bbf3",
-        "created_at": "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:25Z",
-        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-11T18:48:24Z",
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_073f5b537bab46568e93859525858995",
+        "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:09Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:27:08Z",
         "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
-        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220711/5120d81e954746b3bc02a2832b5c29c2.png",
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/895736f7712042719b9df028c9622500.png",
         "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
-        null}, "rates": [{"id": "rate_2cf1c88b893b495796a085b024bc700e", "object":
-        "Rate", "created_at": "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z",
+        null}, "rates": [{"id": "rate_53687088099f4bee98684cd9ed1cabf7", "object":
+        "Rate", "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:08Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_8f18add86eb24dfa99537e5db8323569", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_096044d7bf154612a0acc879af93bf51",
+        "object": "Rate", "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:08Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_8f18add86eb24dfa99537e5db8323569", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_044e55720c1c4513b7082d573050b649",
+        "object": "Rate", "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:08Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_8f18add86eb24dfa99537e5db8323569", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_768850098f694f04983fd5b68e94bc98",
+        "object": "Rate", "created_at": "2022-07-28T20:27:08Z", "updated_at": "2022-07-28T20:27:08Z",
         "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
         "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
         "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
         null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
-        "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
-        {"id": "rate_1c7976a658f7415cb991974bef339259", "object": "Rate", "created_at":
-        "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z", "mode": "test",
-        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
-        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
-        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
-        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
-        "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
-        {"id": "rate_a8ae9d1c9f6341a3ad366028ad8cfa3b", "object": "Rate", "created_at":
-        "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z", "mode": "test",
-        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
-        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
-        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
-        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
-        "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
-        {"id": "rate_a27fc9b42f97406390689e449c90fd8d", "object": "Rate", "created_at":
-        "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z", "mode": "test",
-        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
-        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
-        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
-        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
-        "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
-        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_2cf1c88b893b495796a085b024bc700e",
-        "object": "Rate", "created_at": "2022-07-11T18:48:24Z", "updated_at": "2022-07-11T18:48:24Z",
+        "shp_8f18add86eb24dfa99537e5db8323569", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_768850098f694f04983fd5b68e94bc98",
+        "object": "Rate", "created_at": "2022-07-28T20:27:09Z", "updated_at": "2022-07-28T20:27:09Z",
         "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
         "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
         "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
         null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
-        "shp_c6d79ad25e4949ab99c6115e0abc4654", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
-        "tracker": {"id": "trk_f5d4d7b0fed44c149d4f4de6404131e9", "object": "Tracker",
-        "mode": "test", "tracking_code": "9400100109361127612764", "status": "pre_transit",
-        "status_detail": "status_update", "created_at": "2022-07-11T18:48:25Z", "updated_at":
-        "2022-07-11T18:48:25Z", "signed_by": null, "weight": null, "est_delivery_date":
-        "2022-07-11T18:48:25Z", "shipment_id": "shp_c6d79ad25e4949ab99c6115e0abc4654",
+        "shp_8f18add86eb24dfa99537e5db8323569", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_6da098d899554145a1e18598745581ef", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493961", "status": "pre_transit",
+        "status_detail": "status_update", "created_at": "2022-07-28T20:27:09Z", "updated_at":
+        "2022-07-28T20:27:09Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T20:27:09Z", "shipment_id": "shp_8f18add86eb24dfa99537e5db8323569",
         "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
         "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
-        "status_detail": "status_update", "datetime": "2022-06-11T18:48:25Z", "source":
+        "status_detail": "status_update", "datetime": "2022-06-28T20:27:09Z", "source":
         "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
         "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
         "message": "Shipping Label Created", "description": null, "status": "pre_transit",
-        "status_detail": "status_update", "datetime": "2022-06-12T07:25:25Z", "source":
+        "status_detail": "status_update", "datetime": "2022-06-29T09:04:09Z", "source":
         "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
         "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}], "fees":
         [], "carrier_detail": {"object": "CarrierDetail", "service": "First-Class
@@ -262,9 +263,9 @@ interactions:
         {"object": "TrackingLocation", "city": "HOUSTON", "state": "TX", "country":
         null, "zip": "77063"}, "destination_location": "CHARLESTON SC, 29401", "destination_tracking_location":
         null, "guaranteed_delivery_date": null, "alternate_identifier": null, "initial_delivery_attempt":
-        null}, "public_url": "https://track.easypost.com/djE6dHJrX2Y1ZDRkN2IwZmVkNDRjMTQ5ZDRmNGRlNjQwNDEzMWU5"},
-        "to_address": {"id": "adr_0b16803a014a11edb95bac1f6bc7b362", "object": "Address",
-        "created_at": "2022-07-11T18:48:24+00:00", "updated_at": "2022-07-11T18:48:24+00:00",
+        null}, "public_url": "https://track.easypost.com/djE6dHJrXzZkYTA5OGQ4OTk1NTQxNDVhMWUxODU5ODc0NTU4MWVm"},
+        "to_address": {"id": "adr_a727909c0eb311ed8e31ac1f6bc7bdc6", "object": "Address",
+        "created_at": "2022-07-28T20:27:08+00:00", "updated_at": "2022-07-28T20:27:08+00:00",
         "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
         APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
         "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
@@ -272,14 +273,14 @@ interactions:
         {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
         true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
         "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
-        {"id": "adr_0b180d57014a11ed870eac1f6bc72124", "object": "Address", "created_at":
-        "2022-07-11T18:48:24+00:00", "updated_at": "2022-07-11T18:48:24+00:00", "name":
+        {"id": "adr_a7297c5d0eb311ed8945ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:27:08+00:00", "updated_at": "2022-07-28T20:27:08+00:00", "name":
         "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
         "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
         "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
         null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
-        {}}, "buyer_address": {"id": "adr_0b16803a014a11edb95bac1f6bc7b362", "object":
-        "Address", "created_at": "2022-07-11T18:48:24+00:00", "updated_at": "2022-07-11T18:48:24+00:00",
+        {}}, "buyer_address": {"id": "adr_a727909c0eb311ed8e31ac1f6bc7bdc6", "object":
+        "Address", "created_at": "2022-07-28T20:27:08+00:00", "updated_at": "2022-07-28T20:27:08+00:00",
         "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
         APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
         "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
@@ -287,13 +288,13 @@ interactions:
         {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
         true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
         "time_zone": "America/Los_Angeles"}}}}, "forms": [{"object": "Form", "id":
-        "form_84f7e59bf6ec47e3948bc6dee8e3edb6", "created_at": "2022-07-11T18:48:25Z",
-        "updated_at": "2022-07-11T18:48:26Z", "mode": "test", "form_type": "return_packing_slip",
-        "form_url": "https://easypost-files.s3-us-west-2.amazonaws.com/files/form/20220711/9ccf255343084f83b3ad227346a68d69.pdf",
+        "form_1e2ec9ecec4f4da5a893a323290349cd", "created_at": "2022-07-28T20:27:09Z",
+        "updated_at": "2022-07-28T20:27:09Z", "mode": "test", "form_type": "return_packing_slip",
+        "form_url": "https://easypost-files.s3-us-west-2.amazonaws.com/files/form/20220728/e2362dc4225946f9b031bfa3bdae55b5.pdf",
         "submitted_electronically": null}], "fees": [{"object": "Fee", "type": "LabelFee",
         "amount": "0.00000", "charged": true, "refunded": false}, {"object": "Fee",
         "type": "PostageFee", "amount": "5.49000", "charged": true, "refunded": false}],
-        "id": "shp_c6d79ad25e4949ab99c6115e0abc4654", "object": "Shipment"}'
+        "id": "shp_8f18add86eb24dfa99537e5db8323569", "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -302,11 +303,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"8339dd3acb06f86a9f94743bba37775c"
+      - W/"ef6abf2804cc7b7c6b72430cf40c7e78"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_c6d79ad25e4949ab99c6115e0abc4654/forms/return_packing_slip
+      - /api/v2/shipments/shp_8f18add86eb24dfa99537e5db8323569/forms/return_packing_slip
       pragma:
       - no-cache
       referrer-policy:
@@ -322,20 +323,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 47e9152962cc7079e79b862200033fb4
+      - efdf9dff62e2f11dff23eb230001e959
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb3nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq 403f17ff97
-      - extlb1nuq 403f17ff97
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.719382'
+      - '0.614856'
       x-version-label:
-      - easypost-202207082122-f28717e31b-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_insurance_create.yaml
+++ b/tests/cassettes/test_insurance_create.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:25:40Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768747","updated_at":"2022-05-04T20:25:41Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_5d7b1fb8cbe811ec9facac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:40+00:00","updated_at":"2022-05-04T20:25:40+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_93bb1ef98e914a97abf316da04526fca","object":"Parcel","created_at":"2022-05-04T20:25:40Z","updated_at":"2022-05-04T20:25:40Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_fc1bece56f604b8686da9e71a0abfdf3","created_at":"2022-05-04T20:25:40Z","updated_at":"2022-05-04T20:25:40Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:25:40Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/c04452488a7e4f8faefaf586e0562b33.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_94f2bb2114ac493597cc5f77bc814bcb","object":"Rate","created_at":"2022-05-04T20:25:40Z","updated_at":"2022-05-04T20:25:40Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_f2247295fb114f9796498dae07ad971c","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_39f333f31a3a492d9b398d8101a34b2e","object":"Rate","created_at":"2022-05-04T20:25:40Z","updated_at":"2022-05-04T20:25:40Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f2247295fb114f9796498dae07ad971c","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_48f236e102ef4a8294787ce4baec2d2d","object":"Rate","created_at":"2022-05-04T20:25:40Z","updated_at":"2022-05-04T20:25:40Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_f2247295fb114f9796498dae07ad971c","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_ece9f3f1604744c6a3527b15ccb8a08e","object":"Rate","created_at":"2022-05-04T20:25:40Z","updated_at":"2022-05-04T20:25:40Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f2247295fb114f9796498dae07ad971c","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_ece9f3f1604744c6a3527b15ccb8a08e","object":"Rate","created_at":"2022-05-04T20:25:40Z","updated_at":"2022-05-04T20:25:40Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f2247295fb114f9796498dae07ad971c","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_ad34c1874ec0472c9a9c4ae325f9aeb0","object":"Tracker","mode":"test","tracking_code":"9400100109361117768747","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:25:41Z","updated_at":"2022-05-04T20:25:41Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_f2247295fb114f9796498dae07ad971c","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2FkMzRjMTg3NGVjMDQ3MmM5YTljNGFlMzI1ZjlhZWIw"},"to_address":{"id":"adr_5d790eb0cbe811ec874bac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:40+00:00","updated_at":"2022-05-04T20:25:40+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_5d7b1fb8cbe811ec9facac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:40+00:00","updated_at":"2022-05-04T20:25:40+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_5d790eb0cbe811ec874bac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:40+00:00","updated_at":"2022-05-04T20:25:40+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_f2247295fb114f9796498dae07ad971c","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:53:50Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130483030", "updated_at": "2022-07-28T19:53:50Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_000953830eaf11ed879bac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:53:50+00:00", "updated_at": "2022-07-28T19:53:50+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_764ab2e5f7b84feca5cc1d75480f7b3b",
+        "object": "Parcel", "created_at": "2022-07-28T19:53:50Z", "updated_at": "2022-07-28T19:53:50Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_6269e5e363804d99a0136c742e8d3b48",
+        "created_at": "2022-07-28T19:53:50Z", "updated_at": "2022-07-28T19:53:50Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:53:50Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/a8bfeb531a5a43a8a8316045ac338694.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_73340f8ee37349b081a90feddfd12f35", "object":
+        "Rate", "created_at": "2022-07-28T19:53:50Z", "updated_at": "2022-07-28T19:53:50Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_cb5d7adf0e3640ea9e7dbf0b4baae075", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_6159761dbac3467f96f8b24953a96918",
+        "object": "Rate", "created_at": "2022-07-28T19:53:50Z", "updated_at": "2022-07-28T19:53:50Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_cb5d7adf0e3640ea9e7dbf0b4baae075", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_08ffaba9c5344ddabe06dc9832a61ebd", "object": "Rate", "created_at":
+        "2022-07-28T19:53:50Z", "updated_at": "2022-07-28T19:53:50Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_cb5d7adf0e3640ea9e7dbf0b4baae075", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_74c08e901e0b47f7bfe5ea70b42b1d1d", "object": "Rate", "created_at":
+        "2022-07-28T19:53:50Z", "updated_at": "2022-07-28T19:53:50Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_cb5d7adf0e3640ea9e7dbf0b4baae075", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_6159761dbac3467f96f8b24953a96918",
+        "object": "Rate", "created_at": "2022-07-28T19:53:50Z", "updated_at": "2022-07-28T19:53:50Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_cb5d7adf0e3640ea9e7dbf0b4baae075", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_b6b5050d76764672a30f37aa9fbb1816", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483030", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T19:53:50Z", "updated_at":
+        "2022-07-28T19:53:50Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_cb5d7adf0e3640ea9e7dbf0b4baae075", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrX2I2YjUwNTBkNzY3NjQ2NzJhMzBmMzdhYTlmYmIxODE2"},
+        "to_address": {"id": "adr_00077bdb0eaf11ed86aeac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-28T19:53:50+00:00", "updated_at": "2022-07-28T19:53:50+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_000953830eaf11ed879bac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:53:50+00:00", "updated_at": "2022-07-28T19:53:50+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_00077bdb0eaf11ed86aeac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:53:50+00:00", "updated_at": "2022-07-28T19:53:50+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_cb5d7adf0e3640ea9e7dbf0b4baae075", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"827ad777afe3b7ee0ffc4415aec33c18"
+      - W/"da476526fc49e12fc6bc375f4e4b4988"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_f2247295fb114f9796498dae07ad971c
+      - /api/v2/shipments/shp_cb5d7adf0e3640ea9e7dbf0b4baae075
       pragma:
       - no-cache
       referrer-policy:
@@ -64,20 +145,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b96272e144e786b87e00161d56
+      - 3843704162e2e94dff23df4700340bac
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb9nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.898871'
+      - '0.939989'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -89,7 +171,7 @@ interactions:
       "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
       "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
-      "carrier": "USPS", "amount": "100", "tracking_code": "9400100109361117768747"}}'
+      "carrier": "USPS", "amount": "100", "tracking_code": "9400100109361130483030"}}'
     headers:
       Accept:
       - '*/*'
@@ -109,16 +191,51 @@ interactions:
     uri: https://api.easypost.com/v2/insurances
   response:
     body:
-      string: '{"id":"ins_ca24ee7507fd46bc85c00ae613edb81c","object":"Insurance","mode":"test","reference":null,"status":"pending","amount":"100.00000","provider":"easypost","provider_id":null,"to_address":{"id":"adr_5e0dfad4cbe811ec8770ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:41+00:00","updated_at":"2022-05-04T20:25:41+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"from_address":{"id":"adr_5e12708dcbe811ec9fcdac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:41+00:00","updated_at":"2022-05-04T20:25:41+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"shipment_id":null,"tracker":{"id":"trk_ad34c1874ec0472c9a9c4ae325f9aeb0","object":"Tracker","mode":"test","tracking_code":"9400100109361117768747","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:25:41Z","updated_at":"2022-05-04T20:25:41Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:25:41Z","shipment_id":"shp_f2247295fb114f9796498dae07ad971c","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:25:41Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:02:41Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"finalized":true,"is_return":false,"public_url":"https://track.easypost.com/djE6dHJrX2FkMzRjMTg3NGVjMDQ3MmM5YTljNGFlMzI1ZjlhZWIw","fees":[]},"tracking_code":"9400100109361117768747","fee":{"object":"Fee","type":"InsuranceFee","amount":"1.00000","charged":true,"refunded":false},"messages":[],"created_at":"2022-05-04T20:25:41Z","updated_at":"2022-05-04T20:25:41Z"}'
+      string: '{"id": "ins_9496dfd327ab4de0a333ced98f06a5ed", "object": "Insurance",
+        "mode": "test", "reference": null, "status": "pending", "amount": "100.00000",
+        "provider": "easypost", "provider_id": null, "to_address": {"id": "adr_00bee4820eaf11ed9968ac1f6bc7bdc6",
+        "object": "Address", "created_at": "2022-07-28T19:53:51+00:00", "updated_at":
+        "2022-07-28T19:53:51+00:00", "name": "JACK SPARROW", "company": "EASYPOST",
+        "street1": "388 TOWNSEND ST APT 20", "street2": "", "city": "SAN FRANCISCO",
+        "state": "CA", "zip": "94107-1670", "country": "US", "phone": "5555555555",
+        "email": null, "mode": "test", "carrier_facility": null, "residential": true,
+        "federal_tax_id": null, "state_tax_id": null, "verifications": {"zip4": {"success":
+        true, "errors": [], "details": null}, "delivery": {"success": true, "errors":
+        [], "details": {"latitude": 37.77551, "longitude": -122.39697, "time_zone":
+        "America/Los_Angeles"}}}}, "from_address": {"id": "adr_00c31b690eaf11ed996fac1f6bc7bdc6",
+        "object": "Address", "created_at": "2022-07-28T19:53:51+00:00", "updated_at":
+        "2022-07-28T19:53:51+00:00", "name": "JACK SPARROW", "company": "EASYPOST",
+        "street1": "388 TOWNSEND ST APT 20", "street2": "", "city": "SAN FRANCISCO",
+        "state": "CA", "zip": "94107-1670", "country": "US", "phone": "5555555555",
+        "email": null, "mode": "test", "carrier_facility": null, "residential": true,
+        "federal_tax_id": null, "state_tax_id": null, "verifications": {"zip4": {"success":
+        true, "errors": [], "details": null}, "delivery": {"success": true, "errors":
+        [], "details": {"latitude": 37.77551, "longitude": -122.39697, "time_zone":
+        "America/Los_Angeles"}}}}, "shipment_id": null, "tracker": {"id": "trk_b6b5050d76764672a30f37aa9fbb1816",
+        "object": "Tracker", "mode": "test", "tracking_code": "9400100109361130483030",
+        "status": "pre_transit", "status_detail": "status_update", "created_at": "2022-07-28T19:53:51Z",
+        "updated_at": "2022-07-28T19:53:51Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:53:51Z", "shipment_id": "shp_cb5d7adf0e3640ea9e7dbf0b4baae075",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:53:51Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:30:51Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}], "carrier_detail":
+        {"object": "CarrierDetail", "service": "First-Class Package Service", "container_type":
+        null, "est_delivery_date_local": null, "est_delivery_time_local": null, "origin_location":
+        "HOUSTON TX, 77001", "origin_tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}, "destination_location":
+        "CHARLESTON SC, 29401", "destination_tracking_location": null, "guaranteed_delivery_date":
+        null, "alternate_identifier": null, "initial_delivery_attempt": null}, "finalized":
+        true, "is_return": false, "public_url": "https://track.easypost.com/djE6dHJrX2I2YjUwNTBkNzY3NjQ2NzJhMzBmMzdhYTlmYmIxODE2",
+        "fees": []}, "tracking_code": "9400100109361130483030", "fee": {"object":
+        "Fee", "type": "InsuranceFee", "amount": "1.00000", "charged": true, "refunded":
+        false}, "messages": [], "created_at": "2022-07-28T19:53:51Z", "updated_at":
+        "2022-07-28T19:53:51Z"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -127,11 +244,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"74ff10b7234df7ae1768a05fff40aebf"
+      - W/"7be216cc8d8136b392adb2e6a05caee8"
       expires:
       - '0'
       location:
-      - /api/v2/insurances/ins_ca24ee7507fd46bc85c00ae613edb81c
+      - /api/v2/insurances/ins_9496dfd327ab4de0a333ced98f06a5ed
       pragma:
       - no-cache
       referrer-policy:
@@ -147,7 +264,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b96272e145e786b87e00161dab
+      - 3843704162e2e94fff23df4700340bea
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -155,12 +272,13 @@ interactions:
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.153978'
+      - '0.144757'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_insurance_retrieve.yaml
+++ b/tests/cassettes/test_insurance_retrieve.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:25:41Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768754","updated_at":"2022-05-04T20:25:42Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_5e44d7b2cbe811ec904eac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:41+00:00","updated_at":"2022-05-04T20:25:41+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_15d50051d428411fa1806879366a845a","object":"Parcel","created_at":"2022-05-04T20:25:41Z","updated_at":"2022-05-04T20:25:41Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_bb3365164e1f4c23951481dd311ab341","created_at":"2022-05-04T20:25:42Z","updated_at":"2022-05-04T20:25:42Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:25:42Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/30071245a13344d7ac269880145c0909.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_dad066c8dac148668d5b3559c408771d","object":"Rate","created_at":"2022-05-04T20:25:41Z","updated_at":"2022-05-04T20:25:41Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_8c8ec6d31ee8420792bb9fa84c31e83e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_abdd3d9551024818ac908f443f5b7cbd","object":"Rate","created_at":"2022-05-04T20:25:41Z","updated_at":"2022-05-04T20:25:41Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8c8ec6d31ee8420792bb9fa84c31e83e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_f00530c47e5240ab9402aee7652eb29b","object":"Rate","created_at":"2022-05-04T20:25:41Z","updated_at":"2022-05-04T20:25:41Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_8c8ec6d31ee8420792bb9fa84c31e83e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_31c8af93897940b9a63768b666a33419","object":"Rate","created_at":"2022-05-04T20:25:41Z","updated_at":"2022-05-04T20:25:41Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8c8ec6d31ee8420792bb9fa84c31e83e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_31c8af93897940b9a63768b666a33419","object":"Rate","created_at":"2022-05-04T20:25:42Z","updated_at":"2022-05-04T20:25:42Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8c8ec6d31ee8420792bb9fa84c31e83e","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_685bd0ee1b80488aa84bd623a7f9f724","object":"Tracker","mode":"test","tracking_code":"9400100109361117768754","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:25:42Z","updated_at":"2022-05-04T20:25:42Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_8c8ec6d31ee8420792bb9fa84c31e83e","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzY4NWJkMGVlMWI4MDQ4OGFhODRiZDYyM2E3ZjlmNzI0"},"to_address":{"id":"adr_5e423d92cbe811ec877dac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:41+00:00","updated_at":"2022-05-04T20:25:41+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_5e44d7b2cbe811ec904eac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:41+00:00","updated_at":"2022-05-04T20:25:41+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_5e423d92cbe811ec877dac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:41+00:00","updated_at":"2022-05-04T20:25:41+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_8c8ec6d31ee8420792bb9fa84c31e83e","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:53:51Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130483047", "updated_at": "2022-07-28T19:53:52Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_0108ae980eaf11ed88caac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:53:51+00:00", "updated_at": "2022-07-28T19:53:51+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_0a30f65d420b4c8faea414e19b96458d",
+        "object": "Parcel", "created_at": "2022-07-28T19:53:51Z", "updated_at": "2022-07-28T19:53:51Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_5de8229fa1274b6f898f8673a3cf9e86",
+        "created_at": "2022-07-28T19:53:52Z", "updated_at": "2022-07-28T19:53:52Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:53:52Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/32ce8c0aeab7492a91b7e396cd0bd11a.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_132657775f074eb1b0880aa5e9f39657", "object":
+        "Rate", "created_at": "2022-07-28T19:53:51Z", "updated_at": "2022-07-28T19:53:51Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_8f24834463994842bc28b90496856fa8", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_4990cdaa5a63429582c04f5d530fd580", "object": "Rate", "created_at":
+        "2022-07-28T19:53:52Z", "updated_at": "2022-07-28T19:53:52Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_8f24834463994842bc28b90496856fa8", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_1e9ad52686b745a58056632ee9ab8169", "object": "Rate", "created_at":
+        "2022-07-28T19:53:52Z", "updated_at": "2022-07-28T19:53:52Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_8f24834463994842bc28b90496856fa8", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_6fe6133352444c4cb6f29b8696e9afe2", "object": "Rate", "created_at":
+        "2022-07-28T19:53:52Z", "updated_at": "2022-07-28T19:53:52Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_8f24834463994842bc28b90496856fa8", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_132657775f074eb1b0880aa5e9f39657",
+        "object": "Rate", "created_at": "2022-07-28T19:53:52Z", "updated_at": "2022-07-28T19:53:52Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_8f24834463994842bc28b90496856fa8", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_92f9dfc7c3814d16a605fef1c44c2896", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483047", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T19:53:52Z", "updated_at":
+        "2022-07-28T19:53:52Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_8f24834463994842bc28b90496856fa8", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzkyZjlkZmM3YzM4MTRkMTZhNjA1ZmVmMWM0NGMyODk2"},
+        "to_address": {"id": "adr_0106ea8d0eaf11ed8cb6ac1f6b0a0d1e", "object": "Address",
+        "created_at": "2022-07-28T19:53:51+00:00", "updated_at": "2022-07-28T19:53:52+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_0108ae980eaf11ed88caac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:53:51+00:00", "updated_at": "2022-07-28T19:53:51+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_0106ea8d0eaf11ed8cb6ac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-28T19:53:51+00:00", "updated_at": "2022-07-28T19:53:52+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_8f24834463994842bc28b90496856fa8", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"3c9b925786c7d7122438269473898dcd"
+      - W/"be919924b0b59cb8e8572c569c8ed069"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_8c8ec6d31ee8420792bb9fa84c31e83e
+      - /api/v2/shipments/shp_8f24834463994842bc28b90496856fa8
       pragma:
       - no-cache
       referrer-policy:
@@ -64,20 +145,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b76272e145e786b87f00161dd4
+      - b0657e4362e2e94fff23df480033a106
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '1.046461'
+      - '1.077743'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -89,7 +171,7 @@ interactions:
       "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
       "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
-      "carrier": "USPS", "amount": "100", "tracking_code": "9400100109361117768754"}}'
+      "carrier": "USPS", "amount": "100", "tracking_code": "9400100109361130483047"}}'
     headers:
       Accept:
       - '*/*'
@@ -109,16 +191,51 @@ interactions:
     uri: https://api.easypost.com/v2/insurances
   response:
     body:
-      string: '{"id":"ins_89a6465da6d641d1a171c70a88ceeede","object":"Insurance","mode":"test","reference":null,"status":"pending","amount":"100.00000","provider":"easypost","provider_id":null,"to_address":{"id":"adr_5f0b3a30cbe811eca019ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:42+00:00","updated_at":"2022-05-04T20:25:42+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"from_address":{"id":"adr_5f0f6e5fcbe811eca842ac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:25:42+00:00","updated_at":"2022-05-04T20:25:42+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"shipment_id":null,"tracker":{"id":"trk_685bd0ee1b80488aa84bd623a7f9f724","object":"Tracker","mode":"test","tracking_code":"9400100109361117768754","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:25:42Z","updated_at":"2022-05-04T20:25:42Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:25:42Z","shipment_id":"shp_8c8ec6d31ee8420792bb9fa84c31e83e","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:25:42Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:02:42Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"finalized":true,"is_return":false,"public_url":"https://track.easypost.com/djE6dHJrXzY4NWJkMGVlMWI4MDQ4OGFhODRiZDYyM2E3ZjlmNzI0","fees":[]},"tracking_code":"9400100109361117768754","fee":{"object":"Fee","type":"InsuranceFee","amount":"1.00000","charged":true,"refunded":false},"messages":[],"created_at":"2022-05-04T20:25:42Z","updated_at":"2022-05-04T20:25:42Z"}'
+      string: '{"id": "ins_f0c9e43e83de4bde8464b5d64adaab05", "object": "Insurance",
+        "mode": "test", "reference": null, "status": "pending", "amount": "100.00000",
+        "provider": "easypost", "provider_id": null, "to_address": {"id": "adr_01c849270eaf11ed89b5ac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T19:53:53+00:00", "updated_at":
+        "2022-07-28T19:53:53+00:00", "name": "JACK SPARROW", "company": "EASYPOST",
+        "street1": "388 TOWNSEND ST APT 20", "street2": "", "city": "SAN FRANCISCO",
+        "state": "CA", "zip": "94107-1670", "country": "US", "phone": "5555555555",
+        "email": null, "mode": "test", "carrier_facility": null, "residential": true,
+        "federal_tax_id": null, "state_tax_id": null, "verifications": {"zip4": {"success":
+        true, "errors": [], "details": null}, "delivery": {"success": true, "errors":
+        [], "details": {"latitude": 37.77551, "longitude": -122.39697, "time_zone":
+        "America/Los_Angeles"}}}}, "from_address": {"id": "adr_01cc3a150eaf11ed89bbac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T19:53:53+00:00", "updated_at":
+        "2022-07-28T19:53:53+00:00", "name": "JACK SPARROW", "company": "EASYPOST",
+        "street1": "388 TOWNSEND ST APT 20", "street2": "", "city": "SAN FRANCISCO",
+        "state": "CA", "zip": "94107-1670", "country": "US", "phone": "5555555555",
+        "email": null, "mode": "test", "carrier_facility": null, "residential": true,
+        "federal_tax_id": null, "state_tax_id": null, "verifications": {"zip4": {"success":
+        true, "errors": [], "details": null}, "delivery": {"success": true, "errors":
+        [], "details": {"latitude": 37.77551, "longitude": -122.39697, "time_zone":
+        "America/Los_Angeles"}}}}, "shipment_id": null, "tracker": {"id": "trk_92f9dfc7c3814d16a605fef1c44c2896",
+        "object": "Tracker", "mode": "test", "tracking_code": "9400100109361130483047",
+        "status": "pre_transit", "status_detail": "status_update", "created_at": "2022-07-28T19:53:52Z",
+        "updated_at": "2022-07-28T19:53:52Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:53:52Z", "shipment_id": "shp_8f24834463994842bc28b90496856fa8",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:53:52Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:30:52Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}], "carrier_detail":
+        {"object": "CarrierDetail", "service": "First-Class Package Service", "container_type":
+        null, "est_delivery_date_local": null, "est_delivery_time_local": null, "origin_location":
+        "HOUSTON TX, 77001", "origin_tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}, "destination_location":
+        "CHARLESTON SC, 29401", "destination_tracking_location": null, "guaranteed_delivery_date":
+        null, "alternate_identifier": null, "initial_delivery_attempt": null}, "finalized":
+        true, "is_return": false, "public_url": "https://track.easypost.com/djE6dHJrXzkyZjlkZmM3YzM4MTRkMTZhNjA1ZmVmMWM0NGMyODk2",
+        "fees": []}, "tracking_code": "9400100109361130483047", "fee": {"object":
+        "Fee", "type": "InsuranceFee", "amount": "1.00000", "charged": true, "refunded":
+        false}, "messages": [], "created_at": "2022-07-28T19:53:53Z", "updated_at":
+        "2022-07-28T19:53:53Z"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -127,11 +244,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"6b15f5bae344158d889d7f6c9ffc6297"
+      - W/"3a8632832afab413cb524ce63e8a941a"
       expires:
       - '0'
       location:
-      - /api/v2/insurances/ins_89a6465da6d641d1a171c70a88ceeede
+      - /api/v2/insurances/ins_f0c9e43e83de4bde8464b5d64adaab05
       pragma:
       - no-cache
       referrer-policy:
@@ -147,20 +264,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b76272e146e786b87f00161e57
+      - b0657e4362e2e950ff23df480033a14a
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.162593'
+      - '0.156536'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -180,19 +298,54 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/insurances/ins_89a6465da6d641d1a171c70a88ceeede
+    uri: https://api.easypost.com/v2/insurances/ins_f0c9e43e83de4bde8464b5d64adaab05
   response:
     body:
-      string: '{"id":"ins_89a6465da6d641d1a171c70a88ceeede","object":"Insurance","mode":"test","reference":null,"status":"pending","amount":"100.00000","provider":"easypost","provider_id":null,"to_address":{"id":"adr_5f0b3a30cbe811eca019ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:42+00:00","updated_at":"2022-05-04T20:25:42+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"from_address":{"id":"adr_5f0f6e5fcbe811eca842ac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:25:42+00:00","updated_at":"2022-05-04T20:25:42+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"shipment_id":null,"tracker":{"id":"trk_685bd0ee1b80488aa84bd623a7f9f724","object":"Tracker","mode":"test","tracking_code":"9400100109361117768754","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:25:42Z","updated_at":"2022-05-04T20:25:42Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:25:42Z","shipment_id":"shp_8c8ec6d31ee8420792bb9fa84c31e83e","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:25:42Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:02:42Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"finalized":true,"is_return":false,"public_url":"https://track.easypost.com/djE6dHJrXzY4NWJkMGVlMWI4MDQ4OGFhODRiZDYyM2E3ZjlmNzI0","fees":[]},"tracking_code":"9400100109361117768754","fee":{"object":"Fee","type":"InsuranceFee","amount":"1.00000","charged":true,"refunded":false},"messages":[],"created_at":"2022-05-04T20:25:42Z","updated_at":"2022-05-04T20:25:42Z"}'
+      string: '{"id": "ins_f0c9e43e83de4bde8464b5d64adaab05", "object": "Insurance",
+        "mode": "test", "reference": null, "status": "pending", "amount": "100.00000",
+        "provider": "easypost", "provider_id": null, "to_address": {"id": "adr_01c849270eaf11ed89b5ac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T19:53:53+00:00", "updated_at":
+        "2022-07-28T19:53:53+00:00", "name": "JACK SPARROW", "company": "EASYPOST",
+        "street1": "388 TOWNSEND ST APT 20", "street2": null, "city": "SAN FRANCISCO",
+        "state": "CA", "zip": "94107-1670", "country": "US", "phone": "5555555555",
+        "email": null, "mode": "test", "carrier_facility": null, "residential": true,
+        "federal_tax_id": null, "state_tax_id": null, "verifications": {"zip4": {"success":
+        true, "errors": [], "details": null}, "delivery": {"success": true, "errors":
+        [], "details": {"latitude": 37.77551, "longitude": -122.39697, "time_zone":
+        "America/Los_Angeles"}}}}, "from_address": {"id": "adr_01cc3a150eaf11ed89bbac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T19:53:53+00:00", "updated_at":
+        "2022-07-28T19:53:53+00:00", "name": "JACK SPARROW", "company": "EASYPOST",
+        "street1": "388 TOWNSEND ST APT 20", "street2": null, "city": "SAN FRANCISCO",
+        "state": "CA", "zip": "94107-1670", "country": "US", "phone": "5555555555",
+        "email": null, "mode": "test", "carrier_facility": null, "residential": true,
+        "federal_tax_id": null, "state_tax_id": null, "verifications": {"zip4": {"success":
+        true, "errors": [], "details": null}, "delivery": {"success": true, "errors":
+        [], "details": {"latitude": 37.77551, "longitude": -122.39697, "time_zone":
+        "America/Los_Angeles"}}}}, "shipment_id": null, "tracker": {"id": "trk_92f9dfc7c3814d16a605fef1c44c2896",
+        "object": "Tracker", "mode": "test", "tracking_code": "9400100109361130483047",
+        "status": "pre_transit", "status_detail": "status_update", "created_at": "2022-07-28T19:53:52Z",
+        "updated_at": "2022-07-28T19:53:52Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:53:52Z", "shipment_id": "shp_8f24834463994842bc28b90496856fa8",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:53:52Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:30:52Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}], "carrier_detail":
+        {"object": "CarrierDetail", "service": "First-Class Package Service", "container_type":
+        null, "est_delivery_date_local": null, "est_delivery_time_local": null, "origin_location":
+        "HOUSTON TX, 77001", "origin_tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}, "destination_location":
+        "CHARLESTON SC, 29401", "destination_tracking_location": null, "guaranteed_delivery_date":
+        null, "alternate_identifier": null, "initial_delivery_attempt": null}, "finalized":
+        true, "is_return": false, "public_url": "https://track.easypost.com/djE6dHJrXzkyZjlkZmM3YzM4MTRkMTZhNjA1ZmVmMWM0NGMyODk2",
+        "fees": []}, "tracking_code": "9400100109361130483047", "fee": {"object":
+        "Fee", "type": "InsuranceFee", "amount": "1.00000", "charged": true, "refunded":
+        false}, "messages": [], "created_at": "2022-07-28T19:53:53Z", "updated_at":
+        "2022-07-28T19:53:53Z"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -201,7 +354,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"e002d51648ef9ec8fef1d5adf45f66d1"
+      - W/"39b61417dc19528afdf4a8b979510647"
       expires:
       - '0'
       pragma:
@@ -219,20 +372,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b76272e147e786b87f00161e70
+      - b0657e4362e2e951ff23df480033a160
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb4nuq
+      - bigweb2nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.101520'
+      - '0.072374'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_pickup_buy.yaml
+++ b/tests/cassettes/test_pickup_buy.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:25:53Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768808","updated_at":"2022-05-04T20:25:53Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_65116f73cbe811eca172ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:53+00:00","updated_at":"2022-05-04T20:25:53+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_ffdc4a3daea2478493f23c56f6c73012","object":"Parcel","created_at":"2022-05-04T20:25:53Z","updated_at":"2022-05-04T20:25:53Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_ff71acc7d7424ff3a459139ab1ec2f29","created_at":"2022-05-04T20:25:53Z","updated_at":"2022-05-04T20:25:53Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:25:53Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/1b7e7bc4190442faa00ad3b9b0934c11.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_fc251ceae3024fe5aab18591af0e3f66","object":"Rate","created_at":"2022-05-04T20:25:53Z","updated_at":"2022-05-04T20:25:53Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f837fe0699d44b079e8586420b071bf1","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_6f53aa2b91da40738c8f7d59e19fe035","object":"Rate","created_at":"2022-05-04T20:25:53Z","updated_at":"2022-05-04T20:25:53Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f837fe0699d44b079e8586420b071bf1","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_6cb7c56de0b74c68b381c5f9b925d7e3","object":"Rate","created_at":"2022-05-04T20:25:53Z","updated_at":"2022-05-04T20:25:53Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_f837fe0699d44b079e8586420b071bf1","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_4bb3b983969d4425ab938d2da71fbc74","object":"Rate","created_at":"2022-05-04T20:25:53Z","updated_at":"2022-05-04T20:25:53Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_f837fe0699d44b079e8586420b071bf1","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_6f53aa2b91da40738c8f7d59e19fe035","object":"Rate","created_at":"2022-05-04T20:25:53Z","updated_at":"2022-05-04T20:25:53Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f837fe0699d44b079e8586420b071bf1","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_3799533fe78c45549e0e689b80375b81","object":"Tracker","mode":"test","tracking_code":"9400100109361117768808","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:25:53Z","updated_at":"2022-05-04T20:25:53Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_f837fe0699d44b079e8586420b071bf1","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzM3OTk1MzNmZTc4YzQ1NTQ5ZTBlNjg5YjgwMzc1Yjgx"},"to_address":{"id":"adr_650f0b5fcbe811ec8940ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:52+00:00","updated_at":"2022-05-04T20:25:53+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_65116f73cbe811eca172ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:53+00:00","updated_at":"2022-05-04T20:25:53+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_650f0b5fcbe811ec8940ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:52+00:00","updated_at":"2022-05-04T20:25:53+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_f837fe0699d44b079e8586420b071bf1","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:26:04Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130493862", "updated_at": "2022-07-28T20:26:05Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_813216bf0eb311eda0fbac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:26:04+00:00", "updated_at": "2022-07-28T20:26:04+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_983f1ad3d69e4cbcb7546a2bf6a0a37b",
+        "object": "Parcel", "created_at": "2022-07-28T20:26:04Z", "updated_at": "2022-07-28T20:26:04Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_dea92722ab954e5c990a42e871896906",
+        "created_at": "2022-07-28T20:26:05Z", "updated_at": "2022-07-28T20:26:05Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:26:05Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/8ec3d3a256d74b42a9ecd5a6740f0be6.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_7b6335a41af4489ca15d847eb3b97dae", "object":
+        "Rate", "created_at": "2022-07-28T20:26:04Z", "updated_at": "2022-07-28T20:26:04Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_02fa0264a98d46fe93e575de66d1c01c", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_cece468448bd451a894553131aed3eaf", "object": "Rate", "created_at":
+        "2022-07-28T20:26:04Z", "updated_at": "2022-07-28T20:26:04Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_02fa0264a98d46fe93e575de66d1c01c", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_c45aef46736a4fe7b1e4188c9331558e", "object": "Rate", "created_at":
+        "2022-07-28T20:26:04Z", "updated_at": "2022-07-28T20:26:04Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_02fa0264a98d46fe93e575de66d1c01c", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_01978ec83ae04a8d85cf03dc9b27d0e4", "object": "Rate", "created_at":
+        "2022-07-28T20:26:04Z", "updated_at": "2022-07-28T20:26:04Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_02fa0264a98d46fe93e575de66d1c01c", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_7b6335a41af4489ca15d847eb3b97dae",
+        "object": "Rate", "created_at": "2022-07-28T20:26:05Z", "updated_at": "2022-07-28T20:26:05Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_02fa0264a98d46fe93e575de66d1c01c", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_cbf2608048fd4edda458c22383fb123c", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493862", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T20:26:05Z", "updated_at":
+        "2022-07-28T20:26:05Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_02fa0264a98d46fe93e575de66d1c01c", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrX2NiZjI2MDgwNDhmZDRlZGRhNDU4YzIyMzgzZmIxMjNj"},
+        "to_address": {"id": "adr_813081d60eb311eda5bcac1f6b0a0d1e", "object": "Address",
+        "created_at": "2022-07-28T20:26:04+00:00", "updated_at": "2022-07-28T20:26:05+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_813216bf0eb311eda0fbac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:26:04+00:00", "updated_at": "2022-07-28T20:26:04+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_813081d60eb311eda5bcac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-28T20:26:04+00:00", "updated_at": "2022-07-28T20:26:05+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_02fa0264a98d46fe93e575de66d1c01c", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"cc2b6cd057004110a0595ceb85c8a7d3"
+      - W/"5a5e05113cabc241fc897b249d6950f4"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_f837fe0699d44b079e8586420b071bf1
+      - /api/v2/shipments/shp_02fa0264a98d46fe93e575de66d1c01c
       pragma:
       - no-cache
       referrer-policy:
@@ -64,20 +145,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bc6272e150e786b8a100162292
+      - a41775b762e2f0dcff23eae200000dee
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - extlb2nuq 403f17ff97
       x-runtime:
-      - '0.908308'
+      - '0.997199'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -86,9 +167,9 @@ interactions:
 - request:
     body: '{"pickup": {"address": {"name": "Jack Sparrow", "company": "EasyPost",
       "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
-      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-05-06",
-      "max_datetime": "2022-05-06", "instructions": "Pickup at front door", "shipment":
-      {"id": "shp_f837fe0699d44b079e8586420b071bf1"}}}'
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-07-29",
+      "max_datetime": "2022-07-29", "instructions": "Pickup at front door", "shipment":
+      {"id": "shp_02fa0264a98d46fe93e575de66d1c01c"}}}'
     headers:
       Accept:
       - '*/*'
@@ -108,10 +189,21 @@ interactions:
     uri: https://api.easypost.com/v2/pickups
   response:
     body:
-      string: '{"id":"pickup_a196e33f658242bd91529f61191295be","object":"Pickup","created_at":"2022-05-04T20:25:54Z","updated_at":"2022-05-04T20:25:54Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-06T00:00:00Z","max_datetime":"2022-05-06T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_65a4cb91cbe811ec9200ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:53+00:00","updated_at":"2022-05-04T20:25:53+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-04T20:25:54Z","updated_at":"2022-05-04T20:25:54Z","carrier":"USPS","pickup_id":"pickup_a196e33f658242bd91529f61191295be","id":"pickuprate_8ce8acd760734bbeb40bd92c6b859ae2","object":"PickupRate"}]}'
+      string: '{"id": "pickup_c625a690fa614febb0c7d94eb572e47b", "object": "Pickup",
+        "created_at": "2022-07-28T20:26:05Z", "updated_at": "2022-07-28T20:26:05Z",
+        "mode": "test", "status": "unknown", "reference": null, "min_datetime": "2022-07-29T00:00:00Z",
+        "max_datetime": "2022-07-29T00:00:00Z", "is_account_address": false, "instructions":
+        "Pickup at front door", "messages": [], "confirmation": null, "address": {"id":
+        "adr_81d4b9210eb311eda1c2ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:26:05+00:00", "updated_at": "2022-07-28T20:26:05+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "carrier_accounts": [], "pickup_rates": [{"mode": "test", "service":
+        "NextDay", "rate": "0.00", "currency": "USD", "created_at": "2022-07-28T20:26:06Z",
+        "updated_at": "2022-07-28T20:26:06Z", "carrier": "USPS", "pickup_id": "pickup_c625a690fa614febb0c7d94eb572e47b",
+        "id": "pickuprate_2269388b223f49f9a1a96e2a98190226", "object": "PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -120,7 +212,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"b0511d23b45845ffcba8cb0f098b5303"
+      - W/"d9ab6da3a4f6289649cd1dc223e46d63"
       expires:
       - '0'
       pragma:
@@ -138,20 +230,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bc6272e151e786b8a10016230d
+      - a41775b762e2f0ddff23eae200000e41
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb9nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - extlb2nuq 403f17ff97
       x-runtime:
-      - '0.702178'
+      - '0.715023'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -175,13 +267,24 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/pickups/pickup_a196e33f658242bd91529f61191295be/buy
+    uri: https://api.easypost.com/v2/pickups/pickup_c625a690fa614febb0c7d94eb572e47b/buy
   response:
     body:
-      string: '{"id":"pickup_a196e33f658242bd91529f61191295be","object":"Pickup","created_at":"2022-05-04T20:25:54Z","updated_at":"2022-05-04T20:25:55Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-05-06T00:00:00Z","max_datetime":"2022-05-06T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":"WTC61777384","address":{"id":"adr_65a4cb91cbe811ec9200ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:53+00:00","updated_at":"2022-05-04T20:25:53+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-04T20:25:54Z","updated_at":"2022-05-04T20:25:54Z","carrier":"USPS","pickup_id":"pickup_a196e33f658242bd91529f61191295be","id":"pickuprate_8ce8acd760734bbeb40bd92c6b859ae2","object":"PickupRate"}]}'
+      string: '{"id": "pickup_c625a690fa614febb0c7d94eb572e47b", "object": "Pickup",
+        "created_at": "2022-07-28T20:26:05Z", "updated_at": "2022-07-28T20:26:07Z",
+        "mode": "test", "status": "scheduled", "reference": null, "min_datetime":
+        "2022-07-29T00:00:00Z", "max_datetime": "2022-07-29T00:00:00Z", "is_account_address":
+        false, "instructions": "Pickup at front door", "messages": [], "confirmation":
+        "WTC61989170", "address": {"id": "adr_81d4b9210eb311eda1c2ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T20:26:05+00:00", "updated_at": "2022-07-28T20:26:05+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "carrier_accounts": [], "pickup_rates": [{"mode": "test", "service":
+        "NextDay", "rate": "0.00", "currency": "USD", "created_at": "2022-07-28T20:26:06Z",
+        "updated_at": "2022-07-28T20:26:06Z", "carrier": "USPS", "pickup_id": "pickup_c625a690fa614febb0c7d94eb572e47b",
+        "id": "pickuprate_2269388b223f49f9a1a96e2a98190226", "object": "PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -190,7 +293,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"92e9fd5f3764daca1d83475718911cae"
+      - W/"0cd35ee9f580b981b7cd048ec076dc53"
       expires:
       - '0'
       pragma:
@@ -208,20 +311,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bc6272e152e786b8a10016234e
+      - a41775b762e2f0deff23eae200000e8c
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb9nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - extlb2nuq 403f17ff97
       x-runtime:
-      - '1.052962'
+      - '1.090288'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_pickup_cancel.yaml
+++ b/tests/cassettes/test_pickup_cancel.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:25:56Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768815","updated_at":"2022-05-04T20:25:56Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_66dd3661cbe811eca1e5ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:56+00:00","updated_at":"2022-05-04T20:25:56+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_9b6e7c96135848ceaca9ddfd8e392903","object":"Parcel","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_f07b264cb97d49c39d37736c1fe9072a","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:25:56Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/2ba71f8f9c8043c29c7a628545e458de.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_02497804455d40819a23cde29d7ac42e","object":"Rate","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_3f4617c0bd7d48c0826429d909e98106","object":"Rate","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_8561ef9aa5e948e6a2fa1bd967ea2716","object":"Rate","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_c95d3056d6fb43f1812bc6905dd5c6a9","object":"Rate","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_8561ef9aa5e948e6a2fa1bd967ea2716","object":"Rate","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_66176ea992e94d2dab049f1646a23167","object":"Tracker","mode":"test","tracking_code":"9400100109361117768815","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzY2MTc2ZWE5OTJlOTRkMmRhYjA0OWYxNjQ2YTIzMTY3"},"to_address":{"id":"adr_66db3fcecbe811ec9258ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:56+00:00","updated_at":"2022-05-04T20:25:56+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_66dd3661cbe811eca1e5ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:56+00:00","updated_at":"2022-05-04T20:25:56+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_66db3fcecbe811ec9258ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:56+00:00","updated_at":"2022-05-04T20:25:56+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_ec4cecb611444a7eb251247061ced771","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:26:07Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130493879", "updated_at": "2022-07-28T20:26:08Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_8313be270eb311eda57aac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:26:07+00:00", "updated_at": "2022-07-28T20:26:07+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_0f7671034a9240ed9542666a15855ae3",
+        "object": "Parcel", "created_at": "2022-07-28T20:26:07Z", "updated_at": "2022-07-28T20:26:07Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_2adde98b36d14f85a5ffb5021b11a9ad",
+        "created_at": "2022-07-28T20:26:08Z", "updated_at": "2022-07-28T20:26:08Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:26:08Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/b1b7a101e5a5447193017b29debea2ce.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_6fb416fd32ad4adcaf610c1bd716a77f", "object":
+        "Rate", "created_at": "2022-07-28T20:26:08Z", "updated_at": "2022-07-28T20:26:08Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_39e2bc8fa8884564b66de8418cb64e1f", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_0e132487cc3a45f8b1f6035b015c4b25",
+        "object": "Rate", "created_at": "2022-07-28T20:26:08Z", "updated_at": "2022-07-28T20:26:08Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_39e2bc8fa8884564b66de8418cb64e1f", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_da704197bc7f4d17b4f7f85f218a38b4", "object": "Rate", "created_at":
+        "2022-07-28T20:26:08Z", "updated_at": "2022-07-28T20:26:08Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_39e2bc8fa8884564b66de8418cb64e1f", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_c180b79f7eae48eb80869c7856c6750f", "object": "Rate", "created_at":
+        "2022-07-28T20:26:08Z", "updated_at": "2022-07-28T20:26:08Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_39e2bc8fa8884564b66de8418cb64e1f", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_0e132487cc3a45f8b1f6035b015c4b25",
+        "object": "Rate", "created_at": "2022-07-28T20:26:08Z", "updated_at": "2022-07-28T20:26:08Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_39e2bc8fa8884564b66de8418cb64e1f", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_2983fff2e7b0446697a01da3b7446858", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493879", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T20:26:08Z", "updated_at":
+        "2022-07-28T20:26:08Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_39e2bc8fa8884564b66de8418cb64e1f", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzI5ODNmZmYyZTdiMDQ0NjY5N2EwMWRhM2I3NDQ2ODU4"},
+        "to_address": {"id": "adr_831224b70eb311eda579ac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-28T20:26:07+00:00", "updated_at": "2022-07-28T20:26:08+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_8313be270eb311eda57aac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:26:07+00:00", "updated_at": "2022-07-28T20:26:07+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_831224b70eb311eda579ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T20:26:07+00:00", "updated_at": "2022-07-28T20:26:08+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_39e2bc8fa8884564b66de8418cb64e1f", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"0991deed0ce8392772512c6b9bf21c26"
+      - W/"db75a1fd4efa978a4b951737c609b36f"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_ec4cecb611444a7eb251247061ced771
+      - /api/v2/shipments/shp_39e2bc8fa8884564b66de8418cb64e1f
       pragma:
       - no-cache
       referrer-policy:
@@ -64,20 +145,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330be6272e153e786b8a3001623e0
+      - efdf9e0562e2f0dfff23eafc0001d5b9
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.920166'
+      - '0.997125'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -86,9 +168,9 @@ interactions:
 - request:
     body: '{"pickup": {"address": {"name": "Jack Sparrow", "company": "EasyPost",
       "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
-      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-05-06",
-      "max_datetime": "2022-05-06", "instructions": "Pickup at front door", "shipment":
-      {"id": "shp_ec4cecb611444a7eb251247061ced771"}}}'
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-07-29",
+      "max_datetime": "2022-07-29", "instructions": "Pickup at front door", "shipment":
+      {"id": "shp_39e2bc8fa8884564b66de8418cb64e1f"}}}'
     headers:
       Accept:
       - '*/*'
@@ -108,10 +190,21 @@ interactions:
     uri: https://api.easypost.com/v2/pickups
   response:
     body:
-      string: '{"id":"pickup_9416d45c41b648778fd9b438bff6a85a","object":"Pickup","created_at":"2022-05-04T20:25:57Z","updated_at":"2022-05-04T20:25:57Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-06T00:00:00Z","max_datetime":"2022-05-06T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_677249f3cbe811ec9289ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:57+00:00","updated_at":"2022-05-04T20:25:57+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-04T20:25:57Z","updated_at":"2022-05-04T20:25:57Z","carrier":"USPS","pickup_id":"pickup_9416d45c41b648778fd9b438bff6a85a","id":"pickuprate_9fc2ad19a18d4dde878240f0a0401894","object":"PickupRate"}]}'
+      string: '{"id": "pickup_f2748b8ee8b8413a85e15da1ee6842c2", "object": "Pickup",
+        "created_at": "2022-07-28T20:26:09Z", "updated_at": "2022-07-28T20:26:09Z",
+        "mode": "test", "status": "unknown", "reference": null, "min_datetime": "2022-07-29T00:00:00Z",
+        "max_datetime": "2022-07-29T00:00:00Z", "is_account_address": false, "instructions":
+        "Pickup at front door", "messages": [], "confirmation": null, "address": {"id":
+        "adr_83c189540eb311eda670ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:26:09+00:00", "updated_at": "2022-07-28T20:26:09+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "carrier_accounts": [], "pickup_rates": [{"mode": "test", "service":
+        "NextDay", "rate": "0.00", "currency": "USD", "created_at": "2022-07-28T20:26:09Z",
+        "updated_at": "2022-07-28T20:26:09Z", "carrier": "USPS", "pickup_id": "pickup_f2748b8ee8b8413a85e15da1ee6842c2",
+        "id": "pickuprate_6fdbff3930744601b705f405c054fab7", "object": "PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -120,7 +213,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"0e2022e8d18ee23d8227cfa0b3382e4b"
+      - W/"18e82f35fc87e507c001f0fd5c3c9fc5"
       expires:
       - '0'
       pragma:
@@ -138,20 +231,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330be6272e154e786b8a300162446
+      - efdf9e0562e2f0e0ff23eafc0001d62b
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb2nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.925428'
+      - '0.729180'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -175,13 +269,24 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/pickups/pickup_9416d45c41b648778fd9b438bff6a85a/buy
+    uri: https://api.easypost.com/v2/pickups/pickup_f2748b8ee8b8413a85e15da1ee6842c2/buy
   response:
     body:
-      string: '{"id":"pickup_9416d45c41b648778fd9b438bff6a85a","object":"Pickup","created_at":"2022-05-04T20:25:57Z","updated_at":"2022-05-04T20:25:58Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-05-06T00:00:00Z","max_datetime":"2022-05-06T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":"WTC61777386","address":{"id":"adr_677249f3cbe811ec9289ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:57+00:00","updated_at":"2022-05-04T20:25:57+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-04T20:25:57Z","updated_at":"2022-05-04T20:25:57Z","carrier":"USPS","pickup_id":"pickup_9416d45c41b648778fd9b438bff6a85a","id":"pickuprate_9fc2ad19a18d4dde878240f0a0401894","object":"PickupRate"}]}'
+      string: '{"id": "pickup_f2748b8ee8b8413a85e15da1ee6842c2", "object": "Pickup",
+        "created_at": "2022-07-28T20:26:09Z", "updated_at": "2022-07-28T20:26:11Z",
+        "mode": "test", "status": "scheduled", "reference": null, "min_datetime":
+        "2022-07-29T00:00:00Z", "max_datetime": "2022-07-29T00:00:00Z", "is_account_address":
+        false, "instructions": "Pickup at front door", "messages": [], "confirmation":
+        "WTC61989172", "address": {"id": "adr_83c189540eb311eda670ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T20:26:09+00:00", "updated_at": "2022-07-28T20:26:09+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "carrier_accounts": [], "pickup_rates": [{"mode": "test", "service":
+        "NextDay", "rate": "0.00", "currency": "USD", "created_at": "2022-07-28T20:26:09Z",
+        "updated_at": "2022-07-28T20:26:09Z", "carrier": "USPS", "pickup_id": "pickup_f2748b8ee8b8413a85e15da1ee6842c2",
+        "id": "pickuprate_6fdbff3930744601b705f405c054fab7", "object": "PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -190,7 +295,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"0882cee04aa9da198c6675c97cb404eb"
+      - W/"bc0de12dc2c81308309da04c2ecb41b3"
       expires:
       - '0'
       pragma:
@@ -208,20 +313,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330be6272e155e786b8a3001624b7
+      - efdf9e0562e2f0e1ff23eafc0001d742
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.771490'
+      - '1.167474'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -245,13 +351,24 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/pickups/pickup_9416d45c41b648778fd9b438bff6a85a/cancel
+    uri: https://api.easypost.com/v2/pickups/pickup_f2748b8ee8b8413a85e15da1ee6842c2/cancel
   response:
     body:
-      string: '{"id":"pickup_9416d45c41b648778fd9b438bff6a85a","object":"Pickup","created_at":"2022-05-04T20:25:57Z","updated_at":"2022-05-04T20:25:59Z","mode":"test","status":"canceled","reference":null,"min_datetime":"2022-05-06T00:00:00Z","max_datetime":"2022-05-06T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":"WTC61777386","address":{"id":"adr_677249f3cbe811ec9289ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:57+00:00","updated_at":"2022-05-04T20:25:57+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-04T20:25:57Z","updated_at":"2022-05-04T20:25:57Z","carrier":"USPS","pickup_id":"pickup_9416d45c41b648778fd9b438bff6a85a","id":"pickuprate_9fc2ad19a18d4dde878240f0a0401894","object":"PickupRate"}]}'
+      string: '{"id": "pickup_f2748b8ee8b8413a85e15da1ee6842c2", "object": "Pickup",
+        "created_at": "2022-07-28T20:26:09Z", "updated_at": "2022-07-28T20:26:12Z",
+        "mode": "test", "status": "canceled", "reference": null, "min_datetime": "2022-07-29T00:00:00Z",
+        "max_datetime": "2022-07-29T00:00:00Z", "is_account_address": false, "instructions":
+        "Pickup at front door", "messages": [], "confirmation": "WTC61989172", "address":
+        {"id": "adr_83c189540eb311eda670ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:26:09+00:00", "updated_at": "2022-07-28T20:26:09+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "carrier_accounts": [], "pickup_rates": [{"mode": "test", "service":
+        "NextDay", "rate": "0.00", "currency": "USD", "created_at": "2022-07-28T20:26:09Z",
+        "updated_at": "2022-07-28T20:26:09Z", "carrier": "USPS", "pickup_id": "pickup_f2748b8ee8b8413a85e15da1ee6842c2",
+        "id": "pickuprate_6fdbff3930744601b705f405c054fab7", "object": "PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -260,7 +377,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"b3133f51ab81cb9ecc95d1c328263733"
+      - W/"93187997ec2cd76b223868727701db9f"
       expires:
       - '0'
       pragma:
@@ -278,20 +395,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330be6272e157e786b8a300162524
+      - efdf9e0562e2f0e3ff23eafc0001d7d2
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb9nuq
+      - bigweb2nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.863366'
+      - '0.869820'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_pickup_create.yaml
+++ b/tests/cassettes/test_pickup_create.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:25:48Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768785","updated_at":"2022-05-04T20:25:49Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_6284175fcbe811eca0efac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:48+00:00","updated_at":"2022-05-04T20:25:48+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_be57fcb4f69d4772b1efd6f759f4f843","object":"Parcel","created_at":"2022-05-04T20:25:48Z","updated_at":"2022-05-04T20:25:48Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_b510e5bba5af477b92123b661ca52e62","created_at":"2022-05-04T20:25:49Z","updated_at":"2022-05-04T20:25:49Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:25:49Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/cc1efbff41dd46b3832391ebfacfc768.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_3b35d41d419f4c269d61ed816f6e35ed","object":"Rate","created_at":"2022-05-04T20:25:48Z","updated_at":"2022-05-04T20:25:48Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_8fb56db4b9504711a625163e5b35af59","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_a85628cf4c514b25b4a74eec4fd7aff7","object":"Rate","created_at":"2022-05-04T20:25:48Z","updated_at":"2022-05-04T20:25:48Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8fb56db4b9504711a625163e5b35af59","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_539a9bf42f2f42d98c6f5c91a069a6f9","object":"Rate","created_at":"2022-05-04T20:25:48Z","updated_at":"2022-05-04T20:25:48Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_8fb56db4b9504711a625163e5b35af59","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_4c332953c4f54099bce85e154ad51f02","object":"Rate","created_at":"2022-05-04T20:25:48Z","updated_at":"2022-05-04T20:25:48Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8fb56db4b9504711a625163e5b35af59","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_4c332953c4f54099bce85e154ad51f02","object":"Rate","created_at":"2022-05-04T20:25:49Z","updated_at":"2022-05-04T20:25:49Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8fb56db4b9504711a625163e5b35af59","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_fb495beb021445a9a1dbfa23cb0b765f","object":"Tracker","mode":"test","tracking_code":"9400100109361117768785","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:25:49Z","updated_at":"2022-05-04T20:25:49Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_8fb56db4b9504711a625163e5b35af59","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2ZiNDk1YmViMDIxNDQ1YTlhMWRiZmEyM2NiMGI3NjVm"},"to_address":{"id":"adr_628265c0cbe811ec9165ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:48+00:00","updated_at":"2022-05-04T20:25:48+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_6284175fcbe811eca0efac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:48+00:00","updated_at":"2022-05-04T20:25:48+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_628265c0cbe811ec9165ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:48+00:00","updated_at":"2022-05-04T20:25:48+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_8fb56db4b9504711a625163e5b35af59","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:25:59Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130493848", "updated_at": "2022-07-28T20:26:00Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_7e3186a60eb311ed9df8ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:25:59+00:00", "updated_at": "2022-07-28T20:25:59+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_4e54ded5879a4d67b6a68a2b84270753",
+        "object": "Parcel", "created_at": "2022-07-28T20:25:59Z", "updated_at": "2022-07-28T20:25:59Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_78565b26a581481da7745e0649a8c789",
+        "created_at": "2022-07-28T20:26:00Z", "updated_at": "2022-07-28T20:26:00Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:26:00Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/f5730aa086d4487fac9087dca33161c3.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_e6f61a7cce07463aa6d35e455c5eb6da", "object":
+        "Rate", "created_at": "2022-07-28T20:25:59Z", "updated_at": "2022-07-28T20:25:59Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_b5e774c5ff4c4df7a8850198b852dcdc", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_6154189183b14b6fb3d70ec67c2b3aa2",
+        "object": "Rate", "created_at": "2022-07-28T20:25:59Z", "updated_at": "2022-07-28T20:25:59Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_b5e774c5ff4c4df7a8850198b852dcdc", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_ee14b6c2bc474db89676a9aa038f7450",
+        "object": "Rate", "created_at": "2022-07-28T20:25:59Z", "updated_at": "2022-07-28T20:25:59Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_b5e774c5ff4c4df7a8850198b852dcdc", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_d7219690898043e999e43e142cfa6b55", "object": "Rate", "created_at":
+        "2022-07-28T20:25:59Z", "updated_at": "2022-07-28T20:25:59Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_b5e774c5ff4c4df7a8850198b852dcdc", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_ee14b6c2bc474db89676a9aa038f7450",
+        "object": "Rate", "created_at": "2022-07-28T20:26:00Z", "updated_at": "2022-07-28T20:26:00Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_b5e774c5ff4c4df7a8850198b852dcdc", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_c68667454d0a413c88541755c40ab9c6", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493848", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T20:26:00Z", "updated_at":
+        "2022-07-28T20:26:00Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_b5e774c5ff4c4df7a8850198b852dcdc", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrX2M2ODY2NzQ1NGQwYTQxM2M4ODU0MTc1NWM0MGFiOWM2"},
+        "to_address": {"id": "adr_7e2fa75c0eb311edb616ac1f6bc7bdc6", "object": "Address",
+        "created_at": "2022-07-28T20:25:59+00:00", "updated_at": "2022-07-28T20:25:59+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_7e3186a60eb311ed9df8ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:25:59+00:00", "updated_at": "2022-07-28T20:25:59+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_7e2fa75c0eb311edb616ac1f6bc7bdc6", "object":
+        "Address", "created_at": "2022-07-28T20:25:59+00:00", "updated_at": "2022-07-28T20:25:59+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_b5e774c5ff4c4df7a8850198b852dcdc", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"000d3c39cff2b51329dd06aa16326edb"
+      - W/"5525020ef4491ea1de458bbd6c59c7f6"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_8fb56db4b9504711a625163e5b35af59
+      - /api/v2/shipments/shp_b5e774c5ff4c4df7a8850198b852dcdc
       pragma:
       - no-cache
       referrer-policy:
@@ -59,25 +140,28 @@ interactions:
       - chunked
       x-backend:
       - easypost
+      x-canary:
+      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bd6272e14ce786b89f001620c9
+      - b0657e4162e2f0d7ff23eadf00360b7f
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb7nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '1.099036'
+      - '1.037633'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -86,9 +170,9 @@ interactions:
 - request:
     body: '{"pickup": {"address": {"name": "Jack Sparrow", "company": "EasyPost",
       "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
-      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-05-06",
-      "max_datetime": "2022-05-06", "instructions": "Pickup at front door", "shipment":
-      {"id": "shp_8fb56db4b9504711a625163e5b35af59"}}}'
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-07-29",
+      "max_datetime": "2022-07-29", "instructions": "Pickup at front door", "shipment":
+      {"id": "shp_b5e774c5ff4c4df7a8850198b852dcdc"}}}'
     headers:
       Accept:
       - '*/*'
@@ -108,10 +192,21 @@ interactions:
     uri: https://api.easypost.com/v2/pickups
   response:
     body:
-      string: '{"id":"pickup_9c545da309d749a1b673e1cd791e48e6","object":"Pickup","created_at":"2022-05-04T20:25:49Z","updated_at":"2022-05-04T20:25:49Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-06T00:00:00Z","max_datetime":"2022-05-06T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_633502e9cbe811ec88e2ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:49+00:00","updated_at":"2022-05-04T20:25:49+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-04T20:25:50Z","updated_at":"2022-05-04T20:25:50Z","carrier":"USPS","pickup_id":"pickup_9c545da309d749a1b673e1cd791e48e6","id":"pickuprate_05c860a4ae034b4583dac7bde3c97002","object":"PickupRate"}]}'
+      string: '{"id": "pickup_f25af674d7a34017aa82f3ff70109d17", "object": "Pickup",
+        "created_at": "2022-07-28T20:26:00Z", "updated_at": "2022-07-28T20:26:00Z",
+        "mode": "test", "status": "unknown", "reference": null, "min_datetime": "2022-07-29T00:00:00Z",
+        "max_datetime": "2022-07-29T00:00:00Z", "is_account_address": false, "instructions":
+        "Pickup at front door", "messages": [], "confirmation": null, "address": {"id":
+        "adr_7ee5e43b0eb311edb693ac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-28T20:26:00+00:00", "updated_at": "2022-07-28T20:26:00+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "carrier_accounts": [], "pickup_rates": [{"mode": "test", "service":
+        "NextDay", "rate": "0.00", "currency": "USD", "created_at": "2022-07-28T20:26:01Z",
+        "updated_at": "2022-07-28T20:26:01Z", "carrier": "USPS", "pickup_id": "pickup_f25af674d7a34017aa82f3ff70109d17",
+        "id": "pickuprate_0e68fc8b58ba4c48912adf4563bb560e", "object": "PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -120,7 +215,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"e61a8dbade6374518e7ec2e104041c44"
+      - W/"1ea629ef3e29a7b4ba81e23c05b54472"
       expires:
       - '0'
       pragma:
@@ -138,20 +233,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bd6272e14de786b89f0016213d
+      - b0657e4162e2f0d8ff23eadf00360bd0
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb9nuq
+      - bigweb2nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.805318'
+      - '0.778876'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_pickup_lowest_rate.yaml
+++ b/tests/cassettes/test_pickup_lowest_rate.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:00Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768839","updated_at":"2022-05-04T20:26:01Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_6951a811cbe811eca298ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:00+00:00","updated_at":"2022-05-04T20:26:00+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_c363a8b0d36d41ffa59da05a519845ea","object":"Parcel","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_2e38297ac4d044abbc13e62b9dc7f95b","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:01Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:00Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/093c2153e2d8437b9b20c001712bf9fe.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_2905ed21cebe461ebc6f986c29f5304c","object":"Rate","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_65ab7653326b429491d9a7320e9b6d62","object":"Rate","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_d21af3c219f845d1bdec0aa9261b0fa7","object":"Rate","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_fdd96103d81a46d19494c4e4a8f23218","object":"Rate","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_d21af3c219f845d1bdec0aa9261b0fa7","object":"Rate","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_89ce0d1cd1b14a9eb4b24ac87eb4f552","object":"Tracker","mode":"test","tracking_code":"9400100109361117768839","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:26:01Z","updated_at":"2022-05-04T20:26:01Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzg5Y2UwZDFjZDFiMTRhOWViNGIyNGFjODdlYjRmNTUy"},"to_address":{"id":"adr_694feef2cbe811ec9303ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:00+00:00","updated_at":"2022-05-04T20:26:00+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_6951a811cbe811eca298ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:00+00:00","updated_at":"2022-05-04T20:26:00+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_694feef2cbe811ec9303ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:00+00:00","updated_at":"2022-05-04T20:26:00+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_f5288013455341fa8b320ac6ae2ba40f","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:26:12Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130493886", "updated_at": "2022-07-28T20:26:13Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_85b74c930eb311edaa4aac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T20:26:12+00:00", "updated_at": "2022-07-28T20:26:12+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_258753877b21495a96c544841fe7c6b7",
+        "object": "Parcel", "created_at": "2022-07-28T20:26:12Z", "updated_at": "2022-07-28T20:26:12Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_5cac5f2b4a654e1f9f1eedbda701e78a",
+        "created_at": "2022-07-28T20:26:13Z", "updated_at": "2022-07-28T20:26:13Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:26:13Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/edb07806acf3418dba199909c53eebc8.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_ea03ced1aaba4a91b37da045a7705335", "object":
+        "Rate", "created_at": "2022-07-28T20:26:12Z", "updated_at": "2022-07-28T20:26:12Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_76f8e1ec84f44e1a9bf300dc002aa9dc", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_083109eec5db4b5e8f28eb6aede379fd",
+        "object": "Rate", "created_at": "2022-07-28T20:26:12Z", "updated_at": "2022-07-28T20:26:12Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_76f8e1ec84f44e1a9bf300dc002aa9dc", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_cb47559439104b7682dc942ce009409e", "object": "Rate", "created_at":
+        "2022-07-28T20:26:12Z", "updated_at": "2022-07-28T20:26:12Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_76f8e1ec84f44e1a9bf300dc002aa9dc", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_8817e05621ba47bebc8115268e06b7b4", "object": "Rate", "created_at":
+        "2022-07-28T20:26:12Z", "updated_at": "2022-07-28T20:26:12Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_76f8e1ec84f44e1a9bf300dc002aa9dc", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_083109eec5db4b5e8f28eb6aede379fd",
+        "object": "Rate", "created_at": "2022-07-28T20:26:13Z", "updated_at": "2022-07-28T20:26:13Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_76f8e1ec84f44e1a9bf300dc002aa9dc", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_4e7277d761b048f8952634bd06e205bc", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493886", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T20:26:13Z", "updated_at":
+        "2022-07-28T20:26:13Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_76f8e1ec84f44e1a9bf300dc002aa9dc", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzRlNzI3N2Q3NjFiMDQ4Zjg5NTI2MzRiZDA2ZTIwNWJj"},
+        "to_address": {"id": "adr_85b53bb20eb311eda578ac1f6bc72124", "object": "Address",
+        "created_at": "2022-07-28T20:26:12+00:00", "updated_at": "2022-07-28T20:26:12+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_85b74c930eb311edaa4aac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T20:26:12+00:00", "updated_at": "2022-07-28T20:26:12+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_85b53bb20eb311eda578ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T20:26:12+00:00", "updated_at": "2022-07-28T20:26:12+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_76f8e1ec84f44e1a9bf300dc002aa9dc", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"a6435080434f4978966a9ceed0a0de5c"
+      - W/"1952120b71aa77f521e4dd655fa64c76"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_f5288013455341fa8b320ac6ae2ba40f
+      - /api/v2/shipments/shp_76f8e1ec84f44e1a9bf300dc002aa9dc
       pragma:
       - no-cache
       referrer-policy:
@@ -64,20 +145,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b96272e158e786b8a400162596
+      - b0657e4062e2f0e4ff23eafd00360f48
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb9nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '1.127057'
+      - '1.142226'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -86,9 +168,9 @@ interactions:
 - request:
     body: '{"pickup": {"address": {"name": "Jack Sparrow", "company": "EasyPost",
       "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
-      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-05-06",
-      "max_datetime": "2022-05-06", "instructions": "Pickup at front door", "shipment":
-      {"id": "shp_f5288013455341fa8b320ac6ae2ba40f"}}}'
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-07-29",
+      "max_datetime": "2022-07-29", "instructions": "Pickup at front door", "shipment":
+      {"id": "shp_76f8e1ec84f44e1a9bf300dc002aa9dc"}}}'
     headers:
       Accept:
       - '*/*'
@@ -108,10 +190,21 @@ interactions:
     uri: https://api.easypost.com/v2/pickups
   response:
     body:
-      string: '{"id":"pickup_6affcfed56cf4947b38972a64c4292c9","object":"Pickup","created_at":"2022-05-04T20:26:01Z","updated_at":"2022-05-04T20:26:01Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-06T00:00:00Z","max_datetime":"2022-05-06T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_6a065ba1cbe811eca2b2ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:01+00:00","updated_at":"2022-05-04T20:26:01+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-04T20:26:01Z","updated_at":"2022-05-04T20:26:01Z","carrier":"USPS","pickup_id":"pickup_6affcfed56cf4947b38972a64c4292c9","id":"pickuprate_b9e96c4b0ef748abbd62c5b1855dfcd9","object":"PickupRate"}]}'
+      string: '{"id": "pickup_0859a07d80f94e9a8e5148cbf134ece6", "object": "Pickup",
+        "created_at": "2022-07-28T20:26:13Z", "updated_at": "2022-07-28T20:26:13Z",
+        "mode": "test", "status": "unknown", "reference": null, "min_datetime": "2022-07-29T00:00:00Z",
+        "max_datetime": "2022-07-29T00:00:00Z", "is_account_address": false, "instructions":
+        "Pickup at front door", "messages": [], "confirmation": null, "address": {"id":
+        "adr_8679b36a0eb311edaa79ac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T20:26:13+00:00", "updated_at": "2022-07-28T20:26:13+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "carrier_accounts": [], "pickup_rates": [{"mode": "test", "service":
+        "NextDay", "rate": "0.00", "currency": "USD", "created_at": "2022-07-28T20:26:14Z",
+        "updated_at": "2022-07-28T20:26:14Z", "carrier": "USPS", "pickup_id": "pickup_0859a07d80f94e9a8e5148cbf134ece6",
+        "id": "pickuprate_a7f18ecc880c44a081eeaed67be32b59", "object": "PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -120,7 +213,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"930456a189be2c46628dfb39f7939635"
+      - W/"1c10d878baecd9f7e4269177925c1b37"
       expires:
       - '0'
       pragma:
@@ -138,20 +231,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b96272e159e786b8a400162617
+      - b0657e4062e2f0e5ff23eafd00360f95
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.676594'
+      - '0.798338'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_pickup_retrieve.yaml
+++ b/tests/cassettes/test_pickup_retrieve.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:25:50Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768792","updated_at":"2022-05-04T20:25:51Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_63d16cc7cbe811ec8900ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:50+00:00","updated_at":"2022-05-04T20:25:50+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_41f1b211669947ccbd8809df07d9ffa8","object":"Parcel","created_at":"2022-05-04T20:25:50Z","updated_at":"2022-05-04T20:25:50Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_3a5aa93557424ace8170e6918ad0d70b","created_at":"2022-05-04T20:25:51Z","updated_at":"2022-05-04T20:25:51Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:25:51Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/5fbe2ff7e200494da89376e1e6e761ef.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_30098f8f57dd4524b53d36b60ea126e2","object":"Rate","created_at":"2022-05-04T20:25:51Z","updated_at":"2022-05-04T20:25:51Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9495b7343a544c738f5abeb593c570e2","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_126d502f7cc642b1bc6c7e6063c3eb41","object":"Rate","created_at":"2022-05-04T20:25:51Z","updated_at":"2022-05-04T20:25:51Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9495b7343a544c738f5abeb593c570e2","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_ecf0af7374cf44e6bbe31f93d6af6e62","object":"Rate","created_at":"2022-05-04T20:25:51Z","updated_at":"2022-05-04T20:25:51Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9495b7343a544c738f5abeb593c570e2","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_ce88c8a539774349aaf55569e47c419f","object":"Rate","created_at":"2022-05-04T20:25:51Z","updated_at":"2022-05-04T20:25:51Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9495b7343a544c738f5abeb593c570e2","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_ce88c8a539774349aaf55569e47c419f","object":"Rate","created_at":"2022-05-04T20:25:51Z","updated_at":"2022-05-04T20:25:51Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9495b7343a544c738f5abeb593c570e2","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_68c9482836ea47d2930fb03066cb7499","object":"Tracker","mode":"test","tracking_code":"9400100109361117768792","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:25:51Z","updated_at":"2022-05-04T20:25:51Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_9495b7343a544c738f5abeb593c570e2","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzY4Yzk0ODI4MzZlYTQ3ZDI5MzBmYjAzMDY2Y2I3NDk5"},"to_address":{"id":"adr_63cf9a62cbe811ec91acac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:50+00:00","updated_at":"2022-05-04T20:25:51+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_63d16cc7cbe811ec8900ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:50+00:00","updated_at":"2022-05-04T20:25:50+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_63cf9a62cbe811ec91acac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:50+00:00","updated_at":"2022-05-04T20:25:51+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_9495b7343a544c738f5abeb593c570e2","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:26:01Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130493855", "updated_at": "2022-07-28T20:26:02Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_7f861e7d0eb311edb6d8ac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-28T20:26:01+00:00", "updated_at": "2022-07-28T20:26:01+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_fba96f3aa19a45db903857008d3888d7",
+        "object": "Parcel", "created_at": "2022-07-28T20:26:01Z", "updated_at": "2022-07-28T20:26:01Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_1b0420c5347642e4a625341cb77e79cd",
+        "created_at": "2022-07-28T20:26:02Z", "updated_at": "2022-07-28T20:26:02Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:26:02Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/7ca7824eaba3431db8c4d6f85ebcdc3d.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_891d75dd52cf48f7aa3e0bf360182130", "object":
+        "Rate", "created_at": "2022-07-28T20:26:02Z", "updated_at": "2022-07-28T20:26:02Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_3aceb0ded30e4381a8ec14bd4b2d7fa3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_561164313d324916beeb0027092ac28c",
+        "object": "Rate", "created_at": "2022-07-28T20:26:02Z", "updated_at": "2022-07-28T20:26:02Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_3aceb0ded30e4381a8ec14bd4b2d7fa3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_a39bfa3644744e50aff7d1ac6fcd0a77",
+        "object": "Rate", "created_at": "2022-07-28T20:26:02Z", "updated_at": "2022-07-28T20:26:02Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_3aceb0ded30e4381a8ec14bd4b2d7fa3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_01341e5544f64f888bd05f250bc50d13",
+        "object": "Rate", "created_at": "2022-07-28T20:26:02Z", "updated_at": "2022-07-28T20:26:02Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_3aceb0ded30e4381a8ec14bd4b2d7fa3", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_01341e5544f64f888bd05f250bc50d13",
+        "object": "Rate", "created_at": "2022-07-28T20:26:02Z", "updated_at": "2022-07-28T20:26:02Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_3aceb0ded30e4381a8ec14bd4b2d7fa3", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_3070d439512849cabd8ad92dc9ea596a", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493855", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T20:26:02Z", "updated_at":
+        "2022-07-28T20:26:02Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_3aceb0ded30e4381a8ec14bd4b2d7fa3", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzMwNzBkNDM5NTEyODQ5Y2FiZDhhZDkyZGM5ZWE1OTZh"},
+        "to_address": {"id": "adr_7f843fc50eb311eda1bfac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-28T20:26:01+00:00", "updated_at": "2022-07-28T20:26:02+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_7f861e7d0eb311edb6d8ac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-28T20:26:01+00:00", "updated_at": "2022-07-28T20:26:01+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_7f843fc50eb311eda1bfac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T20:26:01+00:00", "updated_at": "2022-07-28T20:26:02+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_3aceb0ded30e4381a8ec14bd4b2d7fa3", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"49c4e4997a9f890a53a2eb0dfa41fa58"
+      - W/"a8383304c7ea779e83fff6e3b2684e11"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_9495b7343a544c738f5abeb593c570e2
+      - /api/v2/shipments/shp_3aceb0ded30e4381a8ec14bd4b2d7fa3
       pragma:
       - no-cache
       referrer-policy:
@@ -64,20 +145,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bd6272e14ee786b8a0001621a9
+      - 97a38db262e2f0d9ff23eae1000147eb
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - extlb1nuq 403f17ff97
       x-runtime:
-      - '0.888630'
+      - '1.014812'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -86,9 +167,9 @@ interactions:
 - request:
     body: '{"pickup": {"address": {"name": "Jack Sparrow", "company": "EasyPost",
       "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
-      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-05-06",
-      "max_datetime": "2022-05-06", "instructions": "Pickup at front door", "shipment":
-      {"id": "shp_9495b7343a544c738f5abeb593c570e2"}}}'
+      "state": "CA", "zip": "94107", "phone": "5555555555"}, "min_datetime": "2022-07-29",
+      "max_datetime": "2022-07-29", "instructions": "Pickup at front door", "shipment":
+      {"id": "shp_3aceb0ded30e4381a8ec14bd4b2d7fa3"}}}'
     headers:
       Accept:
       - '*/*'
@@ -108,10 +189,21 @@ interactions:
     uri: https://api.easypost.com/v2/pickups
   response:
     body:
-      string: '{"id":"pickup_12265694f7474f6fa46f982b9471910a","object":"Pickup","created_at":"2022-05-04T20:25:51Z","updated_at":"2022-05-04T20:25:51Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-06T00:00:00Z","max_datetime":"2022-05-06T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_6461f574cbe811eca151ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:51+00:00","updated_at":"2022-05-04T20:25:51+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-04T20:25:52Z","updated_at":"2022-05-04T20:25:52Z","carrier":"USPS","pickup_id":"pickup_12265694f7474f6fa46f982b9471910a","id":"pickuprate_4d9e022aa49e4fa785d111e8b41d7446","object":"PickupRate"}]}'
+      string: '{"id": "pickup_4cd93be6be784446a46231f5aea66316", "object": "Pickup",
+        "created_at": "2022-07-28T20:26:03Z", "updated_at": "2022-07-28T20:26:03Z",
+        "mode": "test", "status": "unknown", "reference": null, "min_datetime": "2022-07-29T00:00:00Z",
+        "max_datetime": "2022-07-29T00:00:00Z", "is_account_address": false, "instructions":
+        "Pickup at front door", "messages": [], "confirmation": null, "address": {"id":
+        "adr_802b335a0eb311eda241ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:26:03+00:00", "updated_at": "2022-07-28T20:26:03+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "carrier_accounts": [], "pickup_rates": [{"mode": "test", "service":
+        "NextDay", "rate": "0.00", "currency": "USD", "created_at": "2022-07-28T20:26:04Z",
+        "updated_at": "2022-07-28T20:26:04Z", "carrier": "USPS", "pickup_id": "pickup_4cd93be6be784446a46231f5aea66316",
+        "id": "pickuprate_ffc2339b10434056b62b5db1bb002d84", "object": "PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -120,7 +212,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"2f473c7f9d8ffee26647f9fe3870030c"
+      - W/"666ffddd791f1ec253c6fe1d05c70075"
       expires:
       - '0'
       pragma:
@@ -138,20 +230,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bd6272e14fe786b8a000162213
+      - 97a38db262e2f0dbff23eae100014842
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb3nuq
+      - bigweb9nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - extlb1nuq 403f17ff97
       x-runtime:
-      - '0.778574'
+      - '1.316112'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -171,13 +263,24 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/pickups/pickup_12265694f7474f6fa46f982b9471910a
+    uri: https://api.easypost.com/v2/pickups/pickup_4cd93be6be784446a46231f5aea66316
   response:
     body:
-      string: '{"id":"pickup_12265694f7474f6fa46f982b9471910a","object":"Pickup","created_at":"2022-05-04T20:25:51Z","updated_at":"2022-05-04T20:25:51Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-06T00:00:00Z","max_datetime":"2022-05-06T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_6461f574cbe811eca151ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:51+00:00","updated_at":"2022-05-04T20:25:51+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-04T20:25:52Z","updated_at":"2022-05-04T20:25:52Z","carrier":"USPS","pickup_id":"pickup_12265694f7474f6fa46f982b9471910a","id":"pickuprate_4d9e022aa49e4fa785d111e8b41d7446","object":"PickupRate"}]}'
+      string: '{"id": "pickup_4cd93be6be784446a46231f5aea66316", "object": "Pickup",
+        "created_at": "2022-07-28T20:26:03Z", "updated_at": "2022-07-28T20:26:03Z",
+        "mode": "test", "status": "unknown", "reference": null, "min_datetime": "2022-07-29T00:00:00Z",
+        "max_datetime": "2022-07-29T00:00:00Z", "is_account_address": false, "instructions":
+        "Pickup at front door", "messages": [], "confirmation": null, "address": {"id":
+        "adr_802b335a0eb311eda241ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:26:03+00:00", "updated_at": "2022-07-28T20:26:03+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "carrier_accounts": [], "pickup_rates": [{"mode": "test", "service":
+        "NextDay", "rate": "0.00", "currency": "USD", "created_at": "2022-07-28T20:26:04Z",
+        "updated_at": "2022-07-28T20:26:04Z", "carrier": "USPS", "pickup_id": "pickup_4cd93be6be784446a46231f5aea66316",
+        "id": "pickuprate_ffc2339b10434056b62b5db1bb002d84", "object": "PickupRate"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -186,7 +289,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"2f473c7f9d8ffee26647f9fe3870030c"
+      - W/"666ffddd791f1ec253c6fe1d05c70075"
       expires:
       - '0'
       pragma:
@@ -204,20 +307,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bd6272e150e786b8a00016226c
+      - 97a38db262e2f0dcff23eae1000148d6
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb3nuq
+      - bigweb8nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - extlb1nuq 403f17ff97
       x-runtime:
-      - '0.071007'
+      - '0.064715'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_rate_retrieve.yaml
+++ b/tests/cassettes/test_rate_retrieve.yaml
@@ -5,7 +5,8 @@ interactions:
       "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
       "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
-      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}}}'
+      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}},
+      "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -14,7 +15,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '477'
+      - '501'
       Content-Type:
       - application/json
       authorization:
@@ -25,28 +26,83 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:02Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:02Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_6a926173cbe811ecaa1fac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:02+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_aa0035712d82414d8f57218e36ee07d1","object":"Parcel","created_at":"2022-05-04T20:26:02Z","updated_at":"2022-05-04T20:26:02Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_8e3bdbba2f5143c28cada75a5e86f6e2","object":"Rate","created_at":"2022-05-04T20:26:02Z","updated_at":"2022-05-04T20:26:02Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_0415e3dc970d48159162f9482b94edcd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_811a7fc42a754c90ba6d15a3b1ba4ea4","object":"Rate","created_at":"2022-05-04T20:26:02Z","updated_at":"2022-05-04T20:26:02Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_0415e3dc970d48159162f9482b94edcd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_a19a1ca43d68466f9b836dbf883ce426","object":"Rate","created_at":"2022-05-04T20:26:02Z","updated_at":"2022-05-04T20:26:02Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_0415e3dc970d48159162f9482b94edcd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_c99e3c05df334e7680a24e19852141d2","object":"Rate","created_at":"2022-05-04T20:26:02Z","updated_at":"2022-05-04T20:26:02Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_0415e3dc970d48159162f9482b94edcd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_6a9028f3cbe811ecaa1eac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:02+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_6a926173cbe811ecaa1fac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:02+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6a9028f3cbe811ecaa1eac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:02+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_0415e3dc970d48159162f9482b94edcd","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:08Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        null, "updated_at": "2022-07-28T19:56:08Z", "batch_id": null, "batch_status":
+        null, "batch_message": null, "customs_info": null, "from_address": {"id":
+        "adr_524860c70eaf11ed9989ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:08+00:00", "updated_at": "2022-07-28T19:56:08+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_66e42b4c227c4fd7aba6e07298c609a1",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:08Z", "updated_at": "2022-07-28T19:56:08Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_a7a1252d34304dcc97ac9c6fda3c0d2f",
+        "object": "Rate", "created_at": "2022-07-28T19:56:08Z", "updated_at": "2022-07-28T19:56:08Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_b35da1e9b07946eab22531d6f9a580a4", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_d53afbfd30b6448899267de12a806d64", "object": "Rate", "created_at":
+        "2022-07-28T19:56:08Z", "updated_at": "2022-07-28T19:56:08Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_b35da1e9b07946eab22531d6f9a580a4", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_c26be8423ed24ee2a2b3e6e46abdcdaa", "object": "Rate", "created_at":
+        "2022-07-28T19:56:08Z", "updated_at": "2022-07-28T19:56:08Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_b35da1e9b07946eab22531d6f9a580a4", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_33c2bb1237604f27a3d43ed91bd8b4a0", "object": "Rate", "created_at":
+        "2022-07-28T19:56:08Z", "updated_at": "2022-07-28T19:56:08Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_b35da1e9b07946eab22531d6f9a580a4", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_52467bac0eaf11ed987fac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:56:08+00:00", "updated_at": "2022-07-28T19:56:08+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_524860c70eaf11ed9989ac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T19:56:08+00:00", "updated_at":
+        "2022-07-28T19:56:08+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_52467bac0eaf11ed987fac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:08+00:00", "updated_at": "2022-07-28T19:56:08+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_b35da1e9b07946eab22531d6f9a580a4",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '4729'
+      - '4833'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"912dff4b72b5f52b145a10798651a240"
+      - W/"0e3562aa89151ab1968c416fddaa2dcf"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_0415e3dc970d48159162f9482b94edcd
+      - /api/v2/shipments/shp_b35da1e9b07946eab22531d6f9a580a4
       pragma:
       - no-cache
       referrer-policy:
@@ -62,20 +118,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b76272e15ae786b8a50016267e
+      - 3843703d62e2e9d7ff23e29b0034324a
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.255957'
+      - '0.252968'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -95,19 +152,25 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/rates/rate_8e3bdbba2f5143c28cada75a5e86f6e2
+    uri: https://api.easypost.com/v2/rates/rate_a7a1252d34304dcc97ac9c6fda3c0d2f
   response:
     body:
-      string: '{"id":"rate_8e3bdbba2f5143c28cada75a5e86f6e2","object":"Rate","created_at":"2022-05-04T20:26:02Z","updated_at":"2022-05-04T20:26:02Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_0415e3dc970d48159162f9482b94edcd","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}'
+      string: '{"id": "rate_a7a1252d34304dcc97ac9c6fda3c0d2f", "object": "Rate", "created_at":
+        "2022-07-28T19:56:08Z", "updated_at": "2022-07-28T19:56:08Z", "mode": "test",
+        "service": "First", "carrier": "USPS", "rate": "5.49", "currency": "USD",
+        "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_b35da1e9b07946eab22531d6f9a580a4", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '506'
+      - '532'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"f84f1af74a044ad2d36d62911ee735e1"
+      - W/"03f3f6dc65dc1bd9679c8da14fc53c1f"
       expires:
       - '0'
       pragma:
@@ -120,27 +183,26 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b76272e15ae786b8a50016269d
+      - 3843703d62e2e9d8ff23e29b00343267
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.096170'
+      - '0.176667'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_refund_create.yaml
+++ b/tests/cassettes/test_refund_create.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:03Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768853","updated_at":"2022-05-04T20:26:04Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_6b00f552cbe811ec9366ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:02+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_4287255431dd430f8dea18b4af39623b","object":"Parcel","created_at":"2022-05-04T20:26:02Z","updated_at":"2022-05-04T20:26:02Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_27d0f4c69681458ca8e69b0e427c0d5f","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:03Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/7f833150db0a457bbb13448018ea607c.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_9db00562024b4b35af15541bace0f8e8","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_586e45c3c9db44efb91f6fb5f786851c","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_62544dee7e664a5289f9c6c76b674e8c","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e0e5b1ccb0d043d1a235b8723ccef606","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_9db00562024b4b35af15541bace0f8e8","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_f0351ce9a3e74e63907290799a8bc207","object":"Tracker","mode":"test","tracking_code":"9400100109361117768853","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:26:04Z","updated_at":"2022-05-04T20:26:04Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2YwMzUxY2U5YTNlNzRlNjM5MDcyOTA3OTlhOGJjMjA3"},"to_address":{"id":"adr_6afa9fe0cbe811ec8abbac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:03+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_6b00f552cbe811ec9366ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:02+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6afa9fe0cbe811ec8abbac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:03+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_9e38dcceeaef4d359c38211af1bcca33","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:27:00Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130493923", "updated_at": "2022-07-28T20:27:01Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_a2a02f2c0eb311ed82a0ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:27:00+00:00", "updated_at": "2022-07-28T20:27:00+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_49f8dbdba95249258bf0caf6bcbb6281",
+        "object": "Parcel", "created_at": "2022-07-28T20:27:00Z", "updated_at": "2022-07-28T20:27:00Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_3eb113bc87a8484588b97feac3a7bc92",
+        "created_at": "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:27:01Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/422321c46ac84bd3b6bec16fb9693a56.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_7568eaf35fef4515be58e8af2a83c5e6", "object":
+        "Rate", "created_at": "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_9db138dea626443699553906459b8925", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_51662c27161a4fd184cf18929eb0d2e1", "object": "Rate", "created_at":
+        "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_9db138dea626443699553906459b8925", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_ad0ff3ef927e41f6abc236a3950ee79c", "object": "Rate", "created_at":
+        "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_9db138dea626443699553906459b8925", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_d5043ae56a1b471da9a5c6c37fd1af33", "object": "Rate", "created_at":
+        "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_9db138dea626443699553906459b8925", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_7568eaf35fef4515be58e8af2a83c5e6",
+        "object": "Rate", "created_at": "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_9db138dea626443699553906459b8925", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_87dccad3477e4e07b7eef7edb5f4fe53", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493923", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T20:27:01Z", "updated_at":
+        "2022-07-28T20:27:01Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_9db138dea626443699553906459b8925", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzg3ZGNjYWQzNDc3ZTRlMDdiN2VlZjdlZGI1ZjRmZTUz"},
+        "to_address": {"id": "adr_a29dd4dc0eb311ed8c02ac1f6bc7bdc6", "object": "Address",
+        "created_at": "2022-07-28T20:27:00+00:00", "updated_at": "2022-07-28T20:27:01+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_a2a02f2c0eb311ed82a0ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:27:00+00:00", "updated_at": "2022-07-28T20:27:00+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_a29dd4dc0eb311ed8c02ac1f6bc7bdc6", "object":
+        "Address", "created_at": "2022-07-28T20:27:00+00:00", "updated_at": "2022-07-28T20:27:01+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_9db138dea626443699553906459b8925", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"fda14b9e119ed2527b77d7e0f6ac6b4a"
+      - W/"821e6d1835ef00e8ed3381b11510658f"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_9e38dcceeaef4d359c38211af1bcca33
+      - /api/v2/shipments/shp_9db138dea626443699553906459b8925
       pragma:
       - no-cache
       referrer-policy:
@@ -59,27 +140,25 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bc6272e15ae786b8a6001626bf
+      - a41775b562e2f114ff23eb1e00001cd8
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - extlb2nuq 403f17ff97
       x-runtime:
-      - '1.295066'
+      - '1.048047'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -99,32 +178,122 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_9e38dcceeaef4d359c38211af1bcca33
+    uri: https://api.easypost.com/v2/shipments/shp_9db138dea626443699553906459b8925
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:03Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768853","updated_at":"2022-05-04T20:26:04Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_6b00f552cbe811ec9366ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:02+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_4287255431dd430f8dea18b4af39623b","object":"Parcel","created_at":"2022-05-04T20:26:02Z","updated_at":"2022-05-04T20:26:02Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_27d0f4c69681458ca8e69b0e427c0d5f","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:03Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/7f833150db0a457bbb13448018ea607c.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_9db00562024b4b35af15541bace0f8e8","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_586e45c3c9db44efb91f6fb5f786851c","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_62544dee7e664a5289f9c6c76b674e8c","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e0e5b1ccb0d043d1a235b8723ccef606","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_9db00562024b4b35af15541bace0f8e8","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_f0351ce9a3e74e63907290799a8bc207","object":"Tracker","mode":"test","tracking_code":"9400100109361117768853","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:26:04Z","updated_at":"2022-05-04T20:26:04Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:26:04Z","shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:26:04Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:03:04Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"fees":[],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"public_url":"https://track.easypost.com/djE6dHJrX2YwMzUxY2U5YTNlNzRlNjM5MDcyOTA3OTlhOGJjMjA3"},"to_address":{"id":"adr_6afa9fe0cbe811ec8abbac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:03+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_6b00f552cbe811ec9366ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:02+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6afa9fe0cbe811ec8abbac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:03+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_9e38dcceeaef4d359c38211af1bcca33","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:27:00Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130493923", "updated_at": "2022-07-28T20:27:01Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_a2a02f2c0eb311ed82a0ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:27:00+00:00", "updated_at": "2022-07-28T20:27:00+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_49f8dbdba95249258bf0caf6bcbb6281",
+        "object": "Parcel", "created_at": "2022-07-28T20:27:00Z", "updated_at": "2022-07-28T20:27:00Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_3eb113bc87a8484588b97feac3a7bc92",
+        "created_at": "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:27:01Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/422321c46ac84bd3b6bec16fb9693a56.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_7568eaf35fef4515be58e8af2a83c5e6", "object":
+        "Rate", "created_at": "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_9db138dea626443699553906459b8925", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_51662c27161a4fd184cf18929eb0d2e1", "object": "Rate", "created_at":
+        "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_9db138dea626443699553906459b8925", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_ad0ff3ef927e41f6abc236a3950ee79c", "object": "Rate", "created_at":
+        "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_9db138dea626443699553906459b8925", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_d5043ae56a1b471da9a5c6c37fd1af33", "object": "Rate", "created_at":
+        "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_9db138dea626443699553906459b8925", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_7568eaf35fef4515be58e8af2a83c5e6",
+        "object": "Rate", "created_at": "2022-07-28T20:27:01Z", "updated_at": "2022-07-28T20:27:01Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_9db138dea626443699553906459b8925", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_87dccad3477e4e07b7eef7edb5f4fe53", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493923", "status": "pre_transit",
+        "status_detail": "status_update", "created_at": "2022-07-28T20:27:01Z", "updated_at":
+        "2022-07-28T20:27:01Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T20:27:01Z", "shipment_id": "shp_9db138dea626443699553906459b8925",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T20:27:01Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T09:04:01Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}], "fees":
+        [], "carrier_detail": {"object": "CarrierDetail", "service": "First-Class
+        Package Service", "container_type": null, "est_delivery_date_local": null,
+        "est_delivery_time_local": null, "origin_location": "HOUSTON TX, 77001", "origin_tracking_location":
+        {"object": "TrackingLocation", "city": "HOUSTON", "state": "TX", "country":
+        null, "zip": "77063"}, "destination_location": "CHARLESTON SC, 29401", "destination_tracking_location":
+        null, "guaranteed_delivery_date": null, "alternate_identifier": null, "initial_delivery_attempt":
+        null}, "public_url": "https://track.easypost.com/djE6dHJrXzg3ZGNjYWQzNDc3ZTRlMDdiN2VlZjdlZGI1ZjRmZTUz"},
+        "to_address": {"id": "adr_a29dd4dc0eb311ed8c02ac1f6bc7bdc6", "object": "Address",
+        "created_at": "2022-07-28T20:27:00+00:00", "updated_at": "2022-07-28T20:27:01+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_a2a02f2c0eb311ed82a0ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:27:00+00:00", "updated_at": "2022-07-28T20:27:00+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_a29dd4dc0eb311ed8c02ac1f6bc7bdc6", "object":
+        "Address", "created_at": "2022-07-28T20:27:00+00:00", "updated_at": "2022-07-28T20:27:01+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_9db138dea626443699553906459b8925", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '7960'
+      - '8090'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"8e74069776368689ddcda86b33a6bdf9"
+      - W/"1d1f8b4411c5eabde14d90ac1ef6026d"
       expires:
       - '0'
       pragma:
@@ -142,27 +311,27 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bc6272e15ce786b8a600162748
+      - a41775b562e2f115ff23eb1e00001d0b
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb2nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - extlb2nuq 403f17ff97
       x-runtime:
-      - '0.116770'
+      - '0.127071'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"refund": {"carrier": "USPS", "tracking_codes": "9400100109361117768853"}}'
+    body: '{"refund": {"carrier": "USPS", "tracking_codes": "9400100109361130493923"}}'
     headers:
       Accept:
       - '*/*'
@@ -182,7 +351,10 @@ interactions:
     uri: https://api.easypost.com/v2/refunds
   response:
     body:
-      string: '[{"id":"rfnd_75569d36e3d648b893a875a3070ae92a","object":"Refund","created_at":"2022-05-04T20:26:04Z","updated_at":"2022-05-04T20:26:04Z","tracking_code":"9400100109361117768853","confirmation_number":null,"status":"submitted","carrier":"USPS","shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33"}]'
+      string: '[{"id": "rfnd_594e574079f5446c9aca582a3d56a845", "object": "Refund",
+        "created_at": "2022-07-28T20:27:02Z", "updated_at": "2022-07-28T20:27:02Z",
+        "tracking_code": "9400100109361130493923", "confirmation_number": null, "status":
+        "submitted", "carrier": "USPS", "shipment_id": "shp_9db138dea626443699553906459b8925"}]'
     headers:
       cache-control:
       - no-cache, no-store
@@ -191,7 +363,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"c4f05c1d97ac0c3c506ec09a0a58a413"
+      - W/"6e5af9bfa8d827e5059b4fdb708c2ca5"
       expires:
       - '0'
       pragma:
@@ -209,20 +381,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bc6272e15ce786b8a600162765
+      - a41775b562e2f116ff23eb1e00001d15
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb4nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - extlb2nuq 403f17ff97
       x-runtime:
-      - '0.061732'
+      - '0.071722'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_scanform_create.yaml
+++ b/tests/cassettes/test_scanform_create.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:07Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768860","updated_at":"2022-05-04T20:26:08Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_6d93dfcccbe811eca39eac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:07+00:00","updated_at":"2022-05-04T20:26:07+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_df86243888cd4ca5ab215576d06134c5","object":"Parcel","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_4c845d91a2c8478e9ddd100e0843df0b","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:07Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/f8b6a96562014a4d8e10695163233e63.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_d055f500704f485bbdea6a3bb3a09bd3","object":"Rate","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_07e963110a344db9bb7cc1051b363c17","object":"Rate","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_4516b905eed640d5bb42d5ab3c6c121e","object":"Rate","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_2657a230124a412aa274eefe97dc66e7","object":"Rate","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_2657a230124a412aa274eefe97dc66e7","object":"Rate","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_77b0dbae8eef4334b995ae9c333328fc","object":"Tracker","mode":"test","tracking_code":"9400100109361117768860","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:26:08Z","updated_at":"2022-05-04T20:26:08Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzc3YjBkYmFlOGVlZjQzMzRiOTk1YWU5YzMzMzMyOGZj"},"to_address":{"id":"adr_6d9200b7cbe811eca39dac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:07+00:00","updated_at":"2022-05-04T20:26:07+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_6d93dfcccbe811eca39eac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:07+00:00","updated_at":"2022-05-04T20:26:07+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6d9200b7cbe811eca39dac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:07+00:00","updated_at":"2022-05-04T20:26:07+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_ced9db40c9544da494fb03e96cf8e7df","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:27:02Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130493930", "updated_at": "2022-07-28T20:27:03Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_a3c583d30eb311ed82eeac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:27:02+00:00", "updated_at": "2022-07-28T20:27:02+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_65b9f43171334c8f96b4f19c5431d0c2",
+        "object": "Parcel", "created_at": "2022-07-28T20:27:02Z", "updated_at": "2022-07-28T20:27:02Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_b8feba2b35f34d18b18833c15b01c652",
+        "created_at": "2022-07-28T20:27:03Z", "updated_at": "2022-07-28T20:27:03Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:27:03Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/484715748675440c802b8137b42ef4b5.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_4ae063f5b6f44dfcb936c9c402519cb3", "object":
+        "Rate", "created_at": "2022-07-28T20:27:02Z", "updated_at": "2022-07-28T20:27:02Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_8bdc44a3a4ea4656aa604135e5cd5199", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_6d46447527b04c638d6d6e32bf33d60a",
+        "object": "Rate", "created_at": "2022-07-28T20:27:02Z", "updated_at": "2022-07-28T20:27:02Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_8bdc44a3a4ea4656aa604135e5cd5199", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_2cd31a1322dc48e39878493bad1a8940",
+        "object": "Rate", "created_at": "2022-07-28T20:27:02Z", "updated_at": "2022-07-28T20:27:02Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_8bdc44a3a4ea4656aa604135e5cd5199", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_29fb9f7ae0284d07a6714f1c01ac9a76", "object": "Rate", "created_at":
+        "2022-07-28T20:27:02Z", "updated_at": "2022-07-28T20:27:02Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_8bdc44a3a4ea4656aa604135e5cd5199", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_2cd31a1322dc48e39878493bad1a8940",
+        "object": "Rate", "created_at": "2022-07-28T20:27:03Z", "updated_at": "2022-07-28T20:27:03Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_8bdc44a3a4ea4656aa604135e5cd5199", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_d0169d925716448da2ba2a9c14438406", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493930", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T20:27:03Z", "updated_at":
+        "2022-07-28T20:27:03Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_8bdc44a3a4ea4656aa604135e5cd5199", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrX2QwMTY5ZDkyNTcxNjQ0OGRhMmJhMmE5YzE0NDM4NDA2"},
+        "to_address": {"id": "adr_a3c3a0840eb311ed82edac1f6bc72124", "object": "Address",
+        "created_at": "2022-07-28T20:27:02+00:00", "updated_at": "2022-07-28T20:27:02+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_a3c583d30eb311ed82eeac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T20:27:02+00:00", "updated_at": "2022-07-28T20:27:02+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_a3c3a0840eb311ed82edac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T20:27:02+00:00", "updated_at": "2022-07-28T20:27:02+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_8bdc44a3a4ea4656aa604135e5cd5199", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"2378fe612121892839b8ed4686e4eda7"
+      - W/"aa6ecd64a3d934fae348f58bb144bb6d"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_ced9db40c9544da494fb03e96cf8e7df
+      - /api/v2/shipments/shp_8bdc44a3a4ea4656aa604135e5cd5199
       pragma:
       - no-cache
       referrer-policy:
@@ -64,7 +145,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330be6272e15fe786b8c50016287c
+      - efdf9e0462e2f116ff23eb1f0001e700
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -72,19 +153,20 @@ interactions:
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.925356'
+      - '1.176228'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: '{"shipment": [{"id": "shp_ced9db40c9544da494fb03e96cf8e7df"}]}'
+    body: '{"shipment": [{"id": "shp_8bdc44a3a4ea4656aa604135e5cd5199"}]}'
     headers:
       Accept:
       - '*/*'
@@ -104,9 +186,18 @@ interactions:
     uri: https://api.easypost.com/v2/scan_forms
   response:
     body:
-      string: '{"id":"sf_6be60d730e924ed58918424eaee83aae","object":"ScanForm","created_at":"2022-05-04T20:26:08Z","updated_at":"2022-05-04T20:26:08Z","tracking_codes":["9400100109361117768860"],"address":{"id":"adr_6d93dfcccbe811eca39eac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:07+00:00","updated_at":"2022-05-04T20:26:07+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"status":"created","message":null,"form_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220504/1eae62cbbb1e47488d886b7e52673db2.pdf","form_file_type":null,"batch_id":"batch_a27fd83f1e8e42de8b5389e48dff8c42","confirmation":null}'
+      string: '{"id": "sf_3c8406684c9941ea814522522c965d4e", "object": "ScanForm",
+        "created_at": "2022-07-28T20:27:04Z", "updated_at": "2022-07-28T20:27:04Z",
+        "tracking_codes": ["9400100109361130493930"], "address": {"id": "adr_a3c583d30eb311ed82eeac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T20:27:02+00:00", "updated_at":
+        "2022-07-28T20:27:02+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "status": "created", "message":
+        null, "form_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220728/1bae7b8a20284b50acf19e3b63326009.pdf",
+        "form_file_type": null, "batch_id": "batch_130ddf76701a48a999bd16524daf0200",
+        "confirmation": null}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -115,7 +206,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"07f69d72cf46f49afd2738429780c60e"
+      - W/"d99e84bfd97d0379e5f3a2f4d357e4f3"
       expires:
       - '0'
       pragma:
@@ -133,20 +224,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330be6272e160e786b8c5001629b1
+      - efdf9e0462e2f117ff23eb1f0001e7a6
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.207589'
+      - '0.323591'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_scanform_retrieve.yaml
+++ b/tests/cassettes/test_scanform_retrieve.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:08Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768877","updated_at":"2022-05-04T20:26:09Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_6e86d70ecbe811eca3caac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:08+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_4a8ca385633c4aa0a0ce6915aab835e1","object":"Parcel","created_at":"2022-05-04T20:26:08Z","updated_at":"2022-05-04T20:26:08Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_ed01ea50999240fa9076cd26c2b85b86","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:09Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/85fd19656d194ea48df6358b1309d96b.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_70e6cfa1ecbf4455a2f874cc0bd17f42","object":"Rate","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_c64b04653ff041caa1e4a8f2c76e5e25","object":"Rate","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_eb620e6fdf2043a58d21eb9f59446f18","object":"Rate","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e4d5ae86b46e45c2981c84d418931911","object":"Rate","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_e4d5ae86b46e45c2981c84d418931911","object":"Rate","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_b4b3bd5dad664d60ba65860ed230fa47","object":"Tracker","mode":"test","tracking_code":"9400100109361117768877","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2I0YjNiZDVkYWQ2NjRkNjBiYTY1ODYwZWQyMzBmYTQ3"},"to_address":{"id":"adr_6e84e0edcbe811ec9438ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:09+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_6e86d70ecbe811eca3caac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:08+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6e84e0edcbe811ec9438ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:09+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_85d3d98102be4cd0a67c5004ac0360dc","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:27:04Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130493954", "updated_at": "2022-07-28T20:27:05Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_a4f806ec0eb311ed8cbeac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-28T20:27:04+00:00", "updated_at": "2022-07-28T20:27:04+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_a3b3b9e5aae3460b88d00d53ee98bddc",
+        "object": "Parcel", "created_at": "2022-07-28T20:27:04Z", "updated_at": "2022-07-28T20:27:04Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_02aac10073f242ebbffce57da998a7e7",
+        "created_at": "2022-07-28T20:27:05Z", "updated_at": "2022-07-28T20:27:05Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T20:27:05Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/eafc3fcccb8a46d1b6a6e52216f50345.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_618bb2bd59fe41df8df4aa3a417c6947", "object":
+        "Rate", "created_at": "2022-07-28T20:27:05Z", "updated_at": "2022-07-28T20:27:05Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_a047ffa4f7484a368d33a2f25be39f32", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_a2d1b2285ad94e66977701c1db67be03",
+        "object": "Rate", "created_at": "2022-07-28T20:27:05Z", "updated_at": "2022-07-28T20:27:05Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_a047ffa4f7484a368d33a2f25be39f32", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_2ad5c1cb089a4833ba314cabd5b4555f",
+        "object": "Rate", "created_at": "2022-07-28T20:27:05Z", "updated_at": "2022-07-28T20:27:05Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_a047ffa4f7484a368d33a2f25be39f32", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_cbff870c99ba44468e50a8d8848cab38",
+        "object": "Rate", "created_at": "2022-07-28T20:27:05Z", "updated_at": "2022-07-28T20:27:05Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_a047ffa4f7484a368d33a2f25be39f32", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_cbff870c99ba44468e50a8d8848cab38",
+        "object": "Rate", "created_at": "2022-07-28T20:27:05Z", "updated_at": "2022-07-28T20:27:05Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_a047ffa4f7484a368d33a2f25be39f32", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_d7e1c4be063544939a0c2b01ac7fb350", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130493954", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T20:27:05Z", "updated_at":
+        "2022-07-28T20:27:05Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_a047ffa4f7484a368d33a2f25be39f32", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrX2Q3ZTFjNGJlMDYzNTQ0OTM5YTBjMmIwMWFjN2ZiMzUw"},
+        "to_address": {"id": "adr_a4f6426d0eb311ed882aac1f6b0a0d1e", "object": "Address",
+        "created_at": "2022-07-28T20:27:04+00:00", "updated_at": "2022-07-28T20:27:05+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_a4f806ec0eb311ed8cbeac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-28T20:27:04+00:00", "updated_at": "2022-07-28T20:27:04+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_a4f6426d0eb311ed882aac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-28T20:27:04+00:00", "updated_at": "2022-07-28T20:27:05+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_a047ffa4f7484a368d33a2f25be39f32", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"b899451cf3457f8da98298c59a69505d"
+      - W/"2fa2d63215fcf0b54957b9b6041e7541"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_85d3d98102be4cd0a67c5004ac0360dc
+      - /api/v2/shipments/shp_a047ffa4f7484a368d33a2f25be39f32
       pragma:
       - no-cache
       referrer-policy:
@@ -64,27 +145,28 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b96272e160e786b8c6001629d3
+      - b0657e3c62e2f118ff23eb2000361b04
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.962076'
+      - '1.174882'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: '{"shipment": [{"id": "shp_85d3d98102be4cd0a67c5004ac0360dc"}]}'
+    body: '{"shipment": [{"id": "shp_a047ffa4f7484a368d33a2f25be39f32"}]}'
     headers:
       Accept:
       - '*/*'
@@ -104,9 +186,18 @@ interactions:
     uri: https://api.easypost.com/v2/scan_forms
   response:
     body:
-      string: '{"id":"sf_e2006b6ee77348c3b6178beefd6046df","object":"ScanForm","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:10Z","tracking_codes":["9400100109361117768877"],"address":{"id":"adr_6e86d70ecbe811eca3caac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:08+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"status":"created","message":null,"form_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220504/05451d70bcc8487b9811fd48f6637b21.pdf","form_file_type":null,"batch_id":"batch_bb2a2df31942405faface8f4ac4afbbf","confirmation":null}'
+      string: '{"id": "sf_cb7af190adb5462da22fb9e0f450cb07", "object": "ScanForm",
+        "created_at": "2022-07-28T20:27:06Z", "updated_at": "2022-07-28T20:27:06Z",
+        "tracking_codes": ["9400100109361130493954"], "address": {"id": "adr_a4f806ec0eb311ed8cbeac1f6bc7bdc6",
+        "object": "Address", "created_at": "2022-07-28T20:27:04+00:00", "updated_at":
+        "2022-07-28T20:27:04+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "status": "created", "message":
+        null, "form_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220728/41de0bd4ab274f80b609c92c6a9c9139.pdf",
+        "form_file_type": null, "batch_id": "batch_6de150477f1749c39ec9e9f210e4885f",
+        "confirmation": null}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -115,7 +206,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"488b2169b2e91fe2a01164849a358d25"
+      - W/"d0f1589b700c8e23741e2764969f9dfb"
       expires:
       - '0'
       pragma:
@@ -133,20 +224,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b96272e161e786b8c600162a34
+      - b0657e3c62e2f119ff23eb2000361b4a
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.222970'
+      - '0.322948'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -166,12 +258,21 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/scan_forms/sf_e2006b6ee77348c3b6178beefd6046df
+    uri: https://api.easypost.com/v2/scan_forms/sf_cb7af190adb5462da22fb9e0f450cb07
   response:
     body:
-      string: '{"id":"sf_e2006b6ee77348c3b6178beefd6046df","object":"ScanForm","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:10Z","tracking_codes":["9400100109361117768877"],"address":{"id":"adr_6e86d70ecbe811eca3caac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:08+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"status":"created","message":null,"form_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220504/05451d70bcc8487b9811fd48f6637b21.pdf","form_file_type":null,"batch_id":"batch_bb2a2df31942405faface8f4ac4afbbf","confirmation":null}'
+      string: '{"id": "sf_cb7af190adb5462da22fb9e0f450cb07", "object": "ScanForm",
+        "created_at": "2022-07-28T20:27:06Z", "updated_at": "2022-07-28T20:27:06Z",
+        "tracking_codes": ["9400100109361130493954"], "address": {"id": "adr_a4f806ec0eb311ed8cbeac1f6bc7bdc6",
+        "object": "Address", "created_at": "2022-07-28T20:27:04+00:00", "updated_at":
+        "2022-07-28T20:27:04+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "status": "created", "message":
+        null, "form_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220728/41de0bd4ab274f80b609c92c6a9c9139.pdf",
+        "form_file_type": null, "batch_id": "batch_6de150477f1749c39ec9e9f210e4885f",
+        "confirmation": null}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -180,7 +281,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"488b2169b2e91fe2a01164849a358d25"
+      - W/"d0f1589b700c8e23741e2764969f9dfb"
       expires:
       - '0'
       pragma:
@@ -198,20 +299,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b96272e162e786b8c600162a47
+      - b0657e3c62e2f11aff23eb2000361b69
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb8nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.050337'
+      - '0.051425'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_all.yaml
+++ b/tests/cassettes/test_shipment_all.yaml
@@ -16,85 +16,646 @@ interactions:
     uri: https://api.easypost.com/v2/shipments?page_size=5
   response:
     body:
-      string: '{"shipments":[{"created_at":"2022-05-04T20:26:08Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768877","updated_at":"2022-05-04T20:26:09Z","batch_id":"batch_bb2a2df31942405faface8f4ac4afbbf","batch_status":"postage_purchased","batch_message":null,"customs_info":null,"from_address":{"id":"adr_6e86d70ecbe811eca3caac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:08+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_4a8ca385633c4aa0a0ce6915aab835e1","object":"Parcel","created_at":"2022-05-04T20:26:08Z","updated_at":"2022-05-04T20:26:08Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_ed01ea50999240fa9076cd26c2b85b86","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:09Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/85fd19656d194ea48df6358b1309d96b.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_70e6cfa1ecbf4455a2f874cc0bd17f42","object":"Rate","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_c64b04653ff041caa1e4a8f2c76e5e25","object":"Rate","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_eb620e6fdf2043a58d21eb9f59446f18","object":"Rate","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e4d5ae86b46e45c2981c84d418931911","object":"Rate","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":{"id":"sf_e2006b6ee77348c3b6178beefd6046df","object":"ScanForm","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:10Z","tracking_codes":["9400100109361117768877"],"address":{"id":"adr_6e86d70ecbe811eca3caac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:08+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"status":"created","message":null,"form_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220504/05451d70bcc8487b9811fd48f6637b21.pdf","form_file_type":null,"batch_id":"batch_bb2a2df31942405faface8f4ac4afbbf","confirmation":null},"selected_rate":{"id":"rate_e4d5ae86b46e45c2981c84d418931911","object":"Rate","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_b4b3bd5dad664d60ba65860ed230fa47","object":"Tracker","mode":"test","tracking_code":"9400100109361117768877","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:26:09Z","updated_at":"2022-05-04T20:26:09Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:26:09Z","shipment_id":"shp_85d3d98102be4cd0a67c5004ac0360dc","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:26:09Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:03:09Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"fees":[],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"public_url":"https://track.easypost.com/djE6dHJrX2I0YjNiZDVkYWQ2NjRkNjBiYTY1ODYwZWQyMzBmYTQ3"},"to_address":{"id":"adr_6e84e0edcbe811ec9438ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:09+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_6e86d70ecbe811eca3caac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:08+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6e84e0edcbe811ec9438ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:08+00:00","updated_at":"2022-05-04T20:26:09+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_85d3d98102be4cd0a67c5004ac0360dc","object":"Shipment"},{"created_at":"2022-05-04T20:26:07Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768860","updated_at":"2022-05-04T20:26:08Z","batch_id":"batch_a27fd83f1e8e42de8b5389e48dff8c42","batch_status":"postage_purchased","batch_message":null,"customs_info":null,"from_address":{"id":"adr_6d93dfcccbe811eca39eac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:07+00:00","updated_at":"2022-05-04T20:26:07+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_df86243888cd4ca5ab215576d06134c5","object":"Parcel","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_4c845d91a2c8478e9ddd100e0843df0b","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:07Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/f8b6a96562014a4d8e10695163233e63.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_d055f500704f485bbdea6a3bb3a09bd3","object":"Rate","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_07e963110a344db9bb7cc1051b363c17","object":"Rate","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_4516b905eed640d5bb42d5ab3c6c121e","object":"Rate","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_2657a230124a412aa274eefe97dc66e7","object":"Rate","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":{"id":"sf_6be60d730e924ed58918424eaee83aae","object":"ScanForm","created_at":"2022-05-04T20:26:08Z","updated_at":"2022-05-04T20:26:08Z","tracking_codes":["9400100109361117768860"],"address":{"id":"adr_6d93dfcccbe811eca39eac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:07+00:00","updated_at":"2022-05-04T20:26:07+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"status":"created","message":null,"form_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220504/1eae62cbbb1e47488d886b7e52673db2.pdf","form_file_type":null,"batch_id":"batch_a27fd83f1e8e42de8b5389e48dff8c42","confirmation":null},"selected_rate":{"id":"rate_2657a230124a412aa274eefe97dc66e7","object":"Rate","created_at":"2022-05-04T20:26:07Z","updated_at":"2022-05-04T20:26:07Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_77b0dbae8eef4334b995ae9c333328fc","object":"Tracker","mode":"test","tracking_code":"9400100109361117768860","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:26:08Z","updated_at":"2022-05-04T20:26:08Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:26:08Z","shipment_id":"shp_ced9db40c9544da494fb03e96cf8e7df","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:26:08Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:03:08Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"fees":[],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"public_url":"https://track.easypost.com/djE6dHJrXzc3YjBkYmFlOGVlZjQzMzRiOTk1YWU5YzMzMzMyOGZj"},"to_address":{"id":"adr_6d9200b7cbe811eca39dac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:07+00:00","updated_at":"2022-05-04T20:26:07+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_6d93dfcccbe811eca39eac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:07+00:00","updated_at":"2022-05-04T20:26:07+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6d9200b7cbe811eca39dac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:07+00:00","updated_at":"2022-05-04T20:26:07+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_ced9db40c9544da494fb03e96cf8e7df","object":"Shipment"},{"created_at":"2022-05-04T20:26:03Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768853","updated_at":"2022-05-04T20:26:04Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_6b00f552cbe811ec9366ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:02+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_4287255431dd430f8dea18b4af39623b","object":"Parcel","created_at":"2022-05-04T20:26:02Z","updated_at":"2022-05-04T20:26:02Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_27d0f4c69681458ca8e69b0e427c0d5f","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:03Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/7f833150db0a457bbb13448018ea607c.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_9db00562024b4b35af15541bace0f8e8","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_586e45c3c9db44efb91f6fb5f786851c","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_62544dee7e664a5289f9c6c76b674e8c","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e0e5b1ccb0d043d1a235b8723ccef606","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":"submitted","scan_form":null,"selected_rate":{"id":"rate_9db00562024b4b35af15541bace0f8e8","object":"Rate","created_at":"2022-05-04T20:26:03Z","updated_at":"2022-05-04T20:26:03Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_f0351ce9a3e74e63907290799a8bc207","object":"Tracker","mode":"test","tracking_code":"9400100109361117768853","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:26:04Z","updated_at":"2022-05-04T20:26:04Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:26:04Z","shipment_id":"shp_9e38dcceeaef4d359c38211af1bcca33","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:26:04Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:03:04Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"fees":[],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"public_url":"https://track.easypost.com/djE6dHJrX2YwMzUxY2U5YTNlNzRlNjM5MDcyOTA3OTlhOGJjMjA3"},"to_address":{"id":"adr_6afa9fe0cbe811ec8abbac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:03+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_6b00f552cbe811ec9366ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:02+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6afa9fe0cbe811ec8abbac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:02+00:00","updated_at":"2022-05-04T20:26:03+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_9e38dcceeaef4d359c38211af1bcca33","object":"Shipment"},{"created_at":"2022-05-04T20:26:00Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768839","updated_at":"2022-05-04T20:26:01Z","batch_id":"batch_4933af4e46dd469aae343ae326868546","batch_status":"postage_purchased","batch_message":null,"customs_info":null,"from_address":{"id":"adr_6951a811cbe811eca298ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:00+00:00","updated_at":"2022-05-04T20:26:00+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_c363a8b0d36d41ffa59da05a519845ea","object":"Parcel","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_2e38297ac4d044abbc13e62b9dc7f95b","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:01Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:00Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/093c2153e2d8437b9b20c001712bf9fe.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_2905ed21cebe461ebc6f986c29f5304c","object":"Rate","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_65ab7653326b429491d9a7320e9b6d62","object":"Rate","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_d21af3c219f845d1bdec0aa9261b0fa7","object":"Rate","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_fdd96103d81a46d19494c4e4a8f23218","object":"Rate","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_d21af3c219f845d1bdec0aa9261b0fa7","object":"Rate","created_at":"2022-05-04T20:26:00Z","updated_at":"2022-05-04T20:26:00Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_89ce0d1cd1b14a9eb4b24ac87eb4f552","object":"Tracker","mode":"test","tracking_code":"9400100109361117768839","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:26:01Z","updated_at":"2022-05-04T20:26:01Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:26:01Z","shipment_id":"shp_f5288013455341fa8b320ac6ae2ba40f","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:26:01Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:03:01Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"fees":[],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"public_url":"https://track.easypost.com/djE6dHJrXzg5Y2UwZDFjZDFiMTRhOWViNGIyNGFjODdlYjRmNTUy"},"to_address":{"id":"adr_694feef2cbe811ec9303ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:00+00:00","updated_at":"2022-05-04T20:26:00+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_6951a811cbe811eca298ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:00+00:00","updated_at":"2022-05-04T20:26:00+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_694feef2cbe811ec9303ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:00+00:00","updated_at":"2022-05-04T20:26:00+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_f5288013455341fa8b320ac6ae2ba40f","object":"Shipment"},{"created_at":"2022-05-04T20:25:56Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768815","updated_at":"2022-05-04T20:25:56Z","batch_id":"batch_584a27292fa94bd7a4d8ebc8bfb2b219","batch_status":"postage_purchased","batch_message":null,"customs_info":null,"from_address":{"id":"adr_66dd3661cbe811eca1e5ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:56+00:00","updated_at":"2022-05-04T20:25:56+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_9b6e7c96135848ceaca9ddfd8e392903","object":"Parcel","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_f07b264cb97d49c39d37736c1fe9072a","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:25:56Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/2ba71f8f9c8043c29c7a628545e458de.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_02497804455d40819a23cde29d7ac42e","object":"Rate","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_3f4617c0bd7d48c0826429d909e98106","object":"Rate","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_8561ef9aa5e948e6a2fa1bd967ea2716","object":"Rate","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_c95d3056d6fb43f1812bc6905dd5c6a9","object":"Rate","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_8561ef9aa5e948e6a2fa1bd967ea2716","object":"Rate","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:56Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_66176ea992e94d2dab049f1646a23167","object":"Tracker","mode":"test","tracking_code":"9400100109361117768815","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:25:56Z","updated_at":"2022-05-04T20:25:57Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:25:57Z","shipment_id":"shp_ec4cecb611444a7eb251247061ced771","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:25:57Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:02:57Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"fees":[],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"public_url":"https://track.easypost.com/djE6dHJrXzY2MTc2ZWE5OTJlOTRkMmRhYjA0OWYxNjQ2YTIzMTY3"},"to_address":{"id":"adr_66db3fcecbe811ec9258ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:56+00:00","updated_at":"2022-05-04T20:25:56+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_66dd3661cbe811eca1e5ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:25:56+00:00","updated_at":"2022-05-04T20:25:56+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_66db3fcecbe811ec9258ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:25:56+00:00","updated_at":"2022-05-04T20:25:56+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_ec4cecb611444a7eb251247061ced771","object":"Shipment"}],"has_more":true}'
+      string: '{"shipments": [{"created_at": "2022-07-28T19:54:01Z", "is_return":
+        false, "messages": [], "mode": "test", "options": {"currency": "USD", "payment":
+        {"type": "SENDER"}, "date_advance": 0}, "reference": null, "status": "in_transit",
+        "tracking_code": "9400100109361130483108", "updated_at": "2022-07-28T19:56:10Z",
+        "batch_id": "batch_f8ef1b99fbb643b89762a2665ec75704", "batch_status": "postage_purchased",
+        "batch_message": null, "customs_info": null, "from_address": {"id": "adr_06cf6ffd0eaf11ed8f05ac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T19:54:01+00:00", "updated_at":
+        "2022-07-28T19:54:01+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "insurance": null, "order_id":
+        null, "parcel": {"id": "prcl_febf5c821ed54fbc8d91e6cd0f311665", "object":
+        "Parcel", "created_at": "2022-07-28T19:54:01Z", "updated_at": "2022-07-28T19:54:01Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_06336d90d45e4f43a74858878652623d",
+        "created_at": "2022-07-28T19:54:01Z", "updated_at": "2022-07-28T19:54:02Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:54:01Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/e68dee0e5c2549dd90bf5d778e1275b1.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_c6ee34b7c9144fc5806833385318f91b", "object":
+        "Rate", "created_at": "2022-07-28T19:54:01Z", "updated_at": "2022-07-28T19:54:01Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_aba7397b28ba487e9ee4b553e5791a84", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_fb72bdb283584a3596660af4e6543b9b",
+        "object": "Rate", "created_at": "2022-07-28T19:54:01Z", "updated_at": "2022-07-28T19:54:01Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_aba7397b28ba487e9ee4b553e5791a84", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_3698dcc029b04f4881a566f412504e33",
+        "object": "Rate", "created_at": "2022-07-28T19:54:01Z", "updated_at": "2022-07-28T19:54:01Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_aba7397b28ba487e9ee4b553e5791a84", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_76fd7e23cf4941f79b707431831c3163",
+        "object": "Rate", "created_at": "2022-07-28T19:54:01Z", "updated_at": "2022-07-28T19:54:01Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_aba7397b28ba487e9ee4b553e5791a84", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_76fd7e23cf4941f79b707431831c3163",
+        "object": "Rate", "created_at": "2022-07-28T19:54:01Z", "updated_at": "2022-07-28T19:54:01Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_aba7397b28ba487e9ee4b553e5791a84", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_9def101def494516a4791a253d7628b8", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483108", "status": "out_for_delivery",
+        "status_detail": "out_for_delivery", "created_at": "2022-07-28T19:54:02Z",
+        "updated_at": "2022-07-28T19:56:02Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:56:02Z", "shipment_id": "shp_aba7397b28ba487e9ee4b553e5791a84",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:56:02Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:33:02Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}, {"object":
+        "TrackingDetail", "message": "Arrived at USPS Origin Facility", "description":
+        null, "status": "in_transit", "status_detail": "arrived_at_facility", "datetime":
+        "2022-06-29T18:38:02Z", "source": "USPS", "carrier_code": null, "tracking_location":
+        {"object": "TrackingLocation", "city": "NORTH HOUSTON", "state": "TX", "country":
+        null, "zip": "77315"}}, {"object": "TrackingDetail", "message": "Arrived at
+        USPS Facility", "description": null, "status": "in_transit", "status_detail":
+        "arrived_at_facility", "datetime": "2022-06-30T20:14:02Z", "source": "USPS",
+        "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "COLUMBIA", "state": "SC", "country": null, "zip": "29201"}}, {"object":
+        "TrackingDetail", "message": "Arrived at Post Office", "description": null,
+        "status": "in_transit", "status_detail": "arrived_at_facility", "datetime":
+        "2022-06-30T23:05:02Z", "source": "USPS", "carrier_code": null, "tracking_location":
+        {"object": "TrackingLocation", "city": "CHARLESTON", "state": "SC", "country":
+        null, "zip": "29407"}}, {"object": "TrackingDetail", "message": "Sorting Complete",
+        "description": null, "status": "in_transit", "status_detail": "status_update",
+        "datetime": "2022-07-01T04:45:02Z", "source": "USPS", "carrier_code": null,
+        "tracking_location": {"object": "TrackingLocation", "city": "CHARLESTON",
+        "state": "SC", "country": null, "zip": "29407"}}, {"object": "TrackingDetail",
+        "message": "Out for Delivery", "description": null, "status": "out_for_delivery",
+        "status_detail": "out_for_delivery", "datetime": "2022-07-01T04:55:02Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "CHARLESTON", "state": "SC", "country": null, "zip": "29407"}}], "fees":
+        [], "carrier_detail": {"object": "CarrierDetail", "service": "First-Class
+        Package Service", "container_type": null, "est_delivery_date_local": null,
+        "est_delivery_time_local": null, "origin_location": "HOUSTON TX, 77001", "origin_tracking_location":
+        {"object": "TrackingLocation", "city": "NORTH HOUSTON", "state": "TX", "country":
+        null, "zip": "77315"}, "destination_location": "CHARLESTON SC, 29401", "destination_tracking_location":
+        null, "guaranteed_delivery_date": null, "alternate_identifier": null, "initial_delivery_attempt":
+        null}, "public_url": "https://track.easypost.com/djE6dHJrXzlkZWYxMDFkZWY0OTQ1MTZhNDc5MWEyNTNkNzYyOGI4"},
+        "to_address": {"id": "adr_06cb9cf70eaf11ed9304ac1f6b0a0d1e", "object": "Address",
+        "created_at": "2022-07-28T19:54:01+00:00", "updated_at": "2022-07-28T19:54:01+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_06cf6ffd0eaf11ed8f05ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:54:01+00:00", "updated_at": "2022-07-28T19:54:01+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_06cb9cf70eaf11ed9304ac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-28T19:54:01+00:00", "updated_at": "2022-07-28T19:54:01+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_aba7397b28ba487e9ee4b553e5791a84", "object":
+        "Shipment"}, {"created_at": "2022-07-28T19:53:59Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "in_transit", "tracking_code":
+        "9400100109361130483092", "updated_at": "2022-07-28T19:56:03Z", "batch_id":
+        "batch_5bb14ecff43b47cc92fa8b46409e5aad", "batch_status": "postage_purchased",
+        "batch_message": null, "customs_info": null, "from_address": {"id": "adr_05a680a60eaf11ed8cf5ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-28T19:53:59+00:00", "updated_at":
+        "2022-07-28T19:53:59+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "insurance": null, "order_id":
+        null, "parcel": {"id": "prcl_4d4a9a5c2d694bc5b40cda7f1ecaafce", "object":
+        "Parcel", "created_at": "2022-07-28T19:53:59Z", "updated_at": "2022-07-28T19:53:59Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_88144aec97574bdf8f12be8608572958",
+        "created_at": "2022-07-28T19:54:00Z", "updated_at": "2022-07-28T19:54:00Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:54:00Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/f20499d1b5c3438fa2c2776c86c0bea2.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_81e9b362de6847a983e3a2de9b7400fe", "object":
+        "Rate", "created_at": "2022-07-28T19:53:59Z", "updated_at": "2022-07-28T19:53:59Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_b547fdd9f6f84b07995d6f77c18e4b91", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_55dac63a3cf842109801b70f799265a5",
+        "object": "Rate", "created_at": "2022-07-28T19:53:59Z", "updated_at": "2022-07-28T19:53:59Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_b547fdd9f6f84b07995d6f77c18e4b91", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_f0230c79f77a4c56a42af556d1b57d77",
+        "object": "Rate", "created_at": "2022-07-28T19:53:59Z", "updated_at": "2022-07-28T19:53:59Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_b547fdd9f6f84b07995d6f77c18e4b91", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_6c622b9727104706b0b1600584260d25", "object": "Rate", "created_at":
+        "2022-07-28T19:53:59Z", "updated_at": "2022-07-28T19:53:59Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_b547fdd9f6f84b07995d6f77c18e4b91", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_f0230c79f77a4c56a42af556d1b57d77",
+        "object": "Rate", "created_at": "2022-07-28T19:54:00Z", "updated_at": "2022-07-28T19:54:00Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_b547fdd9f6f84b07995d6f77c18e4b91", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_372df8b528b4419e9c7509687c5d9ead", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483092", "status": "out_for_delivery",
+        "status_detail": "out_for_delivery", "created_at": "2022-07-28T19:54:00Z",
+        "updated_at": "2022-07-28T19:56:00Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:56:00Z", "shipment_id": "shp_b547fdd9f6f84b07995d6f77c18e4b91",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:56:00Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:33:00Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}, {"object":
+        "TrackingDetail", "message": "Arrived at USPS Origin Facility", "description":
+        null, "status": "in_transit", "status_detail": "arrived_at_facility", "datetime":
+        "2022-06-29T18:38:00Z", "source": "USPS", "carrier_code": null, "tracking_location":
+        {"object": "TrackingLocation", "city": "NORTH HOUSTON", "state": "TX", "country":
+        null, "zip": "77315"}}, {"object": "TrackingDetail", "message": "Arrived at
+        USPS Facility", "description": null, "status": "in_transit", "status_detail":
+        "arrived_at_facility", "datetime": "2022-06-30T20:14:00Z", "source": "USPS",
+        "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "COLUMBIA", "state": "SC", "country": null, "zip": "29201"}}, {"object":
+        "TrackingDetail", "message": "Arrived at Post Office", "description": null,
+        "status": "in_transit", "status_detail": "arrived_at_facility", "datetime":
+        "2022-06-30T23:05:00Z", "source": "USPS", "carrier_code": null, "tracking_location":
+        {"object": "TrackingLocation", "city": "CHARLESTON", "state": "SC", "country":
+        null, "zip": "29407"}}, {"object": "TrackingDetail", "message": "Sorting Complete",
+        "description": null, "status": "in_transit", "status_detail": "status_update",
+        "datetime": "2022-07-01T04:45:00Z", "source": "USPS", "carrier_code": null,
+        "tracking_location": {"object": "TrackingLocation", "city": "CHARLESTON",
+        "state": "SC", "country": null, "zip": "29407"}}, {"object": "TrackingDetail",
+        "message": "Out for Delivery", "description": null, "status": "out_for_delivery",
+        "status_detail": "out_for_delivery", "datetime": "2022-07-01T04:55:00Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "CHARLESTON", "state": "SC", "country": null, "zip": "29407"}}], "fees":
+        [], "carrier_detail": {"object": "CarrierDetail", "service": "First-Class
+        Package Service", "container_type": null, "est_delivery_date_local": null,
+        "est_delivery_time_local": null, "origin_location": "HOUSTON TX, 77001", "origin_tracking_location":
+        {"object": "TrackingLocation", "city": "NORTH HOUSTON", "state": "TX", "country":
+        null, "zip": "77315"}, "destination_location": "CHARLESTON SC, 29401", "destination_tracking_location":
+        null, "guaranteed_delivery_date": null, "alternate_identifier": null, "initial_delivery_attempt":
+        null}, "public_url": "https://track.easypost.com/djE6dHJrXzM3MmRmOGI1MjhiNDQxOWU5Yzc1MDk2ODdjNWQ5ZWFk"},
+        "to_address": {"id": "adr_05a4aaf30eaf11ed91cbac1f6b0a0d1e", "object": "Address",
+        "created_at": "2022-07-28T19:53:59+00:00", "updated_at": "2022-07-28T19:53:59+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_05a680a60eaf11ed8cf5ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:53:59+00:00", "updated_at": "2022-07-28T19:53:59+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_05a4aaf30eaf11ed91cbac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-28T19:53:59+00:00", "updated_at": "2022-07-28T19:53:59+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_b547fdd9f6f84b07995d6f77c18e4b91", "object":
+        "Shipment"}, {"created_at": "2022-07-28T19:53:57Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "pre_transit", "tracking_code":
+        "9400100109361130483085", "updated_at": "2022-07-28T19:55:36Z", "batch_id":
+        "batch_a186c46585694fb2a1cee2d8d7c17e65", "batch_status": "postage_purchased",
+        "batch_message": null, "customs_info": null, "from_address": {"id": "adr_04865c300eaf11ed8c8fac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T19:53:57+00:00", "updated_at":
+        "2022-07-28T19:53:57+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "insurance": null, "order_id":
+        null, "parcel": {"id": "prcl_d86152c84d104aa4a6aa27d70079f0a7", "object":
+        "Parcel", "created_at": "2022-07-28T19:53:57Z", "updated_at": "2022-07-28T19:53:57Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_143c2c9f176c43588dd625a83d3de767",
+        "created_at": "2022-07-28T19:53:58Z", "updated_at": "2022-07-28T19:53:58Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:53:58Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/36ea7f8fe6b04543a1e026c6e68e79aa.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_cf201b90e9a341b592c409c839be3384", "object":
+        "Rate", "created_at": "2022-07-28T19:53:57Z", "updated_at": "2022-07-28T19:53:57Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_695ccc1d713642c6b05357a2f6566835", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_276b01f68b1844c59abc68f87847b56f",
+        "object": "Rate", "created_at": "2022-07-28T19:53:57Z", "updated_at": "2022-07-28T19:53:57Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_695ccc1d713642c6b05357a2f6566835", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_919476fec89f401aa03ef387f72db7f5",
+        "object": "Rate", "created_at": "2022-07-28T19:53:57Z", "updated_at": "2022-07-28T19:53:57Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_695ccc1d713642c6b05357a2f6566835", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_aeba70e1de35424e91183cf5025cee53", "object": "Rate", "created_at":
+        "2022-07-28T19:53:57Z", "updated_at": "2022-07-28T19:53:57Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_695ccc1d713642c6b05357a2f6566835", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_919476fec89f401aa03ef387f72db7f5",
+        "object": "Rate", "created_at": "2022-07-28T19:53:58Z", "updated_at": "2022-07-28T19:53:58Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_695ccc1d713642c6b05357a2f6566835", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_85fe762937474fbabdf6552b87961f28", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483085", "status": "out_for_delivery",
+        "status_detail": "out_for_delivery", "created_at": "2022-07-28T19:53:58Z",
+        "updated_at": "2022-07-28T19:55:58Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:55:58Z", "shipment_id": "shp_695ccc1d713642c6b05357a2f6566835",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:55:58Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:32:58Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}, {"object":
+        "TrackingDetail", "message": "Arrived at USPS Origin Facility", "description":
+        null, "status": "in_transit", "status_detail": "arrived_at_facility", "datetime":
+        "2022-06-29T18:37:58Z", "source": "USPS", "carrier_code": null, "tracking_location":
+        {"object": "TrackingLocation", "city": "NORTH HOUSTON", "state": "TX", "country":
+        null, "zip": "77315"}}, {"object": "TrackingDetail", "message": "Arrived at
+        USPS Facility", "description": null, "status": "in_transit", "status_detail":
+        "arrived_at_facility", "datetime": "2022-06-30T20:13:58Z", "source": "USPS",
+        "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "COLUMBIA", "state": "SC", "country": null, "zip": "29201"}}, {"object":
+        "TrackingDetail", "message": "Arrived at Post Office", "description": null,
+        "status": "in_transit", "status_detail": "arrived_at_facility", "datetime":
+        "2022-06-30T23:04:58Z", "source": "USPS", "carrier_code": null, "tracking_location":
+        {"object": "TrackingLocation", "city": "CHARLESTON", "state": "SC", "country":
+        null, "zip": "29407"}}, {"object": "TrackingDetail", "message": "Sorting Complete",
+        "description": null, "status": "in_transit", "status_detail": "status_update",
+        "datetime": "2022-07-01T04:44:58Z", "source": "USPS", "carrier_code": null,
+        "tracking_location": {"object": "TrackingLocation", "city": "CHARLESTON",
+        "state": "SC", "country": null, "zip": "29407"}}, {"object": "TrackingDetail",
+        "message": "Out for Delivery", "description": null, "status": "out_for_delivery",
+        "status_detail": "out_for_delivery", "datetime": "2022-07-01T04:54:58Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "CHARLESTON", "state": "SC", "country": null, "zip": "29407"}}], "fees":
+        [], "carrier_detail": {"object": "CarrierDetail", "service": "First-Class
+        Package Service", "container_type": null, "est_delivery_date_local": null,
+        "est_delivery_time_local": null, "origin_location": "HOUSTON TX, 77001", "origin_tracking_location":
+        {"object": "TrackingLocation", "city": "NORTH HOUSTON", "state": "TX", "country":
+        null, "zip": "77315"}, "destination_location": "CHARLESTON SC, 29401", "destination_tracking_location":
+        null, "guaranteed_delivery_date": null, "alternate_identifier": null, "initial_delivery_attempt":
+        null}, "public_url": "https://track.easypost.com/djE6dHJrXzg1ZmU3NjI5Mzc0NzRmYmFiZGY2NTUyYjg3OTYxZjI4"},
+        "to_address": {"id": "adr_04849e190eaf11ed8bcaac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-28T19:53:57+00:00", "updated_at": "2022-07-28T19:53:57+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_04865c300eaf11ed8c8fac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:53:57+00:00", "updated_at": "2022-07-28T19:53:57+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_04849e190eaf11ed8bcaac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:53:57+00:00", "updated_at": "2022-07-28T19:53:57+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_695ccc1d713642c6b05357a2f6566835", "object":
+        "Shipment"}, {"created_at": "2022-07-28T19:53:55Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "pre_transit", "tracking_code":
+        "9400100109361130483078", "updated_at": "2022-07-28T19:55:01Z", "batch_id":
+        "batch_af6a109d5e8b47ab971e657ab5c9d8ef", "batch_status": "postage_purchased",
+        "batch_message": null, "customs_info": null, "from_address": {"id": "adr_0389611b0eaf11ed8ac4ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-28T19:53:55+00:00", "updated_at":
+        "2022-07-28T19:53:55+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "insurance": null, "order_id":
+        null, "parcel": {"id": "prcl_d51f535046cb49e399fbd55db15209e5", "object":
+        "Parcel", "created_at": "2022-07-28T19:53:55Z", "updated_at": "2022-07-28T19:53:55Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_4b70c2a332a24c3497693d13b787eef4",
+        "created_at": "2022-07-28T19:53:56Z", "updated_at": "2022-07-28T19:53:56Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:53:56Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/e6c38644d683404ab386b7ace377b058.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_a38a6f99b18a4a97b15b7f004148a897", "object":
+        "Rate", "created_at": "2022-07-28T19:53:56Z", "updated_at": "2022-07-28T19:53:56Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_66650153362f475ea06c81838ee42782", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_0224cada8cd24c499ba50a1ac9e259c3",
+        "object": "Rate", "created_at": "2022-07-28T19:53:56Z", "updated_at": "2022-07-28T19:53:56Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_66650153362f475ea06c81838ee42782", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_ab08810b7af0420f9e1914ec42ee5c98",
+        "object": "Rate", "created_at": "2022-07-28T19:53:56Z", "updated_at": "2022-07-28T19:53:56Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_66650153362f475ea06c81838ee42782", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_2bac13d9c840458c86b7f4b73c511361",
+        "object": "Rate", "created_at": "2022-07-28T19:53:56Z", "updated_at": "2022-07-28T19:53:56Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_66650153362f475ea06c81838ee42782", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_2bac13d9c840458c86b7f4b73c511361",
+        "object": "Rate", "created_at": "2022-07-28T19:53:56Z", "updated_at": "2022-07-28T19:53:56Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_66650153362f475ea06c81838ee42782", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_cad53b28f5074aa7aa324cd4e11f673e", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483078", "status": "out_for_delivery",
+        "status_detail": "out_for_delivery", "created_at": "2022-07-28T19:53:56Z",
+        "updated_at": "2022-07-28T19:55:57Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:55:57Z", "shipment_id": "shp_66650153362f475ea06c81838ee42782",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:55:57Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:32:57Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}, {"object":
+        "TrackingDetail", "message": "Arrived at USPS Origin Facility", "description":
+        null, "status": "in_transit", "status_detail": "arrived_at_facility", "datetime":
+        "2022-06-29T18:37:57Z", "source": "USPS", "carrier_code": null, "tracking_location":
+        {"object": "TrackingLocation", "city": "NORTH HOUSTON", "state": "TX", "country":
+        null, "zip": "77315"}}, {"object": "TrackingDetail", "message": "Arrived at
+        USPS Facility", "description": null, "status": "in_transit", "status_detail":
+        "arrived_at_facility", "datetime": "2022-06-30T20:13:57Z", "source": "USPS",
+        "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "COLUMBIA", "state": "SC", "country": null, "zip": "29201"}}, {"object":
+        "TrackingDetail", "message": "Arrived at Post Office", "description": null,
+        "status": "in_transit", "status_detail": "arrived_at_facility", "datetime":
+        "2022-06-30T23:04:57Z", "source": "USPS", "carrier_code": null, "tracking_location":
+        {"object": "TrackingLocation", "city": "CHARLESTON", "state": "SC", "country":
+        null, "zip": "29407"}}, {"object": "TrackingDetail", "message": "Sorting Complete",
+        "description": null, "status": "in_transit", "status_detail": "status_update",
+        "datetime": "2022-07-01T04:44:57Z", "source": "USPS", "carrier_code": null,
+        "tracking_location": {"object": "TrackingLocation", "city": "CHARLESTON",
+        "state": "SC", "country": null, "zip": "29407"}}, {"object": "TrackingDetail",
+        "message": "Out for Delivery", "description": null, "status": "out_for_delivery",
+        "status_detail": "out_for_delivery", "datetime": "2022-07-01T04:54:57Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "CHARLESTON", "state": "SC", "country": null, "zip": "29407"}}], "fees":
+        [], "carrier_detail": {"object": "CarrierDetail", "service": "First-Class
+        Package Service", "container_type": null, "est_delivery_date_local": null,
+        "est_delivery_time_local": null, "origin_location": "HOUSTON TX, 77001", "origin_tracking_location":
+        {"object": "TrackingLocation", "city": "NORTH HOUSTON", "state": "TX", "country":
+        null, "zip": "77315"}, "destination_location": "CHARLESTON SC, 29401", "destination_tracking_location":
+        null, "guaranteed_delivery_date": null, "alternate_identifier": null, "initial_delivery_attempt":
+        null}, "public_url": "https://track.easypost.com/djE6dHJrX2NhZDUzYjI4ZjUwNzRhYTdhYTMyNGNkNGUxMWY2NzNl"},
+        "to_address": {"id": "adr_0387d7160eaf11ed9b5cac1f6bc7bdc6", "object": "Address",
+        "created_at": "2022-07-28T19:53:55+00:00", "updated_at": "2022-07-28T19:53:56+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_0389611b0eaf11ed8ac4ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:53:55+00:00", "updated_at": "2022-07-28T19:53:55+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_0387d7160eaf11ed9b5cac1f6bc7bdc6", "object":
+        "Address", "created_at": "2022-07-28T19:53:55+00:00", "updated_at": "2022-07-28T19:53:56+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_66650153362f475ea06c81838ee42782", "object":
+        "Shipment"}, {"created_at": "2022-07-28T19:53:53Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "in_transit", "tracking_code":
+        "9400100109361130483061", "updated_at": "2022-07-28T19:56:06Z", "batch_id":
+        "batch_f87669079a8944009bd943c6c566f325", "batch_status": "postage_purchased",
+        "batch_message": null, "customs_info": null, "from_address": {"id": "adr_024b601b0eaf11ed8a45ac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T19:53:53+00:00", "updated_at":
+        "2022-07-28T19:53:53+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "insurance": null, "order_id":
+        null, "parcel": {"id": "prcl_fff17c59b18e450582d3642898a36398", "object":
+        "Parcel", "created_at": "2022-07-28T19:53:53Z", "updated_at": "2022-07-28T19:53:53Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_f150cfe652bd4b98b80723d640647d49",
+        "created_at": "2022-07-28T19:53:54Z", "updated_at": "2022-07-28T19:53:54Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:53:54Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/ccf140e60f794be08d536baf233ac0ad.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_a6ed6b2a5de44f6a993a16a1f2df926c", "object":
+        "Rate", "created_at": "2022-07-28T19:53:54Z", "updated_at": "2022-07-28T19:53:54Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_059e077684ef42159c789b81359472bb", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_335a6764031448cbad61705c2a945a9b",
+        "object": "Rate", "created_at": "2022-07-28T19:53:54Z", "updated_at": "2022-07-28T19:53:54Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_059e077684ef42159c789b81359472bb", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_a0e6317019604b03a724ebdfd1ec6b2c",
+        "object": "Rate", "created_at": "2022-07-28T19:53:54Z", "updated_at": "2022-07-28T19:53:54Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_059e077684ef42159c789b81359472bb", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_293ac210c5af4f1da5fba11338ae9edd", "object": "Rate", "created_at":
+        "2022-07-28T19:53:54Z", "updated_at": "2022-07-28T19:53:54Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_059e077684ef42159c789b81359472bb", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_a0e6317019604b03a724ebdfd1ec6b2c",
+        "object": "Rate", "created_at": "2022-07-28T19:53:54Z", "updated_at": "2022-07-28T19:53:54Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_059e077684ef42159c789b81359472bb", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_3228e7c9b87e4e0a8385858734d0352d", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483061", "status": "out_for_delivery",
+        "status_detail": "out_for_delivery", "created_at": "2022-07-28T19:53:55Z",
+        "updated_at": "2022-07-28T19:55:55Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:55:55Z", "shipment_id": "shp_059e077684ef42159c789b81359472bb",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:55:55Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:32:55Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}, {"object":
+        "TrackingDetail", "message": "Arrived at USPS Origin Facility", "description":
+        null, "status": "in_transit", "status_detail": "arrived_at_facility", "datetime":
+        "2022-06-29T18:37:55Z", "source": "USPS", "carrier_code": null, "tracking_location":
+        {"object": "TrackingLocation", "city": "NORTH HOUSTON", "state": "TX", "country":
+        null, "zip": "77315"}}, {"object": "TrackingDetail", "message": "Arrived at
+        USPS Facility", "description": null, "status": "in_transit", "status_detail":
+        "arrived_at_facility", "datetime": "2022-06-30T20:13:55Z", "source": "USPS",
+        "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "COLUMBIA", "state": "SC", "country": null, "zip": "29201"}}, {"object":
+        "TrackingDetail", "message": "Arrived at Post Office", "description": null,
+        "status": "in_transit", "status_detail": "arrived_at_facility", "datetime":
+        "2022-06-30T23:04:55Z", "source": "USPS", "carrier_code": null, "tracking_location":
+        {"object": "TrackingLocation", "city": "CHARLESTON", "state": "SC", "country":
+        null, "zip": "29407"}}, {"object": "TrackingDetail", "message": "Sorting Complete",
+        "description": null, "status": "in_transit", "status_detail": "status_update",
+        "datetime": "2022-07-01T04:44:55Z", "source": "USPS", "carrier_code": null,
+        "tracking_location": {"object": "TrackingLocation", "city": "CHARLESTON",
+        "state": "SC", "country": null, "zip": "29407"}}, {"object": "TrackingDetail",
+        "message": "Out for Delivery", "description": null, "status": "out_for_delivery",
+        "status_detail": "out_for_delivery", "datetime": "2022-07-01T04:54:55Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "CHARLESTON", "state": "SC", "country": null, "zip": "29407"}}], "fees":
+        [], "carrier_detail": {"object": "CarrierDetail", "service": "First-Class
+        Package Service", "container_type": null, "est_delivery_date_local": null,
+        "est_delivery_time_local": null, "origin_location": "HOUSTON TX, 77001", "origin_tracking_location":
+        {"object": "TrackingLocation", "city": "NORTH HOUSTON", "state": "TX", "country":
+        null, "zip": "77315"}, "destination_location": "CHARLESTON SC, 29401", "destination_tracking_location":
+        null, "guaranteed_delivery_date": null, "alternate_identifier": null, "initial_delivery_attempt":
+        null}, "public_url": "https://track.easypost.com/djE6dHJrXzMyMjhlN2M5Yjg3ZTRlMGE4Mzg1ODU4NzM0ZDAzNTJk"},
+        "to_address": {"id": "adr_024915340eaf11ed8e3aac1f6b0a0d1e", "object": "Address",
+        "created_at": "2022-07-28T19:53:53+00:00", "updated_at": "2022-07-28T19:53:54+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_024b601b0eaf11ed8a45ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:53:53+00:00", "updated_at": "2022-07-28T19:53:53+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_024915340eaf11ed8e3aac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-28T19:53:53+00:00", "updated_at": "2022-07-28T19:53:54+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_059e077684ef42159c789b81359472bb", "object":
+        "Shipment"}], "has_more": true}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '41833'
+      - '48913'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"0776aea304c1d8208c99c877cff01418"
+      - W/"1fd10e1f105c091cbb608bc07d83df4f"
       expires:
       - '0'
       pragma:
@@ -112,20 +673,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fba6272e163e786b8e10013ad49
+      - 3843703f62e2e9daff23e29e003433c9
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.375579'
+      - '0.442949'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_buy.yaml
+++ b/tests/cassettes/test_shipment_buy.yaml
@@ -11,7 +11,7 @@ interactions:
       "none", "non_delivery_option": "return", "customs_items": [{"description": "Sweet
       shirts", "quantity": 2, "weight": 11, "value": 23, "hs_tariff_number": "654321",
       "origin_country": "US"}]}, "options": {"label_format": "PNG", "invoice_number":
-      "123"}, "reference": "123"}}'
+      "123"}, "reference": "123"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -20,7 +20,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '932'
+      - '956'
       Content-Type:
       - application/json
       authorization:
@@ -31,30 +31,263 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:12Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:12Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_a135a9371bf14bde89d58e6cd4edf300","object":"CustomsInfo","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_eabfe85b4d104012a8c1da9f1d766c78","object":"CustomsItem","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_70a19c6ccbe811ec8c01ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:12+00:00","updated_at":"2022-05-04T20:26:12+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_5cd02c272b304e0a87ccf4b99a56c647","object":"Parcel","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_164e8012940d49ae9eb3a85584b18d8a","object":"Rate","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_96c051622c9a45f086c56d50a49f95be","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_9c9c75815d3d495dbb74ee8686db2397","object":"Rate","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_96c051622c9a45f086c56d50a49f95be","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_dbc0726c8b444207ba04932a8d8a11c7","object":"Rate","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_96c051622c9a45f086c56d50a49f95be","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_3d4eccb5993b48bd9aa4a79f98ce54dc","object":"Rate","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_96c051622c9a45f086c56d50a49f95be","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_709fddaecbe811ecab0eac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:12+00:00","updated_at":"2022-05-04T20:26:12+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_70a19c6ccbe811ec8c01ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:12+00:00","updated_at":"2022-05-04T20:26:12+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_709fddaecbe811ecab0eac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:12+00:00","updated_at":"2022-05-04T20:26:12+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_96c051622c9a45f086c56d50a49f95be","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:11Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"label_format": "PNG", "invoice_number": "123",
+        "currency": "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference":
+        "123", "status": "unknown", "tracking_code": null, "updated_at": "2022-07-28T19:56:11Z",
+        "batch_id": null, "batch_status": null, "batch_message": null, "customs_info":
+        {"id": "cstinfo_67d4d09e39744f58afa7ea2641d8be59", "object": "CustomsInfo",
+        "created_at": "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z",
+        "contents_explanation": "", "contents_type": "merchandise", "customs_certify":
+        true, "customs_signer": "Steve Brule", "eel_pfc": "NOEEI 30.37(a)", "non_delivery_option":
+        "return", "restriction_comments": null, "restriction_type": "none", "mode":
+        "test", "declaration": null, "customs_items": [{"id": "cstitem_839aad9c623747c082e84d07e5a39ea8",
+        "object": "CustomsItem", "created_at": "2022-07-28T19:56:11Z", "updated_at":
+        "2022-07-28T19:56:11Z", "description": "Sweet shirts", "hs_tariff_number":
+        "654321", "origin_country": "US", "quantity": 2, "value": "23.0", "weight":
+        11.0, "code": null, "mode": "test", "manufacturer": null, "currency": null,
+        "eccn": null, "printed_commodity_identifier": null}]}, "from_address": {"id":
+        "adr_542b5f120eaf11eda04bac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:56:11+00:00", "updated_at": "2022-07-28T19:56:11+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_20c8ffd5809a4d2c8e28984646414df7",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_e3b845251426468dbf344e640f853cfc",
+        "object": "Rate", "created_at": "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_e962962de8854c2dbeaf54cabdf0ebdf", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_be2771b73057473c9d80148f67d7987d", "object": "Rate", "created_at":
+        "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_e962962de8854c2dbeaf54cabdf0ebdf", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_228f5e29068748278fb41505d69be72b", "object": "Rate", "created_at":
+        "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_e962962de8854c2dbeaf54cabdf0ebdf", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_720c2b8588db46bfa32d4dc0c9e111a9", "object": "Rate", "created_at":
+        "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_e962962de8854c2dbeaf54cabdf0ebdf", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_5429e4dc0eaf11ed9acbac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:56:11+00:00", "updated_at": "2022-07-28T19:56:11+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_542b5f120eaf11eda04bac1f6b0a0d1e",
+        "object": "Address", "created_at": "2022-07-28T19:56:11+00:00", "updated_at":
+        "2022-07-28T19:56:11+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_5429e4dc0eaf11ed9acbac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:11+00:00", "updated_at": "2022-07-28T19:56:11+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_e962962de8854c2dbeaf54cabdf0ebdf",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '5563'
+      - '5667'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"295a9e55f73932b7de2722a902db683d"
+      - W/"0bcb34b93391dd9b2d73867567e03173"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_96c051622c9a45f086c56d50a49f95be
+      - /api/v2/shipments/shp_e962962de8854c2dbeaf54cabdf0ebdf
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 3843703d62e2e9dbff23e29f003433f0
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb3nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
+      x-runtime:
+      - '0.276412'
+      x-version-label:
+      - easypost-202207272329-7f74c9e58c-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"rate": {"id": "rate_e3b845251426468dbf344e640f853cfc"}, "carbon_offset":
+      false}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '81'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/shipments/shp_e962962de8854c2dbeaf54cabdf0ebdf/buy
+  response:
+    body:
+      string: '{"created_at": "2022-07-28T19:56:11Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"label_format": "PNG", "invoice_number": "123",
+        "currency": "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference":
+        "123", "status": "unknown", "tracking_code": "9400100109361130483566", "updated_at":
+        "2022-07-28T19:56:12Z", "batch_id": null, "batch_status": null, "batch_message":
+        null, "customs_info": {"id": "cstinfo_67d4d09e39744f58afa7ea2641d8be59", "object":
+        "CustomsInfo", "created_at": "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z",
+        "contents_explanation": "", "contents_type": "merchandise", "customs_certify":
+        true, "customs_signer": "Steve Brule", "eel_pfc": "NOEEI 30.37(a)", "non_delivery_option":
+        "return", "restriction_comments": null, "restriction_type": "none", "mode":
+        "test", "declaration": null, "customs_items": [{"id": "cstitem_839aad9c623747c082e84d07e5a39ea8",
+        "object": "CustomsItem", "created_at": "2022-07-28T19:56:11Z", "updated_at":
+        "2022-07-28T19:56:11Z", "description": "Sweet shirts", "hs_tariff_number":
+        "654321", "origin_country": "US", "quantity": 2, "value": "23.0", "weight":
+        11.0, "code": null, "mode": "test", "manufacturer": null, "currency": null,
+        "eccn": null, "printed_commodity_identifier": null}]}, "from_address": {"id":
+        "adr_542b5f120eaf11eda04bac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:56:11+00:00", "updated_at": "2022-07-28T19:56:11+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_20c8ffd5809a4d2c8e28984646414df7",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_b4b8f142466d419781ec9c7a9ba938c1",
+        "created_at": "2022-07-28T19:56:12Z", "updated_at": "2022-07-28T19:56:12Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:12Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/78b04f8a23bf4a8797337915cd279c84.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_e3b845251426468dbf344e640f853cfc", "object":
+        "Rate", "created_at": "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_e962962de8854c2dbeaf54cabdf0ebdf", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_be2771b73057473c9d80148f67d7987d", "object": "Rate", "created_at":
+        "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_e962962de8854c2dbeaf54cabdf0ebdf", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_228f5e29068748278fb41505d69be72b", "object": "Rate", "created_at":
+        "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_e962962de8854c2dbeaf54cabdf0ebdf", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_720c2b8588db46bfa32d4dc0c9e111a9", "object": "Rate", "created_at":
+        "2022-07-28T19:56:11Z", "updated_at": "2022-07-28T19:56:11Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_e962962de8854c2dbeaf54cabdf0ebdf", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_e3b845251426468dbf344e640f853cfc",
+        "object": "Rate", "created_at": "2022-07-28T19:56:12Z", "updated_at": "2022-07-28T19:56:12Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_e962962de8854c2dbeaf54cabdf0ebdf", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_19c043d83a804316b27b6227085ea01b", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483566", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T19:56:12Z", "updated_at":
+        "2022-07-28T19:56:12Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_e962962de8854c2dbeaf54cabdf0ebdf", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzE5YzA0M2Q4M2E4MDQzMTZiMjdiNjIyNzA4NWVhMDFi"},
+        "to_address": {"id": "adr_5429e4dc0eaf11ed9acbac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-28T19:56:11+00:00", "updated_at": "2022-07-28T19:56:11+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_542b5f120eaf11eda04bac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:56:11+00:00", "updated_at": "2022-07-28T19:56:11+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_5429e4dc0eaf11ed9acbac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:56:11+00:00", "updated_at": "2022-07-28T19:56:11+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_e962962de8854c2dbeaf54cabdf0ebdf", "object":
+        "Shipment"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '7790'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"02a5c937cc9a56f3fc5a85a3d00150e4"
+      expires:
+      - '0'
       pragma:
       - no-cache
       referrer-policy:
@@ -72,7 +305,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb96272e164e786b8e20013ad7d
+      - 3843703d62e2e9dbff23e29f0034341a
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -80,89 +313,13 @@ interactions:
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.299132'
+      - '0.897803'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"rate": {"id": "rate_3d4eccb5993b48bd9aa4a79f98ce54dc"}}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '57'
-      Content-Type:
-      - application/json
-      authorization:
-      - <REDACTED>
-      user-agent:
-      - <REDACTED>
-    method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_96c051622c9a45f086c56d50a49f95be/buy
-  response:
-    body:
-      string: '{"created_at":"2022-05-04T20:26:12Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":"9400100109361117768884","updated_at":"2022-05-04T20:26:13Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_a135a9371bf14bde89d58e6cd4edf300","object":"CustomsInfo","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_eabfe85b4d104012a8c1da9f1d766c78","object":"CustomsItem","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_70a19c6ccbe811ec8c01ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:12+00:00","updated_at":"2022-05-04T20:26:12+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_5cd02c272b304e0a87ccf4b99a56c647","object":"Parcel","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_0b6a7b851d574ad7a8f46964e196ec80","created_at":"2022-05-04T20:26:13Z","updated_at":"2022-05-04T20:26:13Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:13Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/977d8ff0d72448b493ec01059eb9af53.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_164e8012940d49ae9eb3a85584b18d8a","object":"Rate","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_96c051622c9a45f086c56d50a49f95be","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_9c9c75815d3d495dbb74ee8686db2397","object":"Rate","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_96c051622c9a45f086c56d50a49f95be","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_dbc0726c8b444207ba04932a8d8a11c7","object":"Rate","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_96c051622c9a45f086c56d50a49f95be","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_3d4eccb5993b48bd9aa4a79f98ce54dc","object":"Rate","created_at":"2022-05-04T20:26:12Z","updated_at":"2022-05-04T20:26:12Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_96c051622c9a45f086c56d50a49f95be","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_3d4eccb5993b48bd9aa4a79f98ce54dc","object":"Rate","created_at":"2022-05-04T20:26:13Z","updated_at":"2022-05-04T20:26:13Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_96c051622c9a45f086c56d50a49f95be","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_62de9ee096a9474fbb9c2da96e77bbe1","object":"Tracker","mode":"test","tracking_code":"9400100109361117768884","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:26:13Z","updated_at":"2022-05-04T20:26:13Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_96c051622c9a45f086c56d50a49f95be","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzYyZGU5ZWUwOTZhOTQ3NGZiYjljMmRhOTZlNzdiYmUx"},"to_address":{"id":"adr_709fddaecbe811ecab0eac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:12+00:00","updated_at":"2022-05-04T20:26:13+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_70a19c6ccbe811ec8c01ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:12+00:00","updated_at":"2022-05-04T20:26:12+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_709fddaecbe811ecab0eac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:12+00:00","updated_at":"2022-05-04T20:26:13+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_96c051622c9a45f086c56d50a49f95be","object":"Shipment"}'
-    headers:
-      cache-control:
-      - no-cache, no-store
-      content-length:
-      - '7660'
-      content-type:
-      - application/json; charset=utf-8
-      etag:
-      - W/"add35208f671d10f1b9fd81e0d9cebdd"
-      expires:
-      - '0'
-      pragma:
-      - no-cache
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      transfer-encoding:
-      - chunked
-      x-backend:
-      - easypost
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-ep-request-uuid:
-      - 78245fb96272e164e786b8e20013adb5
-      x-frame-options:
-      - SAMEORIGIN
-      x-node:
-      - bigweb3nuq
-      x-permitted-cross-domain-policies:
-      - none
-      x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
-      x-runtime:
-      - '0.933934'
-      x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_buy_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_buy_with_carbon_offset.yaml
@@ -6,7 +6,7 @@ interactions:
       {"name": "EasyPost", "street1": "417 Montgomery Street", "street2": "5th Floor",
       "city": "San Francisco", "state": "CA", "zip": "94104", "country": "US", "phone":
       "4153334445", "email": "support@easypost.com"}, "parcel": {"length": "20.2",
-      "width": "10.9", "height": "5", "weight": "65.9"}}}'
+      "width": "10.9", "height": "5", "weight": "65.9"}}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -15,7 +15,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '527'
+      - '551'
       Content-Type:
       - application/json
       authorization:
@@ -26,64 +26,64 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at": "2022-07-27T22:38:43Z", "is_return": false, "messages":
+      string: '{"created_at": "2022-07-28T19:56:26Z", "is_return": false, "messages":
         [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
         "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        null, "updated_at": "2022-07-27T22:38:43Z", "batch_id": null, "batch_status":
+        null, "updated_at": "2022-07-28T19:56:26Z", "batch_id": null, "batch_status":
         null, "batch_message": null, "customs_info": null, "from_address": {"id":
-        "adr_de63ae580dfc11eda35fac1f6bc7bdc6", "object": "Address", "created_at":
-        "2022-07-27T22:38:43+00:00", "updated_at": "2022-07-27T22:38:43+00:00", "name":
+        "adr_5d1316dc0eaf11eda3d2ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:26+00:00", "updated_at": "2022-07-28T19:56:26+00:00", "name":
         "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
         "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
         "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
         "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
         null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
-        {"id": "prcl_22ce7510d35744c5a2859d246e6c65fb", "object": "Parcel", "created_at":
-        "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z", "length": 20.2,
+        {"id": "prcl_9e0fdb2c4b1f4471905fbe86fbc0f802", "object": "Parcel", "created_at":
+        "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z", "length": 20.2,
         "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
-        "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_576371e5f0f24e44ab75e6f79a41f203",
-        "object": "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
-        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
-        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
-        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_23f9ab55dd7644898eb86ca7d1585651",
-        "object": "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
+        "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_ce97ca4d7bf3458abe8c163b7e2217d2",
+        "object": "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
         "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
         "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
         "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_a40a9ab2e6864b6f8cc36db9f7607439",
-        "object": "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
+        2, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_2616f71260634403a7ccd86e732d798d",
+        "object": "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_81f6f77471df41d284f9bf97308911fb",
+        "object": "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
         "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
         "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
         "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
+        null, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
         "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
-        null, "selected_rate": null, "tracker": null, "to_address": {"id": "adr_de61f13a0dfc11eda5d4ac1f6bc7b362",
-        "object": "Address", "created_at": "2022-07-27T22:38:43+00:00", "updated_at":
-        "2022-07-27T22:38:43+00:00", "name": "Dr. Steve Brule", "company": null, "street1":
+        null, "selected_rate": null, "tracker": null, "to_address": {"id": "adr_5d113f850eaf11eda293ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-28T19:56:26+00:00", "updated_at":
+        "2022-07-28T19:56:26+00:00", "name": "Dr. Steve Brule", "company": null, "street1":
         "179 N Harbor Dr", "street2": null, "city": "Redondo Beach", "state": "CA",
         "zip": "90277", "country": "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com",
         "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
         null, "state_tax_id": null, "verifications": {}}, "usps_zone": 4, "return_address":
-        {"id": "adr_de63ae580dfc11eda35fac1f6bc7bdc6", "object": "Address", "created_at":
-        "2022-07-27T22:38:43+00:00", "updated_at": "2022-07-27T22:38:43+00:00", "name":
+        {"id": "adr_5d1316dc0eaf11eda3d2ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:26+00:00", "updated_at": "2022-07-28T19:56:26+00:00", "name":
         "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
         "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
         "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
         "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
-        null, "verifications": {}}, "buyer_address": {"id": "adr_de61f13a0dfc11eda5d4ac1f6bc7b362",
-        "object": "Address", "created_at": "2022-07-27T22:38:43+00:00", "updated_at":
-        "2022-07-27T22:38:43+00:00", "name": "Dr. Steve Brule", "company": null, "street1":
+        null, "verifications": {}}, "buyer_address": {"id": "adr_5d113f850eaf11eda293ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-28T19:56:26+00:00", "updated_at":
+        "2022-07-28T19:56:26+00:00", "name": "Dr. Steve Brule", "company": null, "street1":
         "179 N Harbor Dr", "street2": null, "city": "Redondo Beach", "state": "CA",
         "zip": "90277", "country": "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com",
         "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
         null, "state_tax_id": null, "verifications": {}}, "forms": [], "fees": [],
-        "id": "shp_2ab2216e186440cb92296cd17e2c7eea", "object": "Shipment"}'
+        "id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -92,11 +92,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"5cbfca5d5c523d62a0f0cb5e8a0276ab"
+      - W/"3bc583dfb84ae2263794c9c2b4005f58"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_2ab2216e186440cb92296cd17e2c7eea
+      - /api/v2/shipments/shp_b49f9bb6bc7b4c458c4a6cbc7e438f73
       pragma:
       - no-cache
       referrer-policy:
@@ -112,28 +112,28 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - a5c9601362e1be73ff22b9c0000ae439
+      - 3843704162e2e9eaff23e2db0034379f
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq 403f17ff97
-      - intlb1wdc 403f17ff97
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
       - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.230989'
+      - '0.286183'
       x-version-label:
-      - easypost-202207272153-717cb56530-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: '{"rate": {"id": "rate_576371e5f0f24e44ab75e6f79a41f203"}, "carbon_offset":
+    body: '{"rate": {"id": "rate_2616f71260634403a7ccd86e732d798d"}, "carbon_offset":
       true}'
     headers:
       Accept:
@@ -151,68 +151,68 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_2ab2216e186440cb92296cd17e2c7eea/buy
+    uri: https://api.easypost.com/v2/shipments/shp_b49f9bb6bc7b4c458c4a6cbc7e438f73/buy
   response:
     body:
-      string: '{"created_at": "2022-07-27T22:38:43Z", "is_return": false, "messages":
+      string: '{"created_at": "2022-07-28T19:56:26Z", "is_return": false, "messages":
         [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
         "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        "9461200109361130325888", "updated_at": "2022-07-27T22:38:44Z", "batch_id":
+        "9461200109361130483632", "updated_at": "2022-07-28T19:56:27Z", "batch_id":
         null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
-        {"id": "adr_de63ae580dfc11eda35fac1f6bc7bdc6", "object": "Address", "created_at":
-        "2022-07-27T22:38:43+00:00", "updated_at": "2022-07-27T22:38:43+00:00", "name":
+        {"id": "adr_5d1316dc0eaf11eda3d2ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:26+00:00", "updated_at": "2022-07-28T19:56:26+00:00", "name":
         "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
         "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
         "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
         "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
         null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
-        {"id": "prcl_22ce7510d35744c5a2859d246e6c65fb", "object": "Parcel", "created_at":
-        "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z", "length": 20.2,
+        {"id": "prcl_9e0fdb2c4b1f4471905fbe86fbc0f802", "object": "Parcel", "created_at":
+        "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z", "length": 20.2,
         "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
-        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_27af96cd11af438890f581f8f2f5a72b",
-        "created_at": "2022-07-27T22:38:44Z", "updated_at": "2022-07-27T22:38:44Z",
-        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-27T22:38:44Z",
+        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_c465aea7d80941ec8f5cde74f2cc4a29",
+        "created_at": "2022-07-28T19:56:27Z", "updated_at": "2022-07-28T19:56:27Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:27Z",
         "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
-        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220727/44f1df13e4e949c29bb69714eb449e96.png",
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/d2da07658ef042989c8f809cf0bcbede.png",
         "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
-        null}, "rates": [{"id": "rate_576371e5f0f24e44ab75e6f79a41f203", "object":
-        "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
-        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
-        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
-        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_23f9ab55dd7644898eb86ca7d1585651",
-        "object": "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
+        null}, "rates": [{"id": "rate_ce97ca4d7bf3458abe8c163b7e2217d2", "object":
+        "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
         "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
         "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
         "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_a40a9ab2e6864b6f8cc36db9f7607439",
-        "object": "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
-        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
-        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
-        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
-        null, "selected_rate": {"id": "rate_576371e5f0f24e44ab75e6f79a41f203", "object":
-        "Rate", "created_at": "2022-07-27T22:38:44Z", "updated_at": "2022-07-27T22:38:44Z",
+        2, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_2616f71260634403a7ccd86e732d798d",
+        "object": "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
         "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
         "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
         "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_04f1c22a62df4477bd1fdfd3de88b707",
-        "object": "Tracker", "mode": "test", "tracking_code": "9461200109361130325888",
-        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-27T22:38:44Z",
-        "updated_at": "2022-07-27T22:38:44Z", "signed_by": null, "weight": null, "est_delivery_date":
-        null, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier": "USPS",
+        5, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_81f6f77471df41d284f9bf97308911fb",
+        "object": "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
+        null, "selected_rate": {"id": "rate_2616f71260634403a7ccd86e732d798d", "object":
+        "Rate", "created_at": "2022-07-28T19:56:27Z", "updated_at": "2022-07-28T19:56:27Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_e8be6d42e73d4eae8c3c2442fce0a40e",
+        "object": "Tracker", "mode": "test", "tracking_code": "9461200109361130483632",
+        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-28T19:56:27Z",
+        "updated_at": "2022-07-28T19:56:27Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier": "USPS",
         "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
-        "https://track.easypost.com/djE6dHJrXzA0ZjFjMjJhNjJkZjQ0NzdiZDFmZGZkM2RlODhiNzA3"},
-        "to_address": {"id": "adr_de61f13a0dfc11eda5d4ac1f6bc7b362", "object": "Address",
-        "created_at": "2022-07-27T22:38:43+00:00", "updated_at": "2022-07-27T22:38:43+00:00",
+        "https://track.easypost.com/djE6dHJrX2U4YmU2ZDQyZTczZDRlYWU4YzNjMjQ0MmZjZTBhNDBl"},
+        "to_address": {"id": "adr_5d113f850eaf11eda293ac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-28T19:56:26+00:00", "updated_at": "2022-07-28T19:56:26+00:00",
         "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
         "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
         "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
@@ -220,15 +220,15 @@ interactions:
         null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
         [], "details": null}, "delivery": {"success": true, "errors": [], "details":
         {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
-        "usps_zone": 4, "return_address": {"id": "adr_de63ae580dfc11eda35fac1f6bc7bdc6",
-        "object": "Address", "created_at": "2022-07-27T22:38:43+00:00", "updated_at":
-        "2022-07-27T22:38:43+00:00", "name": "EasyPost", "company": null, "street1":
+        "usps_zone": 4, "return_address": {"id": "adr_5d1316dc0eaf11eda3d2ac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T19:56:26+00:00", "updated_at":
+        "2022-07-28T19:56:26+00:00", "name": "EasyPost", "company": null, "street1":
         "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
         "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
         "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
         null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
-        "buyer_address": {"id": "adr_de61f13a0dfc11eda5d4ac1f6bc7b362", "object":
-        "Address", "created_at": "2022-07-27T22:38:43+00:00", "updated_at": "2022-07-27T22:38:43+00:00",
+        "buyer_address": {"id": "adr_5d113f850eaf11eda293ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:56:26+00:00", "updated_at": "2022-07-28T19:56:26+00:00",
         "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
         "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
         "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
@@ -240,7 +240,7 @@ interactions:
         "charged": true, "refunded": false}, {"object": "Fee", "type": "PostageFee",
         "amount": "8.91000", "charged": true, "refunded": false}, {"object": "Fee",
         "type": "CarbonOffsetFee", "amount": "0.11000", "charged": true, "refunded":
-        false}], "id": "shp_2ab2216e186440cb92296cd17e2c7eea", "object": "Shipment"}'
+        false}], "id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -249,7 +249,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"f6dbf7ebbddb2bd9abd536692ebfb75d"
+      - W/"1ec27fad6ad8cd61fe947be65589c616"
       expires:
       - '0'
       pragma:
@@ -267,21 +267,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - a5c9601362e1be73ff22b9c0000ae44d
+      - 3843704162e2e9eaff23e2db003437b7
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb4nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq 403f17ff97
-      - intlb1wdc 403f17ff97
+      - intlb2wdc 403f17ff97
       - extlb4wdc 403f17ff97
       x-runtime:
-      - '1.142824'
+      - '1.187351'
       x-version-label:
-      - easypost-202207272153-717cb56530-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_buy_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_buy_with_carbon_offset.yaml
@@ -26,77 +26,82 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at": "2022-07-28T19:56:26Z", "is_return": false, "messages":
-        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
-        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        null, "updated_at": "2022-07-28T19:56:26Z", "batch_id": null, "batch_status":
-        null, "batch_message": null, "customs_info": null, "from_address": {"id":
-        "adr_5d1316dc0eaf11eda3d2ac1f6bc72124", "object": "Address", "created_at":
-        "2022-07-28T19:56:26+00:00", "updated_at": "2022-07-28T19:56:26+00:00", "name":
-        "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
+      string: '{"created_at": "2022-07-29T21:54:51Z", "is_return": false, "messages":
+        [{"carrier": "UPS", "carrier_account_id": "ca_0b351eb47cac405dadaf54c659c0a0eb",
+        "type": "rate_error", "message": "Invalid Access License number"}, {"carrier":
+        "UPS", "carrier_account_id": "ca_ba94eaaacddb4bf2b135953b3067e817", "type":
+        "rate_error", "message": "Invalid Access License number"}, {"carrier": "UPS",
+        "carrier_account_id": "ca_34d97dc9d5df46e48c088455935bc518", "type": "rate_error",
+        "message": "Invalid Access License number"}], "mode": "test", "options": {"currency":
+        "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference": null,
+        "status": "unknown", "tracking_code": null, "updated_at": "2022-07-29T21:54:51Z",
+        "batch_id": null, "batch_status": null, "batch_message": null, "customs_info":
+        null, "from_address": {"id": "adr_126d749e0f8911edac64ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-29T21:54:51+00:00", "updated_at": "2022-07-29T21:54:51+00:00",
+        "name": "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
         "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
         "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
         "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
         null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
-        {"id": "prcl_9e0fdb2c4b1f4471905fbe86fbc0f802", "object": "Parcel", "created_at":
-        "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z", "length": 20.2,
+        {"id": "prcl_9cc9c4c829784a50b9fcbdf30038f479", "object": "Parcel", "created_at":
+        "2022-07-29T21:54:51Z", "updated_at": "2022-07-29T21:54:51Z", "length": 20.2,
         "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
-        "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_ce97ca4d7bf3458abe8c163b7e2217d2",
-        "object": "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
-        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
-        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
-        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_2616f71260634403a7ccd86e732d798d",
-        "object": "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
-        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
-        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
-        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_81f6f77471df41d284f9bf97308911fb",
-        "object": "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
+        "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_6db905bb7a6447d99eaac0dee74ac9b4",
+        "object": "Rate", "created_at": "2022-07-29T21:54:51Z", "updated_at": "2022-07-29T21:54:51Z",
         "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
         "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
         "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
-        null, "selected_rate": null, "tracker": null, "to_address": {"id": "adr_5d113f850eaf11eda293ac1f6bc7b362",
-        "object": "Address", "created_at": "2022-07-28T19:56:26+00:00", "updated_at":
-        "2022-07-28T19:56:26+00:00", "name": "Dr. Steve Brule", "company": null, "street1":
+        null, "shipment_id": "shp_a4e051d971eb4fa69524b02f67a26e8a", "carrier_account_id":
+        "ca_7642d249fdcf47bcb5da9ea34c96dfcf"}, {"id": "rate_c646c55160ba4508aaf7df5a38da5f9d",
+        "object": "Rate", "created_at": "2022-07-29T21:54:51Z", "updated_at": "2022-07-29T21:54:51Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_a4e051d971eb4fa69524b02f67a26e8a", "carrier_account_id":
+        "ca_7642d249fdcf47bcb5da9ea34c96dfcf"}, {"id": "rate_c7024553718e453cafb325daffac9026",
+        "object": "Rate", "created_at": "2022-07-29T21:54:51Z", "updated_at": "2022-07-29T21:54:51Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_a4e051d971eb4fa69524b02f67a26e8a", "carrier_account_id":
+        "ca_7642d249fdcf47bcb5da9ea34c96dfcf"}], "refund_status": null, "scan_form":
+        null, "selected_rate": null, "tracker": null, "to_address": {"id": "adr_126b90600f8911eda21bac1f6b0a0d1e",
+        "object": "Address", "created_at": "2022-07-29T21:54:51+00:00", "updated_at":
+        "2022-07-29T21:54:51+00:00", "name": "Dr. Steve Brule", "company": null, "street1":
         "179 N Harbor Dr", "street2": null, "city": "Redondo Beach", "state": "CA",
         "zip": "90277", "country": "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com",
         "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
         null, "state_tax_id": null, "verifications": {}}, "usps_zone": 4, "return_address":
-        {"id": "adr_5d1316dc0eaf11eda3d2ac1f6bc72124", "object": "Address", "created_at":
-        "2022-07-28T19:56:26+00:00", "updated_at": "2022-07-28T19:56:26+00:00", "name":
+        {"id": "adr_126d749e0f8911edac64ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-29T21:54:51+00:00", "updated_at": "2022-07-29T21:54:51+00:00", "name":
         "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
         "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
         "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
         "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
-        null, "verifications": {}}, "buyer_address": {"id": "adr_5d113f850eaf11eda293ac1f6bc7b362",
-        "object": "Address", "created_at": "2022-07-28T19:56:26+00:00", "updated_at":
-        "2022-07-28T19:56:26+00:00", "name": "Dr. Steve Brule", "company": null, "street1":
+        null, "verifications": {}}, "buyer_address": {"id": "adr_126b90600f8911eda21bac1f6b0a0d1e",
+        "object": "Address", "created_at": "2022-07-29T21:54:51+00:00", "updated_at":
+        "2022-07-29T21:54:51+00:00", "name": "Dr. Steve Brule", "company": null, "street1":
         "179 N Harbor Dr", "street2": null, "city": "Redondo Beach", "state": "CA",
         "zip": "90277", "country": "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com",
         "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
         null, "state_tax_id": null, "verifications": {}}, "forms": [], "fees": [],
-        "id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "object": "Shipment"}'
+        "id": "shp_a4e051d971eb4fa69524b02f67a26e8a", "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '4366'
+      - '4782'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"3bc583dfb84ae2263794c9c2b4005f58"
+      - W/"fc5b70f6db7b8e3b05be0f013d0e9717"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_b49f9bb6bc7b4c458c4a6cbc7e438f73
+      - /api/v2/shipments/shp_a4e051d971eb4fa69524b02f67a26e8a
       pragma:
       - no-cache
       referrer-policy:
@@ -112,28 +117,28 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 3843704162e2e9eaff23e2db0034379f
+      - 1dc2029c62e4572bec3e46d500035c75
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb9nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq 403f17ff97
       - intlb2wdc 403f17ff97
-      - extlb4wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.286183'
+      - '0.656300'
       x-version-label:
-      - easypost-202207272329-7f74c9e58c-master
+      - easypost-202207291722-ecd5579616-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: '{"rate": {"id": "rate_2616f71260634403a7ccd86e732d798d"}, "carbon_offset":
+    body: '{"rate": {"id": "rate_c7024553718e453cafb325daffac9026"}, "carbon_offset":
       true}'
     headers:
       Accept:
@@ -151,84 +156,74 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_b49f9bb6bc7b4c458c4a6cbc7e438f73/buy
+    uri: https://api.easypost.com/v2/shipments/shp_a4e051d971eb4fa69524b02f67a26e8a/buy
   response:
     body:
-      string: '{"created_at": "2022-07-28T19:56:26Z", "is_return": false, "messages":
-        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
-        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        "9461200109361130483632", "updated_at": "2022-07-28T19:56:27Z", "batch_id":
-        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
-        {"id": "adr_5d1316dc0eaf11eda3d2ac1f6bc72124", "object": "Address", "created_at":
-        "2022-07-28T19:56:26+00:00", "updated_at": "2022-07-28T19:56:26+00:00", "name":
-        "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
-        "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
-        "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
-        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
-        null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
-        {"id": "prcl_9e0fdb2c4b1f4471905fbe86fbc0f802", "object": "Parcel", "created_at":
-        "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z", "length": 20.2,
-        "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
-        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_c465aea7d80941ec8f5cde74f2cc4a29",
-        "created_at": "2022-07-28T19:56:27Z", "updated_at": "2022-07-28T19:56:27Z",
-        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:27Z",
-        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
-        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/d2da07658ef042989c8f809cf0bcbede.png",
-        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
-        null}, "rates": [{"id": "rate_ce97ca4d7bf3458abe8c163b7e2217d2", "object":
-        "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
-        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
-        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
-        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_2616f71260634403a7ccd86e732d798d",
-        "object": "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
-        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
-        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
-        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_81f6f77471df41d284f9bf97308911fb",
-        "object": "Rate", "created_at": "2022-07-28T19:56:26Z", "updated_at": "2022-07-28T19:56:26Z",
-        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
-        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
-        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
-        null, "selected_rate": {"id": "rate_2616f71260634403a7ccd86e732d798d", "object":
-        "Rate", "created_at": "2022-07-28T19:56:27Z", "updated_at": "2022-07-28T19:56:27Z",
-        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
-        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
-        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_e8be6d42e73d4eae8c3c2442fce0a40e",
-        "object": "Tracker", "mode": "test", "tracking_code": "9461200109361130483632",
-        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-28T19:56:27Z",
-        "updated_at": "2022-07-28T19:56:27Z", "signed_by": null, "weight": null, "est_delivery_date":
-        null, "shipment_id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "carrier": "USPS",
-        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
-        "https://track.easypost.com/djE6dHJrX2U4YmU2ZDQyZTczZDRlYWU4YzNjMjQ0MmZjZTBhNDBl"},
-        "to_address": {"id": "adr_5d113f850eaf11eda293ac1f6bc7b362", "object": "Address",
-        "created_at": "2022-07-28T19:56:26+00:00", "updated_at": "2022-07-28T19:56:26+00:00",
-        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
-        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
-        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
-        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
-        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
-        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
-        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
-        "usps_zone": 4, "return_address": {"id": "adr_5d1316dc0eaf11eda3d2ac1f6bc72124",
-        "object": "Address", "created_at": "2022-07-28T19:56:26+00:00", "updated_at":
-        "2022-07-28T19:56:26+00:00", "name": "EasyPost", "company": null, "street1":
+      string: '{"created_at": "2022-07-29T21:54:51Z", "is_return": false, "messages":
+        [{"carrier": "UPS", "carrier_account_id": "ca_0b351eb47cac405dadaf54c659c0a0eb",
+        "type": "rate_error", "message": "Invalid Access License number"}, {"carrier":
+        "UPS", "carrier_account_id": "ca_ba94eaaacddb4bf2b135953b3067e817", "type":
+        "rate_error", "message": "Invalid Access License number"}, {"carrier": "UPS",
+        "carrier_account_id": "ca_34d97dc9d5df46e48c088455935bc518", "type": "rate_error",
+        "message": "Invalid Access License number"}], "mode": "test", "options": {"currency":
+        "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference": null,
+        "status": "unknown", "tracking_code": "9461200109361130688693", "updated_at":
+        "2022-07-29T21:54:53Z", "batch_id": null, "batch_status": null, "batch_message":
+        null, "customs_info": null, "from_address": {"id": "adr_126d749e0f8911edac64ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-29T21:54:51+00:00", "updated_at":
+        "2022-07-29T21:54:51+00:00", "name": "EasyPost", "company": null, "street1":
         "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
         "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
         "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
         null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
-        "buyer_address": {"id": "adr_5d113f850eaf11eda293ac1f6bc7b362", "object":
-        "Address", "created_at": "2022-07-28T19:56:26+00:00", "updated_at": "2022-07-28T19:56:26+00:00",
+        "insurance": null, "order_id": null, "parcel": {"id": "prcl_9cc9c4c829784a50b9fcbdf30038f479",
+        "object": "Parcel", "created_at": "2022-07-29T21:54:51Z", "updated_at": "2022-07-29T21:54:51Z",
+        "length": 20.2, "width": 10.9, "height": 5.0, "predefined_package": null,
+        "weight": 65.9, "mode": "test"}, "postage_label": {"object": "PostageLabel",
+        "id": "pl_2ed3c815c4aa440ebce12d7312c6569e", "created_at": "2022-07-29T21:54:52Z",
+        "updated_at": "2022-07-29T21:54:53Z", "date_advance": 0, "integrated_form":
+        "none", "label_date": "2022-07-29T21:54:52Z", "label_resolution": 300, "label_size":
+        "4x6", "label_type": "default", "label_file_type": "image/png", "label_url":
+        "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/8d50e08656814e258b7e94cb863dfa72.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_6db905bb7a6447d99eaac0dee74ac9b4", "object":
+        "Rate", "created_at": "2022-07-29T21:54:51Z", "updated_at": "2022-07-29T21:54:51Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_a4e051d971eb4fa69524b02f67a26e8a", "carrier_account_id":
+        "ca_7642d249fdcf47bcb5da9ea34c96dfcf"}, {"id": "rate_c646c55160ba4508aaf7df5a38da5f9d",
+        "object": "Rate", "created_at": "2022-07-29T21:54:51Z", "updated_at": "2022-07-29T21:54:51Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_a4e051d971eb4fa69524b02f67a26e8a", "carrier_account_id":
+        "ca_7642d249fdcf47bcb5da9ea34c96dfcf"}, {"id": "rate_c7024553718e453cafb325daffac9026",
+        "object": "Rate", "created_at": "2022-07-29T21:54:51Z", "updated_at": "2022-07-29T21:54:51Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_a4e051d971eb4fa69524b02f67a26e8a", "carrier_account_id":
+        "ca_7642d249fdcf47bcb5da9ea34c96dfcf"}], "refund_status": null, "scan_form":
+        null, "selected_rate": {"id": "rate_c7024553718e453cafb325daffac9026", "object":
+        "Rate", "created_at": "2022-07-29T21:54:52Z", "updated_at": "2022-07-29T21:54:52Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_a4e051d971eb4fa69524b02f67a26e8a", "carrier_account_id":
+        "ca_7642d249fdcf47bcb5da9ea34c96dfcf"}, "tracker": {"id": "trk_160c63ea61bb4467ac3c2e56813706e5",
+        "object": "Tracker", "mode": "test", "tracking_code": "9461200109361130688693",
+        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-29T21:54:53Z",
+        "updated_at": "2022-07-29T21:54:53Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_a4e051d971eb4fa69524b02f67a26e8a", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzE2MGM2M2VhNjFiYjQ0NjdhYzNjMmU1NjgxMzcwNmU1"},
+        "to_address": {"id": "adr_126b90600f8911eda21bac1f6b0a0d1e", "object": "Address",
+        "created_at": "2022-07-29T21:54:51+00:00", "updated_at": "2022-07-29T21:54:52+00:00",
         "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
         "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
         "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
@@ -236,20 +231,36 @@ interactions:
         null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
         [], "details": null}, "delivery": {"success": true, "errors": [], "details":
         {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
-        "forms": [], "fees": [{"object": "Fee", "type": "LabelFee", "amount": "0.00000",
+        "usps_zone": 4, "return_address": {"id": "adr_126d749e0f8911edac64ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-29T21:54:51+00:00", "updated_at":
+        "2022-07-29T21:54:51+00:00", "name": "EasyPost", "company": null, "street1":
+        "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
+        "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
+        "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
+        null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
+        "buyer_address": {"id": "adr_126b90600f8911eda21bac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-29T21:54:51+00:00", "updated_at": "2022-07-29T21:54:52+00:00",
+        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
+        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
+        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
+        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
+        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
+        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
+        "forms": [], "fees": [{"object": "Fee", "type": "LabelFee", "amount": "0.01000",
         "charged": true, "refunded": false}, {"object": "Fee", "type": "PostageFee",
         "amount": "8.91000", "charged": true, "refunded": false}, {"object": "Fee",
         "type": "CarbonOffsetFee", "amount": "0.11000", "charged": true, "refunded":
-        false}], "id": "shp_b49f9bb6bc7b4c458c4a6cbc7e438f73", "object": "Shipment"}'
+        false}], "id": "shp_a4e051d971eb4fa69524b02f67a26e8a", "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6583'
+      - '6999'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"1ec27fad6ad8cd61fe947be65589c616"
+      - W/"92bc3751da21a7543b7175c5c47d5235"
       expires:
       - '0'
       pragma:
@@ -267,7 +278,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 3843704162e2e9eaff23e2db003437b7
+      - 1dc2029c62e4572cec3e46d500035c9c
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -275,13 +286,13 @@ interactions:
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq 403f17ff97
-      - intlb2wdc 403f17ff97
-      - extlb4wdc 403f17ff97
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '1.187351'
+      - '0.989798'
       x-version-label:
-      - easypost-202207272329-7f74c9e58c-master
+      - easypost-202207291722-ecd5579616-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_buy_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_buy_with_carbon_offset.yaml
@@ -1,0 +1,290 @@
+interactions:
+- request:
+    body: '{"shipment": {"to_address": {"name": "Dr. Steve Brule", "street1": "179
+      N Harbor Dr", "city": "Redondo Beach", "state": "CA", "zip": "90277", "country":
+      "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com"}, "from_address":
+      {"name": "EasyPost", "street1": "417 Montgomery Street", "street2": "5th Floor",
+      "city": "San Francisco", "state": "CA", "zip": "94104", "country": "US", "phone":
+      "4153334445", "email": "support@easypost.com"}, "parcel": {"length": "20.2",
+      "width": "10.9", "height": "5", "weight": "65.9"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '527'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/shipments
+  response:
+    body:
+      string: '{"created_at": "2022-07-27T22:38:43Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        null, "updated_at": "2022-07-27T22:38:43Z", "batch_id": null, "batch_status":
+        null, "batch_message": null, "customs_info": null, "from_address": {"id":
+        "adr_de63ae580dfc11eda35fac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-27T22:38:43+00:00", "updated_at": "2022-07-27T22:38:43+00:00", "name":
+        "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
+        "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
+        "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
+        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
+        {"id": "prcl_22ce7510d35744c5a2859d246e6c65fb", "object": "Parcel", "created_at":
+        "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z", "length": 20.2,
+        "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
+        "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_576371e5f0f24e44ab75e6f79a41f203",
+        "object": "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_23f9ab55dd7644898eb86ca7d1585651",
+        "object": "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_a40a9ab2e6864b6f8cc36db9f7607439",
+        "object": "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
+        null, "selected_rate": null, "tracker": null, "to_address": {"id": "adr_de61f13a0dfc11eda5d4ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-27T22:38:43+00:00", "updated_at":
+        "2022-07-27T22:38:43+00:00", "name": "Dr. Steve Brule", "company": null, "street1":
+        "179 N Harbor Dr", "street2": null, "city": "Redondo Beach", "state": "CA",
+        "zip": "90277", "country": "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com",
+        "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "usps_zone": 4, "return_address":
+        {"id": "adr_de63ae580dfc11eda35fac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-27T22:38:43+00:00", "updated_at": "2022-07-27T22:38:43+00:00", "name":
+        "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
+        "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
+        "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
+        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {}}, "buyer_address": {"id": "adr_de61f13a0dfc11eda5d4ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-27T22:38:43+00:00", "updated_at":
+        "2022-07-27T22:38:43+00:00", "name": "Dr. Steve Brule", "company": null, "street1":
+        "179 N Harbor Dr", "street2": null, "city": "Redondo Beach", "state": "CA",
+        "zip": "90277", "country": "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com",
+        "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "forms": [], "fees": [],
+        "id": "shp_2ab2216e186440cb92296cd17e2c7eea", "object": "Shipment"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4366'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"5cbfca5d5c523d62a0f0cb5e8a0276ab"
+      expires:
+      - '0'
+      location:
+      - /api/v2/shipments/shp_2ab2216e186440cb92296cd17e2c7eea
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - a5c9601362e1be73ff22b9c0000ae439
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb6nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
+      x-runtime:
+      - '0.230989'
+      x-version-label:
+      - easypost-202207272153-717cb56530-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"rate": {"id": "rate_576371e5f0f24e44ab75e6f79a41f203"}, "carbon_offset":
+      true}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '80'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/shipments/shp_2ab2216e186440cb92296cd17e2c7eea/buy
+  response:
+    body:
+      string: '{"created_at": "2022-07-27T22:38:43Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9461200109361130325888", "updated_at": "2022-07-27T22:38:44Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_de63ae580dfc11eda35fac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-27T22:38:43+00:00", "updated_at": "2022-07-27T22:38:43+00:00", "name":
+        "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
+        "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
+        "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
+        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
+        {"id": "prcl_22ce7510d35744c5a2859d246e6c65fb", "object": "Parcel", "created_at":
+        "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z", "length": 20.2,
+        "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
+        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_27af96cd11af438890f581f8f2f5a72b",
+        "created_at": "2022-07-27T22:38:44Z", "updated_at": "2022-07-27T22:38:44Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-27T22:38:44Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220727/44f1df13e4e949c29bb69714eb449e96.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_576371e5f0f24e44ab75e6f79a41f203", "object":
+        "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_23f9ab55dd7644898eb86ca7d1585651",
+        "object": "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_a40a9ab2e6864b6f8cc36db9f7607439",
+        "object": "Rate", "created_at": "2022-07-27T22:38:43Z", "updated_at": "2022-07-27T22:38:43Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
+        null, "selected_rate": {"id": "rate_576371e5f0f24e44ab75e6f79a41f203", "object":
+        "Rate", "created_at": "2022-07-27T22:38:44Z", "updated_at": "2022-07-27T22:38:44Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_04f1c22a62df4477bd1fdfd3de88b707",
+        "object": "Tracker", "mode": "test", "tracking_code": "9461200109361130325888",
+        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-27T22:38:44Z",
+        "updated_at": "2022-07-27T22:38:44Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_2ab2216e186440cb92296cd17e2c7eea", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzA0ZjFjMjJhNjJkZjQ0NzdiZDFmZGZkM2RlODhiNzA3"},
+        "to_address": {"id": "adr_de61f13a0dfc11eda5d4ac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-27T22:38:43+00:00", "updated_at": "2022-07-27T22:38:43+00:00",
+        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
+        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
+        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
+        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
+        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
+        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
+        "usps_zone": 4, "return_address": {"id": "adr_de63ae580dfc11eda35fac1f6bc7bdc6",
+        "object": "Address", "created_at": "2022-07-27T22:38:43+00:00", "updated_at":
+        "2022-07-27T22:38:43+00:00", "name": "EasyPost", "company": null, "street1":
+        "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
+        "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
+        "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
+        null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
+        "buyer_address": {"id": "adr_de61f13a0dfc11eda5d4ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-27T22:38:43+00:00", "updated_at": "2022-07-27T22:38:43+00:00",
+        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
+        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
+        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
+        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
+        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
+        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
+        "forms": [], "fees": [{"object": "Fee", "type": "LabelFee", "amount": "0.00000",
+        "charged": true, "refunded": false}, {"object": "Fee", "type": "PostageFee",
+        "amount": "8.91000", "charged": true, "refunded": false}, {"object": "Fee",
+        "type": "CarbonOffsetFee", "amount": "0.11000", "charged": true, "refunded":
+        false}], "id": "shp_2ab2216e186440cb92296cd17e2c7eea", "object": "Shipment"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '6583'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"f6dbf7ebbddb2bd9abd536692ebfb75d"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - a5c9601362e1be73ff22b9c0000ae44d
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb4nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
+      x-runtime:
+      - '1.142824'
+      x-version-label:
+      - easypost-202207272153-717cb56530-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_shipment_convert_label.yaml
+++ b/tests/cassettes/test_shipment_convert_label.yaml
@@ -11,7 +11,7 @@ interactions:
       "none", "non_delivery_option": "return", "customs_items": [{"description": "Sweet
       shirts", "quantity": 2, "weight": 11, "value": 23, "hs_tariff_number": "654321",
       "origin_country": "US"}]}, "options": {"label_format": "PNG", "invoice_number":
-      "123"}, "reference": "123"}}'
+      "123"}, "reference": "123"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -20,7 +20,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '932'
+      - '956'
       Content-Type:
       - application/json
       authorization:
@@ -31,30 +31,94 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:14Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:14Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_b53087ce08604fbbbd6c80fcddd14a8b","object":"CustomsInfo","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_bb5b391006114a8f8baee3f05352fd71","object":"CustomsItem","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_7215ccd5cbe811ec8c45ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_116325e84ede4cf6863a742e5782c618","object":"Parcel","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_351acab605624b79a9de943141acfcd5","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_11f82e2757b14f4787c57c678015dc1d","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_10e1662d07e14f33ba7fc8d4ef0ceb78","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e879d6be98e54cf69610e2e59f565699","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_72140bcacbe811ec94e2ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_7215ccd5cbe811ec8c45ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_72140bcacbe811ec94e2ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:13Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"label_format": "PNG", "invoice_number": "123",
+        "currency": "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference":
+        "123", "status": "unknown", "tracking_code": null, "updated_at": "2022-07-28T19:56:13Z",
+        "batch_id": null, "batch_status": null, "batch_message": null, "customs_info":
+        {"id": "cstinfo_3e828c4fed5540218121cb3867320cd1", "object": "CustomsInfo",
+        "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "contents_explanation": "", "contents_type": "merchandise", "customs_certify":
+        true, "customs_signer": "Steve Brule", "eel_pfc": "NOEEI 30.37(a)", "non_delivery_option":
+        "return", "restriction_comments": null, "restriction_type": "none", "mode":
+        "test", "declaration": null, "customs_items": [{"id": "cstitem_588f8105621d4d15bd17c991cfaac9d7",
+        "object": "CustomsItem", "created_at": "2022-07-28T19:56:13Z", "updated_at":
+        "2022-07-28T19:56:13Z", "description": "Sweet shirts", "hs_tariff_number":
+        "654321", "origin_country": "US", "quantity": 2, "value": "23.0", "weight":
+        11.0, "code": null, "mode": "test", "manufacturer": null, "currency": null,
+        "eccn": null, "printed_commodity_identifier": null}]}, "from_address": {"id":
+        "adr_55c175170eaf11ed9c97ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:13+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_e6f09a507fe145509192779188118e32",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_456133125b50485fbff060d50f708184",
+        "object": "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_f354d83f3fc24e6b8fd9fb55e13ca60f",
+        "object": "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_abd6982071c4491cae0ee2b1f9eb77c5",
+        "object": "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_e0a194f01c334277ab70314f7b46aad1", "object": "Rate", "created_at":
+        "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_55bfa4780eaf11ed9d95ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:13+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_55c175170eaf11ed9c97ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-28T19:56:13+00:00", "updated_at":
+        "2022-07-28T19:56:13+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_55bfa4780eaf11ed9d95ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:13+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_1c63268c58c34e64b6f505d6d6cd57ab",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '5563'
+      - '5667'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"9361ec9c868fba5b1b4c1cb3e6adb78e"
+      - W/"ac119a4e762471baa7f52a663ed4821c"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_6b7295f147ea4ee8b5a65ea481e1eebb
+      - /api/v2/shipments/shp_1c63268c58c34e64b6f505d6d6cd57ab
       pragma:
       - no-cache
       referrer-policy:
@@ -70,27 +134,29 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fba6272e166e786b8e50013ae44
+      - 3843704062e2e9ddff23e2a100343489
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb8nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.416692'
+      - '0.306055'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: '{"rate": {"id": "rate_e879d6be98e54cf69610e2e59f565699"}}'
+    body: '{"rate": {"id": "rate_abd6982071c4491cae0ee2b1f9eb77c5"}, "carbon_offset":
+      false}'
     headers:
       Accept:
       - '*/*'
@@ -99,7 +165,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '57'
+      - '81'
       Content-Type:
       - application/json
       authorization:
@@ -107,29 +173,119 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_6b7295f147ea4ee8b5a65ea481e1eebb/buy
+    uri: https://api.easypost.com/v2/shipments/shp_1c63268c58c34e64b6f505d6d6cd57ab/buy
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:14Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":"9400100109361117768891","updated_at":"2022-05-04T20:26:16Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_b53087ce08604fbbbd6c80fcddd14a8b","object":"CustomsInfo","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_bb5b391006114a8f8baee3f05352fd71","object":"CustomsItem","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_7215ccd5cbe811ec8c45ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_116325e84ede4cf6863a742e5782c618","object":"Parcel","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_15b7c9dfdb5e499e982a040cff7ed1f0","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:15Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/8393ada5b1174d519e2085b4e2f65cf1.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_351acab605624b79a9de943141acfcd5","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_11f82e2757b14f4787c57c678015dc1d","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_10e1662d07e14f33ba7fc8d4ef0ceb78","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e879d6be98e54cf69610e2e59f565699","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_e879d6be98e54cf69610e2e59f565699","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_41ad8d2eb9fc41c991243dc059a40101","object":"Tracker","mode":"test","tracking_code":"9400100109361117768891","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:26:16Z","updated_at":"2022-05-04T20:26:16Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzQxYWQ4ZDJlYjlmYzQxYzk5MTI0M2RjMDU5YTQwMTAx"},"to_address":{"id":"adr_72140bcacbe811ec94e2ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:15+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_7215ccd5cbe811ec8c45ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_72140bcacbe811ec94e2ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:15+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:13Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"label_format": "PNG", "invoice_number": "123",
+        "currency": "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference":
+        "123", "status": "unknown", "tracking_code": "9400100109361130483580", "updated_at":
+        "2022-07-28T19:56:15Z", "batch_id": null, "batch_status": null, "batch_message":
+        null, "customs_info": {"id": "cstinfo_3e828c4fed5540218121cb3867320cd1", "object":
+        "CustomsInfo", "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "contents_explanation": "", "contents_type": "merchandise", "customs_certify":
+        true, "customs_signer": "Steve Brule", "eel_pfc": "NOEEI 30.37(a)", "non_delivery_option":
+        "return", "restriction_comments": null, "restriction_type": "none", "mode":
+        "test", "declaration": null, "customs_items": [{"id": "cstitem_588f8105621d4d15bd17c991cfaac9d7",
+        "object": "CustomsItem", "created_at": "2022-07-28T19:56:13Z", "updated_at":
+        "2022-07-28T19:56:13Z", "description": "Sweet shirts", "hs_tariff_number":
+        "654321", "origin_country": "US", "quantity": 2, "value": "23.0", "weight":
+        11.0, "code": null, "mode": "test", "manufacturer": null, "currency": null,
+        "eccn": null, "printed_commodity_identifier": null}]}, "from_address": {"id":
+        "adr_55c175170eaf11ed9c97ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:13+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_e6f09a507fe145509192779188118e32",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_2abe9797dfb943a18ebae81b6404b058",
+        "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:15Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:14Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/4ed9e0d7e6924f3589b8ae925210aca6.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_456133125b50485fbff060d50f708184", "object":
+        "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_f354d83f3fc24e6b8fd9fb55e13ca60f",
+        "object": "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_abd6982071c4491cae0ee2b1f9eb77c5",
+        "object": "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_e0a194f01c334277ab70314f7b46aad1", "object": "Rate", "created_at":
+        "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_abd6982071c4491cae0ee2b1f9eb77c5",
+        "object": "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_a1a34f93a68c4d03b04513577bb55b17", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483580", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T19:56:15Z", "updated_at":
+        "2022-07-28T19:56:15Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrX2ExYTM0ZjkzYTY4YzRkMDNiMDQ1MTM1NzdiYjU1YjE3"},
+        "to_address": {"id": "adr_55bfa4780eaf11ed9d95ac1f6bc72124", "object": "Address",
+        "created_at": "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:14+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_55c175170eaf11ed9c97ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:13+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_55bfa4780eaf11ed9d95ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:14+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_1c63268c58c34e64b6f505d6d6cd57ab", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '7660'
+      - '7790'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"88d0fc47f3c360b431db44dae8925ee8"
+      - W/"8a1bc9e74bf8739e675ebc562287f86f"
       expires:
       - '0'
       pragma:
@@ -147,20 +303,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fba6272e167e786b8e50013ae69
+      - 3843704062e2e9deff23e2a1003434c9
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb9nuq
+      - bigweb2nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.802893'
+      - '0.883607'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -180,34 +337,133 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_6b7295f147ea4ee8b5a65ea481e1eebb/label?file_format=ZPL
+    uri: https://api.easypost.com/v2/shipments/shp_1c63268c58c34e64b6f505d6d6cd57ab/label?file_format=ZPL
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:14Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":"9400100109361117768891","updated_at":"2022-05-04T20:26:16Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_b53087ce08604fbbbd6c80fcddd14a8b","object":"CustomsInfo","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_bb5b391006114a8f8baee3f05352fd71","object":"CustomsItem","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_7215ccd5cbe811ec8c45ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_116325e84ede4cf6863a742e5782c618","object":"Parcel","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_15b7c9dfdb5e499e982a040cff7ed1f0","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:17Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:15Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/8393ada5b1174d519e2085b4e2f65cf1.png","label_pdf_url":null,"label_zpl_url":"https://easypost-files.s3-us-west-2.amazonaws.com/files/postage_label/20220504/bad0aae6f8674f42a246b754586c6cb2.zpl","label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_351acab605624b79a9de943141acfcd5","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_11f82e2757b14f4787c57c678015dc1d","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_10e1662d07e14f33ba7fc8d4ef0ceb78","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e879d6be98e54cf69610e2e59f565699","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_e879d6be98e54cf69610e2e59f565699","object":"Rate","created_at":"2022-05-04T20:26:15Z","updated_at":"2022-05-04T20:26:15Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_41ad8d2eb9fc41c991243dc059a40101","object":"Tracker","mode":"test","tracking_code":"9400100109361117768891","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:26:16Z","updated_at":"2022-05-04T20:26:16Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:26:16Z","shipment_id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:26:16Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:03:16Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"fees":[],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"public_url":"https://track.easypost.com/djE6dHJrXzQxYWQ4ZDJlYjlmYzQxYzk5MTI0M2RjMDU5YTQwMTAx"},"to_address":{"id":"adr_72140bcacbe811ec94e2ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:15+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_7215ccd5cbe811ec8c45ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_72140bcacbe811ec94e2ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:15+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_6b7295f147ea4ee8b5a65ea481e1eebb","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:13Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"label_format": "PNG", "invoice_number": "123",
+        "currency": "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference":
+        "123", "status": "unknown", "tracking_code": "9400100109361130483580", "updated_at":
+        "2022-07-28T19:56:15Z", "batch_id": null, "batch_status": null, "batch_message":
+        null, "customs_info": {"id": "cstinfo_3e828c4fed5540218121cb3867320cd1", "object":
+        "CustomsInfo", "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "contents_explanation": "", "contents_type": "merchandise", "customs_certify":
+        true, "customs_signer": "Steve Brule", "eel_pfc": "NOEEI 30.37(a)", "non_delivery_option":
+        "return", "restriction_comments": null, "restriction_type": "none", "mode":
+        "test", "declaration": null, "customs_items": [{"id": "cstitem_588f8105621d4d15bd17c991cfaac9d7",
+        "object": "CustomsItem", "created_at": "2022-07-28T19:56:13Z", "updated_at":
+        "2022-07-28T19:56:13Z", "description": "Sweet shirts", "hs_tariff_number":
+        "654321", "origin_country": "US", "quantity": 2, "value": "23.0", "weight":
+        11.0, "code": null, "mode": "test", "manufacturer": null, "currency": null,
+        "eccn": null, "printed_commodity_identifier": null}]}, "from_address": {"id":
+        "adr_55c175170eaf11ed9c97ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:13+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_e6f09a507fe145509192779188118e32",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_2abe9797dfb943a18ebae81b6404b058",
+        "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:16Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:14Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/4ed9e0d7e6924f3589b8ae925210aca6.png",
+        "label_pdf_url": null, "label_zpl_url": "https://easypost-files.s3-us-west-2.amazonaws.com/files/postage_label/20220728/a4231e7429b34135988e921e0a53e046.zpl",
+        "label_epl2_url": null, "label_file": null}, "rates": [{"id": "rate_456133125b50485fbff060d50f708184",
+        "object": "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_f354d83f3fc24e6b8fd9fb55e13ca60f",
+        "object": "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_abd6982071c4491cae0ee2b1f9eb77c5",
+        "object": "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_e0a194f01c334277ab70314f7b46aad1", "object": "Rate", "created_at":
+        "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_abd6982071c4491cae0ee2b1f9eb77c5",
+        "object": "Rate", "created_at": "2022-07-28T19:56:14Z", "updated_at": "2022-07-28T19:56:14Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_1c63268c58c34e64b6f505d6d6cd57ab", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_a1a34f93a68c4d03b04513577bb55b17", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483580", "status": "pre_transit",
+        "status_detail": "status_update", "created_at": "2022-07-28T19:56:15Z", "updated_at":
+        "2022-07-28T19:56:15Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:56:15Z", "shipment_id": "shp_1c63268c58c34e64b6f505d6d6cd57ab",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:56:15Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:33:15Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}], "fees":
+        [], "carrier_detail": {"object": "CarrierDetail", "service": "First-Class
+        Package Service", "container_type": null, "est_delivery_date_local": null,
+        "est_delivery_time_local": null, "origin_location": "HOUSTON TX, 77001", "origin_tracking_location":
+        {"object": "TrackingLocation", "city": "HOUSTON", "state": "TX", "country":
+        null, "zip": "77063"}, "destination_location": "CHARLESTON SC, 29401", "destination_tracking_location":
+        null, "guaranteed_delivery_date": null, "alternate_identifier": null, "initial_delivery_attempt":
+        null}, "public_url": "https://track.easypost.com/djE6dHJrX2ExYTM0ZjkzYTY4YzRkMDNiMDQ1MTM1NzdiYjU1YjE3"},
+        "to_address": {"id": "adr_55bfa4780eaf11ed9d95ac1f6bc72124", "object": "Address",
+        "created_at": "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:14+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_55c175170eaf11ed9c97ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:13+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_55bfa4780eaf11ed9d95ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T19:56:13+00:00", "updated_at": "2022-07-28T19:56:14+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_1c63268c58c34e64b6f505d6d6cd57ab", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '8907'
+      - '9037'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"d27eeae403b2c5c1d1074abccf35c5e9"
+      - W/"f8764c605fc012c9b41e57defaf7d8f5"
       expires:
       - '0'
       pragma:
@@ -225,20 +481,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fba6272e168e786b8e50013aeae
+      - 3843704062e2e9dfff23e2a10034351f
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '1.640868'
+      - '1.551742'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_create.yaml
+++ b/tests/cassettes/test_shipment_create.yaml
@@ -11,7 +11,7 @@ interactions:
       "none", "non_delivery_option": "return", "customs_items": [{"description": "Sweet
       shirts", "quantity": 2, "weight": 11, "value": 23, "hs_tariff_number": "654321",
       "origin_country": "US"}]}, "options": {"label_format": "PNG", "invoice_number":
-      "123"}, "reference": "123"}}'
+      "123"}, "reference": "123"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -20,7 +20,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '932'
+      - '956'
       Content-Type:
       - application/json
       authorization:
@@ -31,30 +31,94 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:10Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:10Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_5bb96b03dd4f4ccea7375d6946efad61","object":"CustomsInfo","created_at":"2022-05-04T20:26:10Z","updated_at":"2022-05-04T20:26:10Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_453498ba5db94695b0e75637429a295d","object":"CustomsItem","created_at":"2022-05-04T20:26:10Z","updated_at":"2022-05-04T20:26:10Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_6f938385cbe811ecaae7ac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:10+00:00","updated_at":"2022-05-04T20:26:10+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_1b3ceb0abe5e491cbd1787867b3c38a8","object":"Parcel","created_at":"2022-05-04T20:26:10Z","updated_at":"2022-05-04T20:26:10Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_0fc3dbb71e054bc9aec3ce9cae3ab6a8","object":"Rate","created_at":"2022-05-04T20:26:10Z","updated_at":"2022-05-04T20:26:10Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ca6ea74a3f77456d85b30a4fbefd304c","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_626b02e9e0b84114a19d2d8825a943a4","object":"Rate","created_at":"2022-05-04T20:26:10Z","updated_at":"2022-05-04T20:26:10Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ca6ea74a3f77456d85b30a4fbefd304c","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_1f0fb17b527c4511853563024f15f009","object":"Rate","created_at":"2022-05-04T20:26:10Z","updated_at":"2022-05-04T20:26:10Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ca6ea74a3f77456d85b30a4fbefd304c","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_c292a85b48f941f18e0e692e4084bf0f","object":"Rate","created_at":"2022-05-04T20:26:10Z","updated_at":"2022-05-04T20:26:10Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ca6ea74a3f77456d85b30a4fbefd304c","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_6f91db53cbe811eca3f4ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:10+00:00","updated_at":"2022-05-04T20:26:10+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_6f938385cbe811ecaae7ac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:10+00:00","updated_at":"2022-05-04T20:26:10+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6f91db53cbe811eca3f4ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:10+00:00","updated_at":"2022-05-04T20:26:10+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_ca6ea74a3f77456d85b30a4fbefd304c","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:09Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"label_format": "PNG", "invoice_number": "123",
+        "currency": "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference":
+        "123", "status": "unknown", "tracking_code": null, "updated_at": "2022-07-28T19:56:09Z",
+        "batch_id": null, "batch_status": null, "batch_message": null, "customs_info":
+        {"id": "cstinfo_a469b9b3e07c44d99ac5a661d8511eeb", "object": "CustomsInfo",
+        "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "contents_explanation": "", "contents_type": "merchandise", "customs_certify":
+        true, "customs_signer": "Steve Brule", "eel_pfc": "NOEEI 30.37(a)", "non_delivery_option":
+        "return", "restriction_comments": null, "restriction_type": "none", "mode":
+        "test", "declaration": null, "customs_items": [{"id": "cstitem_974e27617226427398b18e0f3dabb96a",
+        "object": "CustomsItem", "created_at": "2022-07-28T19:56:09Z", "updated_at":
+        "2022-07-28T19:56:09Z", "description": "Sweet shirts", "hs_tariff_number":
+        "654321", "origin_country": "US", "quantity": 2, "value": "23.0", "weight":
+        11.0, "code": null, "mode": "test", "manufacturer": null, "currency": null,
+        "eccn": null, "printed_commodity_identifier": null}]}, "from_address": {"id":
+        "adr_52f7f6360eaf11ed9941ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:09+00:00", "updated_at": "2022-07-28T19:56:09+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_1b8ebda4e8934370847599a190af3d5f",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_5c1764f9223a4041b717d6b0025d3000",
+        "object": "Rate", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_514cd79a702f43468be986aaef79a086", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_83856f26b1e24274b5af238c3908f6da",
+        "object": "Rate", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_514cd79a702f43468be986aaef79a086", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_a46de7bc8bd14244836be6e7d219d81c",
+        "object": "Rate", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_514cd79a702f43468be986aaef79a086", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_a4bbc85140f141e1bee0f2c6f44de07a",
+        "object": "Rate", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_514cd79a702f43468be986aaef79a086", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_52f63d760eaf11ed993fac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:56:09+00:00", "updated_at": "2022-07-28T19:56:09+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_52f7f6360eaf11ed9941ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-28T19:56:09+00:00", "updated_at":
+        "2022-07-28T19:56:09+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_52f63d760eaf11ed993fac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:09+00:00", "updated_at": "2022-07-28T19:56:09+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_514cd79a702f43468be986aaef79a086",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '5563'
+      - '5667'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"48a92d961b556d8b10d58bac596709cb"
+      - W/"bfc5cc6894a77a82c54f5295b91a106e"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_ca6ea74a3f77456d85b30a4fbefd304c
+      - /api/v2/shipments/shp_514cd79a702f43468be986aaef79a086
       pragma:
       - no-cache
       referrer-policy:
@@ -65,25 +129,28 @@ interactions:
       - chunked
       x-backend:
       - easypost
+      x-canary:
+      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330bb6272e162e786b8df00162a6e
+      - b0657e3e62e2e9d9ff23e29c0033c952
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb7nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.320368'
+      - '0.293240'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_create_empty_objects.yaml
+++ b/tests/cassettes/test_shipment_create_empty_objects.yaml
@@ -6,7 +6,8 @@ interactions:
       "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "customs_info":
-      {}, "options": null, "tax_identifiers": null, "reference": ""}}'
+      {}, "options": null, "tax_identifiers": null, "reference": ""}, "carbon_offset":
+      false}'
     headers:
       Accept:
       - '*/*'
@@ -15,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '556'
+      - '580'
       Content-Type:
       - application/json
       authorization:
@@ -26,28 +27,83 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:29:59Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:29:59Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_f7cfdd6ecbe811ecbc66ac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:29:59+00:00","updated_at":"2022-05-04T20:29:59+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_3e10fd7180694a998ef2314033f52cef","object":"Parcel","created_at":"2022-05-04T20:29:59Z","updated_at":"2022-05-04T20:29:59Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_2ceef7f288e8499b9dae50702d25ef06","object":"Rate","created_at":"2022-05-04T20:29:59Z","updated_at":"2022-05-04T20:29:59Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_52b963e2540f491bb6980b43689a42a5","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_569285a7b7984a8ca7c7e03e02d9f9e1","object":"Rate","created_at":"2022-05-04T20:29:59Z","updated_at":"2022-05-04T20:29:59Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_52b963e2540f491bb6980b43689a42a5","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_6ae198b041994a47a15d1918d35e4964","object":"Rate","created_at":"2022-05-04T20:29:59Z","updated_at":"2022-05-04T20:29:59Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_52b963e2540f491bb6980b43689a42a5","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_5f1a81ba6cf84d1885b2ae09556d7a99","object":"Rate","created_at":"2022-05-04T20:29:59Z","updated_at":"2022-05-04T20:29:59Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_52b963e2540f491bb6980b43689a42a5","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_f7cdca50cbe811ec80e3ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:29:59+00:00","updated_at":"2022-05-04T20:29:59+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_f7cfdd6ecbe811ecbc66ac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:29:59+00:00","updated_at":"2022-05-04T20:29:59+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_f7cdca50cbe811ec80e3ac1f6bc72124","object":"Address","created_at":"2022-05-04T20:29:59+00:00","updated_at":"2022-05-04T20:29:59+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_52b963e2540f491bb6980b43689a42a5","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:21Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        null, "updated_at": "2022-07-28T19:56:21Z", "batch_id": null, "batch_status":
+        null, "batch_message": null, "customs_info": null, "from_address": {"id":
+        "adr_5a11e09e0eaf11ed9fc9ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:21+00:00", "updated_at": "2022-07-28T19:56:21+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_acd6da14853d46b49010505514d24e23",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:21Z", "updated_at": "2022-07-28T19:56:21Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_63d449a17ad6459eb05a94fb81fac1cf",
+        "object": "Rate", "created_at": "2022-07-28T19:56:21Z", "updated_at": "2022-07-28T19:56:21Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_2cb1380d58e7405d9e3592ec037eb322", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_5dc785b73d3a460488c255585dc29d3a", "object": "Rate", "created_at":
+        "2022-07-28T19:56:21Z", "updated_at": "2022-07-28T19:56:21Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_2cb1380d58e7405d9e3592ec037eb322", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_357749ddadd244a89d9112e497106950", "object": "Rate", "created_at":
+        "2022-07-28T19:56:21Z", "updated_at": "2022-07-28T19:56:21Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_2cb1380d58e7405d9e3592ec037eb322", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_29b130a8c3d048b6aa0be4f3c6597649", "object": "Rate", "created_at":
+        "2022-07-28T19:56:21Z", "updated_at": "2022-07-28T19:56:21Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_2cb1380d58e7405d9e3592ec037eb322", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_5a0ffbc00eaf11eda52cac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-28T19:56:21+00:00", "updated_at": "2022-07-28T19:56:21+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_5a11e09e0eaf11ed9fc9ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-28T19:56:21+00:00", "updated_at":
+        "2022-07-28T19:56:21+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_5a0ffbc00eaf11eda52cac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:56:21+00:00", "updated_at": "2022-07-28T19:56:21+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_2cb1380d58e7405d9e3592ec037eb322",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '4729'
+      - '4833'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"3786cb29b911a5735e81c0ea76df90f9"
+      - W/"14114dd7a0702e8ac1dba00f7fa5569f"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_52b963e2540f491bb6980b43689a42a5
+      - /api/v2/shipments/shp_2cb1380d58e7405d9e3592ec037eb322
       pragma:
       - no-cache
       referrer-policy:
@@ -63,20 +119,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb66272e247e786bc840013e4f4
+      - 3843703e62e2e9e5ff23e2bd00343680
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.240073'
+      - '0.263433'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_create_tax_identifier.yaml
+++ b/tests/cassettes/test_shipment_create_tax_identifier.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "tax_identifiers":
       [{"entity": "SENDER", "tax_id_type": "IOSS", "tax_id": "12345", "issuing_country":
-      "GB"}]}}'
+      "GB"}]}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '587'
+      - '611'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,84 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:22Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:22Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_7660b495cbe811ecabb7ac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:22+00:00","updated_at":"2022-05-04T20:26:22+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_6706f1c99d004c67a43e7f4cad14fde4","object":"Parcel","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_54f1ca8587ba4b2e92c761bdaa735c37","object":"Rate","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2339c0348b35491e93a3645dc99b09ac","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_db1f3f711f114c63899ef790c6d739b3","object":"Rate","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_2339c0348b35491e93a3645dc99b09ac","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_f9ef88a5d4424643b56b85c7324bdb7c","object":"Rate","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2339c0348b35491e93a3645dc99b09ac","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_fed2cdb9494f4479846e8d239489dc13","object":"Rate","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_2339c0348b35491e93a3645dc99b09ac","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_765e711ccbe811ec8d14ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:22+00:00","updated_at":"2022-05-04T20:26:22+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_7660b495cbe811ecabb7ac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:22+00:00","updated_at":"2022-05-04T20:26:22+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_765e711ccbe811ec8d14ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:22+00:00","updated_at":"2022-05-04T20:26:22+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_2339c0348b35491e93a3645dc99b09ac","object":"Shipment","tax_identifiers":[{"entity":"SENDER","tax_id":"HIDDEN","tax_id_type":"IOSS","issuing_country":"GB"}]}'
+      string: '{"created_at": "2022-07-28T19:56:21Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        null, "updated_at": "2022-07-28T19:56:21Z", "batch_id": null, "batch_status":
+        null, "batch_message": null, "customs_info": null, "from_address": {"id":
+        "adr_5a5795b70eaf11ed8fd6ac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-28T19:56:21+00:00", "updated_at": "2022-07-28T19:56:21+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_595312c3625e40699697bf85d829f95b",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:21Z", "updated_at": "2022-07-28T19:56:21Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_f50b055ffb424d2fb9f42dcb9220b3d7",
+        "object": "Rate", "created_at": "2022-07-28T19:56:21Z", "updated_at": "2022-07-28T19:56:21Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_14add31f838f4032adb2f1f2491303aa", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_6c08abef196845e9a154f1e38bff1b42",
+        "object": "Rate", "created_at": "2022-07-28T19:56:21Z", "updated_at": "2022-07-28T19:56:21Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_14add31f838f4032adb2f1f2491303aa", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_4151e223f2b44e68951fa382e0c56e02", "object": "Rate", "created_at":
+        "2022-07-28T19:56:21Z", "updated_at": "2022-07-28T19:56:21Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_14add31f838f4032adb2f1f2491303aa", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_0b6f371f8e65437c824f2918d4f943c5", "object": "Rate", "created_at":
+        "2022-07-28T19:56:21Z", "updated_at": "2022-07-28T19:56:21Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_14add31f838f4032adb2f1f2491303aa", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_5a55decb0eaf11eda0e8ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T19:56:21+00:00", "updated_at": "2022-07-28T19:56:21+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_5a5795b70eaf11ed8fd6ac1f6bc7bdc6",
+        "object": "Address", "created_at": "2022-07-28T19:56:21+00:00", "updated_at":
+        "2022-07-28T19:56:21+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_5a55decb0eaf11eda0e8ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:21+00:00", "updated_at": "2022-07-28T19:56:21+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_14add31f838f4032adb2f1f2491303aa",
+        "object": "Shipment", "tax_identifiers": [{"entity": "SENDER", "tax_id": "HIDDEN",
+        "tax_id_type": "IOSS", "issuing_country": "GB"}]}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '4831'
+      - '4935'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"0846f7e4125da2c1d5f94efb438eb518"
+      - W/"57b6f00182deab9e119f7977ea09f4ef"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_2339c0348b35491e93a3645dc99b09ac
+      - /api/v2/shipments/shp_14add31f838f4032adb2f1f2491303aa
       pragma:
       - no-cache
       referrer-policy:
@@ -64,20 +120,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fbb6272e16ee786b9010013b03f
+      - 3843703f62e2e9e5ff23e2be003436a1
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb9nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.257762'
+      - '0.252222'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_create_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_create_with_carbon_offset.yaml
@@ -1,0 +1,138 @@
+interactions:
+- request:
+    body: '{"shipment": {"to_address": {"name": "Dr. Steve Brule", "street1": "179
+      N Harbor Dr", "city": "Redondo Beach", "state": "CA", "zip": "90277", "country":
+      "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com"}, "from_address":
+      {"name": "EasyPost", "street1": "417 Montgomery Street", "street2": "5th Floor",
+      "city": "San Francisco", "state": "CA", "zip": "94104", "country": "US", "phone":
+      "4153334445", "email": "support@easypost.com"}, "parcel": {"length": "20.2",
+      "width": "10.9", "height": "5", "weight": "65.9"}}, "carbon_offset": true}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '550'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/shipments
+  response:
+    body:
+      string: '{"created_at": "2022-07-27T22:03:59Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        null, "updated_at": "2022-07-27T22:03:59Z", "batch_id": null, "batch_status":
+        null, "batch_message": null, "customs_info": null, "from_address": {"id":
+        "adr_042f98b90df811edb981ac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-27T22:03:59+00:00", "updated_at": "2022-07-27T22:03:59+00:00", "name":
+        "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
+        "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
+        "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
+        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
+        {"id": "prcl_de6823bd1edd408f98574ad64478e99b", "object": "Parcel", "created_at":
+        "2022-07-27T22:03:59Z", "updated_at": "2022-07-27T22:03:59Z", "length": 20.2,
+        "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
+        "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_10369e47b8b148e3bf680daed2d9087b",
+        "object": "Rate", "created_at": "2022-07-27T22:03:59Z", "updated_at": "2022-07-27T22:03:59Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_b70f120ff3a34c51bdc30db7fde30a7d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_4a16868146ca454b9e4af9de6a937a2e",
+        "object": "Rate", "created_at": "2022-07-27T22:03:59Z", "updated_at": "2022-07-27T22:03:59Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_b70f120ff3a34c51bdc30db7fde30a7d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_abc714066fa84d54af39e587cd696f1b",
+        "object": "Rate", "created_at": "2022-07-27T22:03:59Z", "updated_at": "2022-07-27T22:03:59Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_b70f120ff3a34c51bdc30db7fde30a7d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}], "refund_status": null,
+        "scan_form": null, "selected_rate": null, "tracker": null, "to_address": {"id":
+        "adr_042dd7030df811edb980ac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-27T22:03:59+00:00", "updated_at": "2022-07-27T22:03:59+00:00", "name":
+        "Dr. Steve Brule", "company": null, "street1": "179 N Harbor Dr", "street2":
+        null, "city": "Redondo Beach", "state": "CA", "zip": "90277", "country": "US",
+        "phone": "8573875756", "email": "dr_steve_brule@gmail.com", "mode": "test",
+        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {}}, "usps_zone": 4, "return_address": {"id": "adr_042f98b90df811edb981ac1f6bc7bdc6",
+        "object": "Address", "created_at": "2022-07-27T22:03:59+00:00", "updated_at":
+        "2022-07-27T22:03:59+00:00", "name": "EasyPost", "company": null, "street1":
+        "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
+        "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
+        "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
+        null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
+        "buyer_address": {"id": "adr_042dd7030df811edb980ac1f6bc7bdc6", "object":
+        "Address", "created_at": "2022-07-27T22:03:59+00:00", "updated_at": "2022-07-27T22:03:59+00:00",
+        "name": "Dr. Steve Brule", "company": null, "street1": "179 N Harbor Dr",
+        "street2": null, "city": "Redondo Beach", "state": "CA", "zip": "90277", "country":
+        "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com", "mode":
+        "test", "carrier_facility": null, "residential": null, "federal_tax_id": null,
+        "state_tax_id": null, "verifications": {}}, "forms": [], "fees": [], "id":
+        "shp_b70f120ff3a34c51bdc30db7fde30a7d", "object": "Shipment"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4624'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"f0b5d9afdfa4023ae15a2c93c0edc395"
+      expires:
+      - '0'
+      location:
+      - /api/v2/shipments/shp_b70f120ff3a34c51bdc30db7fde30a7d
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - bdfa366a62e1b64fff2241fa0057387d
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb2nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq 403f17ff97
+      - extlb2nuq 403f17ff97
+      x-runtime:
+      - '0.643110'
+      x-version-label:
+      - easypost-202207272030-717cb56530-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/cassettes/test_shipment_create_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_create_with_carbon_offset.yaml
@@ -26,68 +26,68 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at": "2022-07-27T22:03:59Z", "is_return": false, "messages":
+      string: '{"created_at": "2022-07-28T19:56:25Z", "is_return": false, "messages":
         [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
         "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        null, "updated_at": "2022-07-27T22:03:59Z", "batch_id": null, "batch_status":
+        null, "updated_at": "2022-07-28T19:56:25Z", "batch_id": null, "batch_status":
         null, "batch_message": null, "customs_info": null, "from_address": {"id":
-        "adr_042f98b90df811edb981ac1f6bc7bdc6", "object": "Address", "created_at":
-        "2022-07-27T22:03:59+00:00", "updated_at": "2022-07-27T22:03:59+00:00", "name":
+        "adr_5c7ba6d70eaf11ed9122ac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-28T19:56:25+00:00", "updated_at": "2022-07-28T19:56:25+00:00", "name":
         "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
         "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
         "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
         "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
         null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
-        {"id": "prcl_de6823bd1edd408f98574ad64478e99b", "object": "Parcel", "created_at":
-        "2022-07-27T22:03:59Z", "updated_at": "2022-07-27T22:03:59Z", "length": 20.2,
+        {"id": "prcl_41e10ed606c0441f9368a8dcafc1d422", "object": "Parcel", "created_at":
+        "2022-07-28T19:56:25Z", "updated_at": "2022-07-28T19:56:25Z", "length": 20.2,
         "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
-        "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_10369e47b8b148e3bf680daed2d9087b",
-        "object": "Rate", "created_at": "2022-07-27T22:03:59Z", "updated_at": "2022-07-27T22:03:59Z",
-        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
-        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
-        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_b70f120ff3a34c51bdc30db7fde30a7d", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_4a16868146ca454b9e4af9de6a937a2e",
-        "object": "Rate", "created_at": "2022-07-27T22:03:59Z", "updated_at": "2022-07-27T22:03:59Z",
+        "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_27ffd58d25d145be849e5ec137ec430c",
+        "object": "Rate", "created_at": "2022-07-28T19:56:25Z", "updated_at": "2022-07-28T19:56:25Z",
         "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
         "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
         "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_b70f120ff3a34c51bdc30db7fde30a7d", "carrier_account_id":
+        2, "shipment_id": "shp_b7892bf189604028895eff184daa363d", "carrier_account_id":
         "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_abc714066fa84d54af39e587cd696f1b",
-        "object": "Rate", "created_at": "2022-07-27T22:03:59Z", "updated_at": "2022-07-27T22:03:59Z",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_f74bd58274f64784b124923459df67a3",
+        "object": "Rate", "created_at": "2022-07-28T19:56:25Z", "updated_at": "2022-07-28T19:56:25Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_b7892bf189604028895eff184daa363d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_e495789abaa84ab2bae55a516d0d4483",
+        "object": "Rate", "created_at": "2022-07-28T19:56:25Z", "updated_at": "2022-07-28T19:56:25Z",
         "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
         "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
         "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_b70f120ff3a34c51bdc30db7fde30a7d", "carrier_account_id":
+        5, "shipment_id": "shp_b7892bf189604028895eff184daa363d", "carrier_account_id":
         "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
         "grams": 154, "price": "0.11", "currency": "USD"}}], "refund_status": null,
         "scan_form": null, "selected_rate": null, "tracker": null, "to_address": {"id":
-        "adr_042dd7030df811edb980ac1f6bc7bdc6", "object": "Address", "created_at":
-        "2022-07-27T22:03:59+00:00", "updated_at": "2022-07-27T22:03:59+00:00", "name":
+        "adr_5c774d780eaf11eda329ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:25+00:00", "updated_at": "2022-07-28T19:56:25+00:00", "name":
         "Dr. Steve Brule", "company": null, "street1": "179 N Harbor Dr", "street2":
         null, "city": "Redondo Beach", "state": "CA", "zip": "90277", "country": "US",
         "phone": "8573875756", "email": "dr_steve_brule@gmail.com", "mode": "test",
         "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
-        null, "verifications": {}}, "usps_zone": 4, "return_address": {"id": "adr_042f98b90df811edb981ac1f6bc7bdc6",
-        "object": "Address", "created_at": "2022-07-27T22:03:59+00:00", "updated_at":
-        "2022-07-27T22:03:59+00:00", "name": "EasyPost", "company": null, "street1":
+        null, "verifications": {}}, "usps_zone": 4, "return_address": {"id": "adr_5c7ba6d70eaf11ed9122ac1f6bc7bdc6",
+        "object": "Address", "created_at": "2022-07-28T19:56:25+00:00", "updated_at":
+        "2022-07-28T19:56:25+00:00", "name": "EasyPost", "company": null, "street1":
         "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
         "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
         "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
         null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
-        "buyer_address": {"id": "adr_042dd7030df811edb980ac1f6bc7bdc6", "object":
-        "Address", "created_at": "2022-07-27T22:03:59+00:00", "updated_at": "2022-07-27T22:03:59+00:00",
+        "buyer_address": {"id": "adr_5c774d780eaf11eda329ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T19:56:25+00:00", "updated_at": "2022-07-28T19:56:25+00:00",
         "name": "Dr. Steve Brule", "company": null, "street1": "179 N Harbor Dr",
         "street2": null, "city": "Redondo Beach", "state": "CA", "zip": "90277", "country":
         "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com", "mode":
         "test", "carrier_facility": null, "residential": null, "federal_tax_id": null,
         "state_tax_id": null, "verifications": {}}, "forms": [], "fees": [], "id":
-        "shp_b70f120ff3a34c51bdc30db7fde30a7d", "object": "Shipment"}'
+        "shp_b7892bf189604028895eff184daa363d", "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -96,11 +96,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"f0b5d9afdfa4023ae15a2c93c0edc395"
+      - W/"d9d7be073268e181e17aa801d6c3cfa4"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_b70f120ff3a34c51bdc30db7fde30a7d
+      - /api/v2/shipments/shp_b7892bf189604028895eff184daa363d
       pragma:
       - no-cache
       referrer-policy:
@@ -116,20 +116,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bdfa366a62e1b64fff2241fa0057387d
+      - 3843703d62e2e9e9ff23e2c30034376c
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb1nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq 403f17ff97
-      - extlb2nuq 403f17ff97
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.643110'
+      - '0.643296'
       x-version-label:
-      - easypost-202207272030-717cb56530-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_create_with_ids.yaml
+++ b/tests/cassettes/test_shipment_create_with_ids.yaml
@@ -22,9 +22,13 @@ interactions:
     uri: https://api.easypost.com/v2/addresses
   response:
     body:
-      string: '{"id":"adr_76a2cd08cbe811ec8d21ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:22+00:00","updated_at":"2022-05-04T20:26:22+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+      string: '{"id": "adr_5a9b1bcf0eaf11eda11fac1f6bc72124", "object": "Address",
+        "created_at": "2022-07-28T19:56:22+00:00", "updated_at": "2022-07-28T19:56:22+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "<REDACTED>", "email": "<REDACTED>", "mode": "test",
+        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {}}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -33,11 +37,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"cf3eeb02e7aa70343d6107060b89fa1a"
+      - W/"ee16f1ffc76f78209f9f9534b8802444"
       expires:
       - '0'
       location:
-      - /api/v2/addresses/adr_76a2cd08cbe811ec8d21ac1f6bc7b362
+      - /api/v2/addresses/adr_5a9b1bcf0eaf11eda11fac1f6bc72124
       pragma:
       - no-cache
       referrer-policy:
@@ -53,20 +57,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb66272e16ee786b9020013b05c
+      - 3843703e62e2e9e5ff23e2bf003436b7
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb4nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.031807'
+      - '0.031695'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -95,9 +100,13 @@ interactions:
     uri: https://api.easypost.com/v2/addresses
   response:
     body:
-      string: '{"id":"adr_76b17473cbe811ec8d25ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:22+00:00","updated_at":"2022-05-04T20:26:22+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+      string: '{"id": "adr_5ab5bcd10eaf11eda042ac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-28T19:56:22+00:00", "updated_at": "2022-07-28T19:56:22+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "<REDACTED>", "email": "<REDACTED>", "mode": "test",
+        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {}}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -106,11 +115,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"6af45bc12e30887609cd8bd0766ab653"
+      - W/"6d712a042336eb7617da3ccedcc12333"
       expires:
       - '0'
       location:
-      - /api/v2/addresses/adr_76b17473cbe811ec8d25ac1f6bc7b362
+      - /api/v2/addresses/adr_5ab5bcd10eaf11eda042ac1f6bc7b362
       pragma:
       - no-cache
       referrer-policy:
@@ -126,20 +135,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb66272e16ee786b9020013b063
+      - 3843703e62e2e9e6ff23e2bf003436c4
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb8nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.030072'
+      - '0.027463'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -166,7 +176,10 @@ interactions:
     uri: https://api.easypost.com/v2/parcels
   response:
     body:
-      string: '{"id":"prcl_7c5092538a614fc7ab31bcd118ca79f3","object":"Parcel","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"}'
+      string: '{"id": "prcl_52018d604e2f466ea7fc7a46b4fcbe20", "object": "Parcel",
+        "created_at": "2022-07-28T19:56:22Z", "updated_at": "2022-07-28T19:56:22Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -175,11 +188,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"3213613d6b31031f1803e86d71ec745b"
+      - W/"b6d5d12678ee9b475bf988ab7f98cc95"
       expires:
       - '0'
       location:
-      - /api/v2/parcels.prcl_7c5092538a614fc7ab31bcd118ca79f3
+      - /api/v2/parcels.prcl_52018d604e2f466ea7fc7a46b4fcbe20
       pragma:
       - no-cache
       referrer-policy:
@@ -195,29 +208,30 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb66272e16ee786b9020013b066
+      - 3843703e62e2e9e6ff23e2bf003436cd
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb4nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.021809'
+      - '0.022036'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: '{"shipment": {"from_address": {"id": "adr_76a2cd08cbe811ec8d21ac1f6bc7b362"},
-      "to_address": {"id": "adr_76b17473cbe811ec8d25ac1f6bc7b362"}, "parcel": {"id":
-      "prcl_7c5092538a614fc7ab31bcd118ca79f3"}}}'
+    body: '{"shipment": {"from_address": {"id": "adr_5a9b1bcf0eaf11eda11fac1f6bc72124"},
+      "to_address": {"id": "adr_5ab5bcd10eaf11eda042ac1f6bc7b362"}, "parcel": {"id":
+      "prcl_52018d604e2f466ea7fc7a46b4fcbe20"}}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -226,7 +240,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '199'
+      - '223'
       Content-Type:
       - application/json
       authorization:
@@ -237,28 +251,83 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:22Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:22Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_76a2cd08cbe811ec8d21ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:22+00:00","updated_at":"2022-05-04T20:26:22+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_7c5092538a614fc7ab31bcd118ca79f3","object":"Parcel","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_d6ee31e86b5e421eb48ddac570974cbe","object":"Rate","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8ed97268ed0b4992aa49cd2fed4ac621","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_d03dd7fe2a1d43c0a3a0f21f35beef46","object":"Rate","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_8ed97268ed0b4992aa49cd2fed4ac621","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_f7be9a005e514a30859bc6cb42d669d6","object":"Rate","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8ed97268ed0b4992aa49cd2fed4ac621","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_76c84b05a12d42328d81ae7b3bb89825","object":"Rate","created_at":"2022-05-04T20:26:22Z","updated_at":"2022-05-04T20:26:22Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_8ed97268ed0b4992aa49cd2fed4ac621","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_76b17473cbe811ec8d25ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:22+00:00","updated_at":"2022-05-04T20:26:22+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_76a2cd08cbe811ec8d21ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:22+00:00","updated_at":"2022-05-04T20:26:22+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_76b17473cbe811ec8d25ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:22+00:00","updated_at":"2022-05-04T20:26:22+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_8ed97268ed0b4992aa49cd2fed4ac621","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:22Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        null, "updated_at": "2022-07-28T19:56:22Z", "batch_id": null, "batch_status":
+        null, "batch_message": null, "customs_info": null, "from_address": {"id":
+        "adr_5a9b1bcf0eaf11eda11fac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:22+00:00", "updated_at": "2022-07-28T19:56:22+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_52018d604e2f466ea7fc7a46b4fcbe20",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:22Z", "updated_at": "2022-07-28T19:56:22Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_504995ecd50445168efdf7f8952a46c8",
+        "object": "Rate", "created_at": "2022-07-28T19:56:22Z", "updated_at": "2022-07-28T19:56:22Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_f45ce7aeef1f4c6eb8ecd3025d9c8ff1", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_743cd2c7dac840c3977a6150463c7607",
+        "object": "Rate", "created_at": "2022-07-28T19:56:22Z", "updated_at": "2022-07-28T19:56:22Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_f45ce7aeef1f4c6eb8ecd3025d9c8ff1", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_9e4a8ff32c0a4a78a851cf4d6eb120fb",
+        "object": "Rate", "created_at": "2022-07-28T19:56:22Z", "updated_at": "2022-07-28T19:56:22Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_f45ce7aeef1f4c6eb8ecd3025d9c8ff1", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_1fa963d6cd54453dbb7690456c40fc2a", "object": "Rate", "created_at":
+        "2022-07-28T19:56:22Z", "updated_at": "2022-07-28T19:56:22Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_f45ce7aeef1f4c6eb8ecd3025d9c8ff1", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_5ab5bcd10eaf11eda042ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:56:22+00:00", "updated_at": "2022-07-28T19:56:22+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_5a9b1bcf0eaf11eda11fac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T19:56:22+00:00", "updated_at":
+        "2022-07-28T19:56:22+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_5ab5bcd10eaf11eda042ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:22+00:00", "updated_at": "2022-07-28T19:56:22+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_f45ce7aeef1f4c6eb8ecd3025d9c8ff1",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '4729'
+      - '4833'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"30e78265fa6eecd06353d9df1987f3e8"
+      - W/"720999d42689d82e7eea5e072d6ea179"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_8ed97268ed0b4992aa49cd2fed4ac621
+      - /api/v2/shipments/shp_f45ce7aeef1f4c6eb8ecd3025d9c8ff1
       pragma:
       - no-cache
       referrer-policy:
@@ -274,20 +343,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb66272e16ee786b9020013b06b
+      - 3843703e62e2e9e6ff23e2bf003436d7
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.255081'
+      - '0.278955'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_get_lowest_smartrate.yaml
+++ b/tests/cassettes/test_shipment_get_lowest_smartrate.yaml
@@ -5,7 +5,8 @@ interactions:
       "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
       "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
-      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}}}'
+      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}},
+      "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -14,7 +15,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '477'
+      - '501'
       Content-Type:
       - application/json
       authorization:
@@ -25,28 +26,83 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:24Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:24Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_7804e92bcbe811eca58eac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:24+00:00","updated_at":"2022-05-04T20:26:24+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_bff25ff71c6f47e7a5df9edcd5853de4","object":"Parcel","created_at":"2022-05-04T20:26:24Z","updated_at":"2022-05-04T20:26:24Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_0d1598a88c6d448fabba046ba602504a","object":"Rate","created_at":"2022-05-04T20:26:25Z","updated_at":"2022-05-04T20:26:25Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a75e7ef9f90f4d69a3197e1fd5dce15b","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_2b1ce8b41e5b4b14b88bc81577a1888e","object":"Rate","created_at":"2022-05-04T20:26:25Z","updated_at":"2022-05-04T20:26:25Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a75e7ef9f90f4d69a3197e1fd5dce15b","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_8da980fb97214472a34e60ddaa953b16","object":"Rate","created_at":"2022-05-04T20:26:25Z","updated_at":"2022-05-04T20:26:25Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_a75e7ef9f90f4d69a3197e1fd5dce15b","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_88bb96e6d40147a3b3ca6a205c547288","object":"Rate","created_at":"2022-05-04T20:26:25Z","updated_at":"2022-05-04T20:26:25Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_a75e7ef9f90f4d69a3197e1fd5dce15b","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_7802ff50cbe811ec95fbac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:24+00:00","updated_at":"2022-05-04T20:26:24+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_7804e92bcbe811eca58eac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:24+00:00","updated_at":"2022-05-04T20:26:24+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_7802ff50cbe811ec95fbac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:24+00:00","updated_at":"2022-05-04T20:26:24+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_a75e7ef9f90f4d69a3197e1fd5dce15b","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:27:07Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        null, "updated_at": "2022-07-28T20:27:07Z", "batch_id": null, "batch_status":
+        null, "batch_message": null, "customs_info": null, "from_address": {"id":
+        "adr_a6c06f4a0eb311ed88c6ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:27:07+00:00", "updated_at": "2022-07-28T20:27:07+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_844752fd3d2c4a8ca62d24a6c1b3bddf",
+        "object": "Parcel", "created_at": "2022-07-28T20:27:07Z", "updated_at": "2022-07-28T20:27:07Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_6348100939da4b9cabbe18532fa4d6e4",
+        "object": "Rate", "created_at": "2022-07-28T20:27:07Z", "updated_at": "2022-07-28T20:27:07Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_d048d20d5490480184a3c776a26d1010", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_d860fe82abb0436cb840b00f1d3bdadc",
+        "object": "Rate", "created_at": "2022-07-28T20:27:07Z", "updated_at": "2022-07-28T20:27:07Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_d048d20d5490480184a3c776a26d1010", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_970f492ca9304f679b30c0fa9bff563d",
+        "object": "Rate", "created_at": "2022-07-28T20:27:07Z", "updated_at": "2022-07-28T20:27:07Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_d048d20d5490480184a3c776a26d1010", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_20f3907766704e368bc28fbe3c09a08e", "object": "Rate", "created_at":
+        "2022-07-28T20:27:07Z", "updated_at": "2022-07-28T20:27:07Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_d048d20d5490480184a3c776a26d1010", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_a6be96f90eb311ed8de0ac1f6bc7bdc6", "object":
+        "Address", "created_at": "2022-07-28T20:27:07+00:00", "updated_at": "2022-07-28T20:27:07+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_a6c06f4a0eb311ed88c6ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-28T20:27:07+00:00", "updated_at":
+        "2022-07-28T20:27:07+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_a6be96f90eb311ed8de0ac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-28T20:27:07+00:00", "updated_at": "2022-07-28T20:27:07+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_d048d20d5490480184a3c776a26d1010",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '4729'
+      - '4833'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"04a868aa9320370213340ce772fde969"
+      - W/"cb94e825c64464526b200cbe51b487b3"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_a75e7ef9f90f4d69a3197e1fd5dce15b
+      - /api/v2/shipments/shp_d048d20d5490480184a3c776a26d1010
       pragma:
       - no-cache
       referrer-policy:
@@ -62,20 +118,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb56272e170e786b9060013b0f3
+      - efdf9e0562e2f11bff23eb220001e8d2
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.312797'
+      - '0.236483'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -95,10 +152,44 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_a75e7ef9f90f4d69a3197e1fd5dce15b/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_d048d20d5490480184a3c776a26d1010/smartrate
   response:
     body:
-      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:25Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_0d1598a88c6d448fabba046ba602504a","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_a75e7ef9f90f4d69a3197e1fd5dce15b","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-05-04T20:26:25Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:25Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_2b1ce8b41e5b4b14b88bc81577a1888e","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_a75e7ef9f90f4d69a3197e1fd5dce15b","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-04T20:26:25Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:25Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_8da980fb97214472a34e60ddaa953b16","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_a75e7ef9f90f4d69a3197e1fd5dce15b","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-05-04T20:26:25Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:25Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_88bb96e6d40147a3b3ca6a205c547288","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_a75e7ef9f90f4d69a3197e1fd5dce15b","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-04T20:26:25Z"}]}'
+      string: '{"result": [{"carrier": "USPS", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e",
+        "created_at": "2022-07-28T20:27:07Z", "currency": "USD", "delivery_date":
+        null, "delivery_date_guaranteed": false, "delivery_days": 1, "est_delivery_days":
+        1, "id": "rate_6348100939da4b9cabbe18532fa4d6e4", "list_currency": "USD",
+        "list_rate": 7.37, "mode": "test", "object": "Rate", "rate": 7.37, "retail_currency":
+        "USD", "retail_rate": 8.7, "service": "Priority", "shipment_id": "shp_d048d20d5490480184a3c776a26d1010",
+        "time_in_transit": {"percentile_50": 1, "percentile_75": 1, "percentile_85":
+        2, "percentile_90": 2, "percentile_95": 2, "percentile_97": 3, "percentile_99":
+        6}, "updated_at": "2022-07-28T20:27:07Z"}, {"carrier": "USPS", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "created_at": "2022-07-28T20:27:07Z",
+        "currency": "USD", "delivery_date": null, "delivery_date_guaranteed": false,
+        "delivery_days": 2, "est_delivery_days": 2, "id": "rate_d860fe82abb0436cb840b00f1d3bdadc",
+        "list_currency": "USD", "list_rate": 7.22, "mode": "test", "object": "Rate",
+        "rate": 7.22, "retail_currency": "USD", "retail_rate": 7.22, "service": "ParcelSelect",
+        "shipment_id": "shp_d048d20d5490480184a3c776a26d1010", "time_in_transit":
+        {"percentile_50": 2, "percentile_75": 3, "percentile_85": 3, "percentile_90":
+        4, "percentile_95": 5, "percentile_97": 5, "percentile_99": 8}, "updated_at":
+        "2022-07-28T20:27:07Z"}, {"carrier": "USPS", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e",
+        "created_at": "2022-07-28T20:27:07Z", "currency": "USD", "delivery_date":
+        null, "delivery_date_guaranteed": false, "delivery_days": 2, "est_delivery_days":
+        2, "id": "rate_970f492ca9304f679b30c0fa9bff563d", "list_currency": "USD",
+        "list_rate": 5.49, "mode": "test", "object": "Rate", "rate": 5.49, "retail_currency":
+        "USD", "retail_rate": 5.49, "service": "First", "shipment_id": "shp_d048d20d5490480184a3c776a26d1010",
+        "time_in_transit": {"percentile_50": 1, "percentile_75": 1, "percentile_85":
+        2, "percentile_90": 2, "percentile_95": 2, "percentile_97": 2, "percentile_99":
+        3}, "updated_at": "2022-07-28T20:27:07Z"}, {"carrier": "USPS", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "created_at": "2022-07-28T20:27:07Z",
+        "currency": "USD", "delivery_date": null, "delivery_date_guaranteed": false,
+        "delivery_days": null, "est_delivery_days": null, "id": "rate_20f3907766704e368bc28fbe3c09a08e",
+        "list_currency": "USD", "list_rate": 23.75, "mode": "test", "object": "Rate",
+        "rate": 23.75, "retail_currency": "USD", "retail_rate": 27.4, "service": "Express",
+        "shipment_id": "shp_d048d20d5490480184a3c776a26d1010", "time_in_transit":
+        {"percentile_50": 1, "percentile_75": 1, "percentile_85": 1, "percentile_90":
+        2, "percentile_95": 2, "percentile_97": 2, "percentile_99": 4}, "updated_at":
+        "2022-07-28T20:27:07Z"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -107,7 +198,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"28249fac14a5226903a47218e0b2853b"
+      - W/"7fb33224755085477c3631fab1561ca7"
       expires:
       - '0'
       pragma:
@@ -125,7 +216,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb56272e171e786b9060013b110
+      - efdf9e0562e2f11cff23eb220001e8ed
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -133,12 +224,13 @@ interactions:
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.063599'
+      - '0.085026'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_insure.yaml
+++ b/tests/cassettes/test_shipment_insure.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS", "insurance": 0}}'
+      "USPS", "insurance": 0}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '593'
+      - '617'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:18Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768907","updated_at":"2022-05-04T20:26:18Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_7400ae39cbe811ec9544ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:18+00:00","updated_at":"2022-05-04T20:26:18+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_31c5430055614a2c967bfeaaab521846","object":"Parcel","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_1b48449c37864d4ca8aff1bc715f5e89","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:18Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/545806ed105849da897943fcb91cf015.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_bb310bb56e6942b989e59c8cc87210a4","object":"Rate","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_8171c07ad2d9496f8e4a6359f2bf9a95","object":"Rate","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_b15c68af250c4f61ac416ea4ecbbba76","object":"Rate","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_db8dd73381e74e48b2cb8922befe3295","object":"Rate","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_bb310bb56e6942b989e59c8cc87210a4","object":"Rate","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_f676429a00ad499aa97697370c807481","object":"Tracker","mode":"test","tracking_code":"9400100109361117768907","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2Y2NzY0MjlhMDBhZDQ5OWFhOTc2OTczNzBjODA3NDgx"},"to_address":{"id":"adr_73ff029acbe811ec8ca7ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:18+00:00","updated_at":"2022-05-04T20:26:18+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_7400ae39cbe811ec9544ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:18+00:00","updated_at":"2022-05-04T20:26:18+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_73ff029acbe811ec8ca7ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:18+00:00","updated_at":"2022-05-04T20:26:18+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:17Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130483597", "updated_at": "2022-07-28T19:56:18Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_57e237710eaf11ed9eb8ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:17+00:00", "updated_at": "2022-07-28T19:56:17+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_683e83de32b845edb4c3ea304cca6e3a",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_2d805041d10a4f719736a033d5982261",
+        "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:18Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:17Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/43591631f256470abab2325f5eac816a.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_ee564e35899c403cb0585dd4fd5cff1c", "object":
+        "Rate", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_be3b5d4b81534ce48ce18bf3bde90950",
+        "object": "Rate", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_baf28666d49a42dc81704811f5ae45ee",
+        "object": "Rate", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_572af98f52984862a63bc1bd018ede26",
+        "object": "Rate", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_572af98f52984862a63bc1bd018ede26",
+        "object": "Rate", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_93f071cf8d014de6874a04a407e6a9b6", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483597", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T19:56:18Z", "updated_at":
+        "2022-07-28T19:56:18Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzkzZjA3MWNmOGQwMTRkZTY4NzRhMDRhNDA3ZTZhOWI2"},
+        "to_address": {"id": "adr_57e07cf70eaf11ed9eb5ac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-28T19:56:17+00:00", "updated_at": "2022-07-28T19:56:17+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_57e237710eaf11ed9eb8ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:17+00:00", "updated_at": "2022-07-28T19:56:17+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_57e07cf70eaf11ed9eb5ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:56:17+00:00", "updated_at": "2022-07-28T19:56:17+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"280fa87fcd639c11637ec7796b8988c0"
+      - W/"cd6e998bd417e10111c99bb4ae9674eb"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_9db7a6ac1ad3405a987ef6224f6064f8
+      - /api/v2/shipments/shp_6dbfbd3dcdf84e7f97356d4743ec2d13
       pragma:
       - no-cache
       referrer-policy:
@@ -64,20 +145,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb56272e16ae786b8e60013af28
+      - 3843704362e2e9e1ff23e2a200343599
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb2nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.909429'
+      - '0.873421'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -101,27 +183,123 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_9db7a6ac1ad3405a987ef6224f6064f8/insure
+    uri: https://api.easypost.com/v2/shipments/shp_6dbfbd3dcdf84e7f97356d4743ec2d13/insure
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:18Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768907","updated_at":"2022-05-04T20:26:18Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_7400ae39cbe811ec9544ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:18+00:00","updated_at":"2022-05-04T20:26:18+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":"100.00","order_id":null,"parcel":{"id":"prcl_31c5430055614a2c967bfeaaab521846","object":"Parcel","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_1b48449c37864d4ca8aff1bc715f5e89","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:18Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/545806ed105849da897943fcb91cf015.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_bb310bb56e6942b989e59c8cc87210a4","object":"Rate","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_8171c07ad2d9496f8e4a6359f2bf9a95","object":"Rate","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_b15c68af250c4f61ac416ea4ecbbba76","object":"Rate","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_db8dd73381e74e48b2cb8922befe3295","object":"Rate","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_bb310bb56e6942b989e59c8cc87210a4","object":"Rate","created_at":"2022-05-04T20:26:18Z","updated_at":"2022-05-04T20:26:18Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":null,"to_address":{"id":"adr_73ff029acbe811ec8ca7ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:18+00:00","updated_at":"2022-05-04T20:26:18+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_7400ae39cbe811ec9544ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:18+00:00","updated_at":"2022-05-04T20:26:18+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_73ff029acbe811ec8ca7ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:18+00:00","updated_at":"2022-05-04T20:26:18+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false},{"object":"Fee","type":"InsuranceFee","amount":"1.00000","charged":true,"refunded":false}],"id":"shp_9db7a6ac1ad3405a987ef6224f6064f8","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:17Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130483597", "updated_at": "2022-07-28T19:56:18Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_57e237710eaf11ed9eb8ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:17+00:00", "updated_at": "2022-07-28T19:56:17+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": "100.00", "order_id": null, "parcel": {"id": "prcl_683e83de32b845edb4c3ea304cca6e3a",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_2d805041d10a4f719736a033d5982261",
+        "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:18Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:17Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/43591631f256470abab2325f5eac816a.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_ee564e35899c403cb0585dd4fd5cff1c", "object":
+        "Rate", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_be3b5d4b81534ce48ce18bf3bde90950",
+        "object": "Rate", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_baf28666d49a42dc81704811f5ae45ee",
+        "object": "Rate", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_572af98f52984862a63bc1bd018ede26",
+        "object": "Rate", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_572af98f52984862a63bc1bd018ede26",
+        "object": "Rate", "created_at": "2022-07-28T19:56:17Z", "updated_at": "2022-07-28T19:56:17Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_6dbfbd3dcdf84e7f97356d4743ec2d13", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_93f071cf8d014de6874a04a407e6a9b6", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483597", "status": "pre_transit",
+        "status_detail": "status_update", "created_at": "2022-07-28T19:56:18Z", "updated_at":
+        "2022-07-28T19:56:18Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:56:18Z", "shipment_id": "shp_6dbfbd3dcdf84e7f97356d4743ec2d13",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:56:18Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:33:18Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}], "fees":
+        [], "carrier_detail": {"object": "CarrierDetail", "service": "First-Class
+        Package Service", "container_type": null, "est_delivery_date_local": null,
+        "est_delivery_time_local": null, "origin_location": "HOUSTON TX, 77001", "origin_tracking_location":
+        {"object": "TrackingLocation", "city": "HOUSTON", "state": "TX", "country":
+        null, "zip": "77063"}, "destination_location": "CHARLESTON SC, 29401", "destination_tracking_location":
+        null, "guaranteed_delivery_date": null, "alternate_identifier": null, "initial_delivery_attempt":
+        null}, "public_url": "https://track.easypost.com/djE6dHJrXzkzZjA3MWNmOGQwMTRkZTY4NzRhMDRhNDA3ZTZhOWI2"},
+        "to_address": {"id": "adr_57e07cf70eaf11ed9eb5ac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-28T19:56:17+00:00", "updated_at": "2022-07-28T19:56:17+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_57e237710eaf11ed9eb8ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:17+00:00", "updated_at": "2022-07-28T19:56:17+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_57e07cf70eaf11ed9eb5ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:56:17+00:00", "updated_at": "2022-07-28T19:56:17+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}, {"object": "Fee", "type": "InsuranceFee", "amount": "1.00000",
+        "charged": true, "refunded": false}], "id": "shp_6dbfbd3dcdf84e7f97356d4743ec2d13",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6413'
+      - '8184'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"dd2d7fa4c589f112bf2d42dd64398398"
+      - W/"1f2977131eb7ea8834e517810aff6eb9"
       expires:
       - '0'
       pragma:
@@ -139,20 +317,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb56272e16be786b8e60013af6a
+      - 3843704362e2e9e2ff23e2a2003435d9
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb1nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.145643'
+      - '0.160528'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_lowest_rate.yaml
+++ b/tests/cassettes/test_shipment_lowest_rate.yaml
@@ -11,7 +11,7 @@ interactions:
       "none", "non_delivery_option": "return", "customs_items": [{"description": "Sweet
       shirts", "quantity": 2, "weight": 11, "value": 23, "hs_tariff_number": "654321",
       "origin_country": "US"}]}, "options": {"label_format": "PNG", "invoice_number":
-      "123"}, "reference": "123"}}'
+      "123"}, "reference": "123"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -20,7 +20,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '932'
+      - '956'
       Content-Type:
       - application/json
       authorization:
@@ -31,30 +31,94 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:23Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:23Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_27490d3c6a834201b60bb9a20d1b9473","object":"CustomsInfo","created_at":"2022-05-04T20:26:23Z","updated_at":"2022-05-04T20:26:23Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_e1329b6186ca4c2e967dbd45b116629c","object":"CustomsItem","created_at":"2022-05-04T20:26:23Z","updated_at":"2022-05-04T20:26:23Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_77137445cbe811ec95d7ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:23+00:00","updated_at":"2022-05-04T20:26:23+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_25587052df564f78b57b06caf0cf7468","object":"Parcel","created_at":"2022-05-04T20:26:23Z","updated_at":"2022-05-04T20:26:23Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_d8d0b38e584f45eeae02ca00bb8ae2ac","object":"Rate","created_at":"2022-05-04T20:26:23Z","updated_at":"2022-05-04T20:26:23Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_a098dedef5ea41e2b202be32586aad79","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_10d75b3b86cf4047a3f8dc691e328f8c","object":"Rate","created_at":"2022-05-04T20:26:23Z","updated_at":"2022-05-04T20:26:23Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a098dedef5ea41e2b202be32586aad79","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_f316067858b444d1b0f4ac9539e68046","object":"Rate","created_at":"2022-05-04T20:26:23Z","updated_at":"2022-05-04T20:26:23Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_a098dedef5ea41e2b202be32586aad79","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_49935b0c7d3a433197cae8d9227648bd","object":"Rate","created_at":"2022-05-04T20:26:23Z","updated_at":"2022-05-04T20:26:23Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a098dedef5ea41e2b202be32586aad79","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_771197afcbe811ec95d6ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:23+00:00","updated_at":"2022-05-04T20:26:23+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_77137445cbe811ec95d7ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:23+00:00","updated_at":"2022-05-04T20:26:23+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_771197afcbe811ec95d6ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:23+00:00","updated_at":"2022-05-04T20:26:23+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_a098dedef5ea41e2b202be32586aad79","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:23Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"label_format": "PNG", "invoice_number": "123",
+        "currency": "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference":
+        "123", "status": "unknown", "tracking_code": null, "updated_at": "2022-07-28T19:56:23Z",
+        "batch_id": null, "batch_status": null, "batch_message": null, "customs_info":
+        {"id": "cstinfo_469cf31445d646f28fa6b3e636087113", "object": "CustomsInfo",
+        "created_at": "2022-07-28T19:56:23Z", "updated_at": "2022-07-28T19:56:23Z",
+        "contents_explanation": "", "contents_type": "merchandise", "customs_certify":
+        true, "customs_signer": "Steve Brule", "eel_pfc": "NOEEI 30.37(a)", "non_delivery_option":
+        "return", "restriction_comments": null, "restriction_type": "none", "mode":
+        "test", "declaration": null, "customs_items": [{"id": "cstitem_14b90f02fcc94769bb26997a6655cc6c",
+        "object": "CustomsItem", "created_at": "2022-07-28T19:56:23Z", "updated_at":
+        "2022-07-28T19:56:23Z", "description": "Sweet shirts", "hs_tariff_number":
+        "654321", "origin_country": "US", "quantity": 2, "value": "23.0", "weight":
+        11.0, "code": null, "mode": "test", "manufacturer": null, "currency": null,
+        "eccn": null, "printed_commodity_identifier": null}]}, "from_address": {"id":
+        "adr_5b3bb1a00eaf11eda642ac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:56:23+00:00", "updated_at": "2022-07-28T19:56:23+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_166eb3907f774f51b08e2279d052fb45",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:23Z", "updated_at": "2022-07-28T19:56:23Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_65b88384a82849a5bf44c5485e190ec2",
+        "object": "Rate", "created_at": "2022-07-28T19:56:23Z", "updated_at": "2022-07-28T19:56:23Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_c5de3b916e4b44b4bba29f25ed3788f7", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_f506e3a68b72421e9fbb0fdf62149fe3",
+        "object": "Rate", "created_at": "2022-07-28T19:56:23Z", "updated_at": "2022-07-28T19:56:23Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_c5de3b916e4b44b4bba29f25ed3788f7", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_d2d34f66463c46c69a02549687607599",
+        "object": "Rate", "created_at": "2022-07-28T19:56:23Z", "updated_at": "2022-07-28T19:56:23Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_c5de3b916e4b44b4bba29f25ed3788f7", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_a36c9beb2d0e453a93098191d93690b2", "object": "Rate", "created_at":
+        "2022-07-28T19:56:23Z", "updated_at": "2022-07-28T19:56:23Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_c5de3b916e4b44b4bba29f25ed3788f7", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_5b39dcf90eaf11eda63fac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-28T19:56:23+00:00", "updated_at": "2022-07-28T19:56:23+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_5b3bb1a00eaf11eda642ac1f6b0a0d1e",
+        "object": "Address", "created_at": "2022-07-28T19:56:23+00:00", "updated_at":
+        "2022-07-28T19:56:23+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_5b39dcf90eaf11eda63fac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:56:23+00:00", "updated_at": "2022-07-28T19:56:23+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_c5de3b916e4b44b4bba29f25ed3788f7",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '5563'
+      - '5667'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"58df5d4fa41117c1cd32ad7f3be9dde5"
+      - W/"99d3714034be137bff4b9436dd424b05"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_a098dedef5ea41e2b202be32586aad79
+      - /api/v2/shipments/shp_c5de3b916e4b44b4bba29f25ed3788f7
       pragma:
       - no-cache
       referrer-policy:
@@ -70,20 +134,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb76272e16fe786b9040013b088
+      - 3843704362e2e9e6ff23e2c0003436f5
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb4nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.361034'
+      - '0.290165'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_lowest_smartrate.yaml
+++ b/tests/cassettes/test_shipment_lowest_smartrate.yaml
@@ -5,7 +5,8 @@ interactions:
       "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
       "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
-      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}}}'
+      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}},
+      "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -14,7 +15,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '477'
+      - '501'
       Content-Type:
       - application/json
       authorization:
@@ -25,28 +26,83 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:23Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:23Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_777fd874cbe811ec95e8ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:23+00:00","updated_at":"2022-05-04T20:26:23+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_459bf3ad407742a3ab389fbd133d92cf","object":"Parcel","created_at":"2022-05-04T20:26:23Z","updated_at":"2022-05-04T20:26:23Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_1bf9fc25687348949fb744b933d2c72b","object":"Rate","created_at":"2022-05-04T20:26:24Z","updated_at":"2022-05-04T20:26:24Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_24e4d016e5ee410aa30e4046d9ab2e3f","object":"Rate","created_at":"2022-05-04T20:26:24Z","updated_at":"2022-05-04T20:26:24Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_0643b8e678364026ab503a5bb919849f","object":"Rate","created_at":"2022-05-04T20:26:24Z","updated_at":"2022-05-04T20:26:24Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_91ad99e5901b482d8fc04d03b2b2acc7","object":"Rate","created_at":"2022-05-04T20:26:24Z","updated_at":"2022-05-04T20:26:24Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_777df655cbe811ecabd2ac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:23+00:00","updated_at":"2022-05-04T20:26:23+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_777fd874cbe811ec95e8ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:23+00:00","updated_at":"2022-05-04T20:26:23+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_777df655cbe811ecabd2ac1f6bc7bdc6","object":"Address","created_at":"2022-05-04T20:26:23+00:00","updated_at":"2022-05-04T20:26:23+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T20:59:07Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        null, "updated_at": "2022-07-28T20:59:07Z", "batch_id": null, "batch_status":
+        null, "batch_message": null, "customs_info": null, "from_address": {"id":
+        "adr_1edb289e0eb811ed8dcfac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:59:07+00:00", "updated_at": "2022-07-28T20:59:07+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_1820b619445a41cab4d0cbd74931abcd",
+        "object": "Parcel", "created_at": "2022-07-28T20:59:07Z", "updated_at": "2022-07-28T20:59:07Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_0e8aff312a9d4806bdf807ba8d3939ef",
+        "object": "Rate", "created_at": "2022-07-28T20:59:07Z", "updated_at": "2022-07-28T20:59:07Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_da53588772c44de69ddde44f963372b2", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_af41d41bd30c46a48296784647096c77",
+        "object": "Rate", "created_at": "2022-07-28T20:59:07Z", "updated_at": "2022-07-28T20:59:07Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_da53588772c44de69ddde44f963372b2", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_564c9204fec24873af1789e1fb471d83",
+        "object": "Rate", "created_at": "2022-07-28T20:59:07Z", "updated_at": "2022-07-28T20:59:07Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_da53588772c44de69ddde44f963372b2", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_b67b4b0ade84415281017162fa1c0193",
+        "object": "Rate", "created_at": "2022-07-28T20:59:07Z", "updated_at": "2022-07-28T20:59:07Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_da53588772c44de69ddde44f963372b2", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_1ed9779c0eb811ed8dccac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T20:59:07+00:00", "updated_at": "2022-07-28T20:59:07+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_1edb289e0eb811ed8dcfac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-28T20:59:07+00:00", "updated_at":
+        "2022-07-28T20:59:07+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_1ed9779c0eb811ed8dccac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T20:59:07+00:00", "updated_at": "2022-07-28T20:59:07+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_da53588772c44de69ddde44f963372b2",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '4729'
+      - '4833'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"e665bc726e5b72bb6151bafc16931bdb"
+      - W/"0bec8140ad040ec6e83c5aad54553004"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_de101d80a5564a1ea9ce6c5e6b8f9c4a
+      - /api/v2/shipments/shp_da53588772c44de69ddde44f963372b2
       pragma:
       - no-cache
       referrer-policy:
@@ -62,20 +118,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fbb6272e16fe786b9050013b0ba
+      - b0657e3f62e2f89aff2459be00381da6
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb9nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.241012'
+      - '0.466796'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207282048-993576a700-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -95,10 +152,44 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_de101d80a5564a1ea9ce6c5e6b8f9c4a/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_da53588772c44de69ddde44f963372b2/smartrate
   response:
     body:
-      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_1bf9fc25687348949fb744b933d2c72b","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-05-04T20:26:24Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_24e4d016e5ee410aa30e4046d9ab2e3f","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-05-04T20:26:24Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_0643b8e678364026ab503a5bb919849f","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-04T20:26:24Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_91ad99e5901b482d8fc04d03b2b2acc7","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-04T20:26:24Z"}]}'
+      string: '{"result": [{"carrier": "USPS", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e",
+        "created_at": "2022-07-28T20:59:07Z", "currency": "USD", "delivery_date":
+        null, "delivery_date_guaranteed": false, "delivery_days": null, "est_delivery_days":
+        null, "id": "rate_0e8aff312a9d4806bdf807ba8d3939ef", "list_currency": "USD",
+        "list_rate": 23.75, "mode": "test", "object": "Rate", "rate": 23.75, "retail_currency":
+        "USD", "retail_rate": 27.4, "service": "Express", "shipment_id": "shp_da53588772c44de69ddde44f963372b2",
+        "time_in_transit": {"percentile_50": 1, "percentile_75": 1, "percentile_85":
+        1, "percentile_90": 2, "percentile_95": 2, "percentile_97": 2, "percentile_99":
+        4}, "updated_at": "2022-07-28T20:59:07Z"}, {"carrier": "USPS", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "created_at": "2022-07-28T20:59:07Z",
+        "currency": "USD", "delivery_date": null, "delivery_date_guaranteed": false,
+        "delivery_days": 1, "est_delivery_days": 1, "id": "rate_af41d41bd30c46a48296784647096c77",
+        "list_currency": "USD", "list_rate": 7.37, "mode": "test", "object": "Rate",
+        "rate": 7.37, "retail_currency": "USD", "retail_rate": 8.7, "service": "Priority",
+        "shipment_id": "shp_da53588772c44de69ddde44f963372b2", "time_in_transit":
+        {"percentile_50": 1, "percentile_75": 1, "percentile_85": 2, "percentile_90":
+        2, "percentile_95": 2, "percentile_97": 3, "percentile_99": 6}, "updated_at":
+        "2022-07-28T20:59:07Z"}, {"carrier": "USPS", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e",
+        "created_at": "2022-07-28T20:59:07Z", "currency": "USD", "delivery_date":
+        null, "delivery_date_guaranteed": false, "delivery_days": 2, "est_delivery_days":
+        2, "id": "rate_564c9204fec24873af1789e1fb471d83", "list_currency": "USD",
+        "list_rate": 7.22, "mode": "test", "object": "Rate", "rate": 7.22, "retail_currency":
+        "USD", "retail_rate": 7.22, "service": "ParcelSelect", "shipment_id": "shp_da53588772c44de69ddde44f963372b2",
+        "time_in_transit": {"percentile_50": 2, "percentile_75": 3, "percentile_85":
+        3, "percentile_90": 4, "percentile_95": 5, "percentile_97": 5, "percentile_99":
+        8}, "updated_at": "2022-07-28T20:59:07Z"}, {"carrier": "USPS", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "created_at": "2022-07-28T20:59:07Z",
+        "currency": "USD", "delivery_date": null, "delivery_date_guaranteed": false,
+        "delivery_days": 2, "est_delivery_days": 2, "id": "rate_b67b4b0ade84415281017162fa1c0193",
+        "list_currency": "USD", "list_rate": 5.49, "mode": "test", "object": "Rate",
+        "rate": 5.49, "retail_currency": "USD", "retail_rate": 5.49, "service": "First",
+        "shipment_id": "shp_da53588772c44de69ddde44f963372b2", "time_in_transit":
+        {"percentile_50": 1, "percentile_75": 1, "percentile_85": 2, "percentile_90":
+        2, "percentile_95": 2, "percentile_97": 2, "percentile_99": 3}, "updated_at":
+        "2022-07-28T20:59:07Z"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -107,7 +198,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"5e2610902ec2665e8e800424f8d63eb7"
+      - W/"2c853cc8ae6827f6c959fa3cced3bdfd"
       expires:
       - '0'
       pragma:
@@ -120,27 +211,26 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fbb6272e170e786b9050013b0d0
+      - b0657e3f62e2f89bff2459be00381dd2
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7nuq
+      - bigweb4nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.066122'
+      - '0.148221'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207282005-993576a700-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -160,10 +250,44 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_de101d80a5564a1ea9ce6c5e6b8f9c4a/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_da53588772c44de69ddde44f963372b2/smartrate
   response:
     body:
-      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_1bf9fc25687348949fb744b933d2c72b","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-05-04T20:26:24Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_24e4d016e5ee410aa30e4046d9ab2e3f","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-05-04T20:26:24Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_0643b8e678364026ab503a5bb919849f","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-04T20:26:24Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_91ad99e5901b482d8fc04d03b2b2acc7","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-04T20:26:24Z"}]}'
+      string: '{"result": [{"carrier": "USPS", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e",
+        "created_at": "2022-07-28T20:59:07Z", "currency": "USD", "delivery_date":
+        null, "delivery_date_guaranteed": false, "delivery_days": null, "est_delivery_days":
+        null, "id": "rate_0e8aff312a9d4806bdf807ba8d3939ef", "list_currency": "USD",
+        "list_rate": 23.75, "mode": "test", "object": "Rate", "rate": 23.75, "retail_currency":
+        "USD", "retail_rate": 27.4, "service": "Express", "shipment_id": "shp_da53588772c44de69ddde44f963372b2",
+        "time_in_transit": {"percentile_50": 1, "percentile_75": 1, "percentile_85":
+        1, "percentile_90": 2, "percentile_95": 2, "percentile_97": 2, "percentile_99":
+        4}, "updated_at": "2022-07-28T20:59:07Z"}, {"carrier": "USPS", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "created_at": "2022-07-28T20:59:07Z",
+        "currency": "USD", "delivery_date": null, "delivery_date_guaranteed": false,
+        "delivery_days": 1, "est_delivery_days": 1, "id": "rate_af41d41bd30c46a48296784647096c77",
+        "list_currency": "USD", "list_rate": 7.37, "mode": "test", "object": "Rate",
+        "rate": 7.37, "retail_currency": "USD", "retail_rate": 8.7, "service": "Priority",
+        "shipment_id": "shp_da53588772c44de69ddde44f963372b2", "time_in_transit":
+        {"percentile_50": 1, "percentile_75": 1, "percentile_85": 2, "percentile_90":
+        2, "percentile_95": 2, "percentile_97": 3, "percentile_99": 6}, "updated_at":
+        "2022-07-28T20:59:07Z"}, {"carrier": "USPS", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e",
+        "created_at": "2022-07-28T20:59:07Z", "currency": "USD", "delivery_date":
+        null, "delivery_date_guaranteed": false, "delivery_days": 2, "est_delivery_days":
+        2, "id": "rate_564c9204fec24873af1789e1fb471d83", "list_currency": "USD",
+        "list_rate": 7.22, "mode": "test", "object": "Rate", "rate": 7.22, "retail_currency":
+        "USD", "retail_rate": 7.22, "service": "ParcelSelect", "shipment_id": "shp_da53588772c44de69ddde44f963372b2",
+        "time_in_transit": {"percentile_50": 2, "percentile_75": 3, "percentile_85":
+        3, "percentile_90": 4, "percentile_95": 5, "percentile_97": 5, "percentile_99":
+        8}, "updated_at": "2022-07-28T20:59:07Z"}, {"carrier": "USPS", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "created_at": "2022-07-28T20:59:07Z",
+        "currency": "USD", "delivery_date": null, "delivery_date_guaranteed": false,
+        "delivery_days": 2, "est_delivery_days": 2, "id": "rate_b67b4b0ade84415281017162fa1c0193",
+        "list_currency": "USD", "list_rate": 5.49, "mode": "test", "object": "Rate",
+        "rate": 5.49, "retail_currency": "USD", "retail_rate": 5.49, "service": "First",
+        "shipment_id": "shp_da53588772c44de69ddde44f963372b2", "time_in_transit":
+        {"percentile_50": 1, "percentile_75": 1, "percentile_85": 2, "percentile_90":
+        2, "percentile_95": 2, "percentile_97": 2, "percentile_99": 3}, "updated_at":
+        "2022-07-28T20:59:07Z"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -172,7 +296,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"5e2610902ec2665e8e800424f8d63eb7"
+      - W/"2c853cc8ae6827f6c959fa3cced3bdfd"
       expires:
       - '0'
       pragma:
@@ -185,27 +309,26 @@ interactions:
       - chunked
       x-backend:
       - easypost
-      x-canary:
-      - direct
       x-content-type-options:
       - nosniff
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fbb6272e170e786b9050013b0d7
+      - b0657e3f62e2f89bff2459be00381df0
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb7nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.087774'
+      - '0.094762'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207282048-993576a700-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -225,10 +348,44 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_de101d80a5564a1ea9ce6c5e6b8f9c4a/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_da53588772c44de69ddde44f963372b2/smartrate
   response:
     body:
-      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_1bf9fc25687348949fb744b933d2c72b","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-05-04T20:26:24Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_24e4d016e5ee410aa30e4046d9ab2e3f","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-05-04T20:26:24Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_0643b8e678364026ab503a5bb919849f","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-04T20:26:24Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:24Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_91ad99e5901b482d8fc04d03b2b2acc7","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_de101d80a5564a1ea9ce6c5e6b8f9c4a","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-04T20:26:24Z"}]}'
+      string: '{"result": [{"carrier": "USPS", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e",
+        "created_at": "2022-07-28T20:59:07Z", "currency": "USD", "delivery_date":
+        null, "delivery_date_guaranteed": false, "delivery_days": null, "est_delivery_days":
+        null, "id": "rate_0e8aff312a9d4806bdf807ba8d3939ef", "list_currency": "USD",
+        "list_rate": 23.75, "mode": "test", "object": "Rate", "rate": 23.75, "retail_currency":
+        "USD", "retail_rate": 27.4, "service": "Express", "shipment_id": "shp_da53588772c44de69ddde44f963372b2",
+        "time_in_transit": {"percentile_50": 1, "percentile_75": 1, "percentile_85":
+        1, "percentile_90": 2, "percentile_95": 2, "percentile_97": 2, "percentile_99":
+        4}, "updated_at": "2022-07-28T20:59:07Z"}, {"carrier": "USPS", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "created_at": "2022-07-28T20:59:07Z",
+        "currency": "USD", "delivery_date": null, "delivery_date_guaranteed": false,
+        "delivery_days": 1, "est_delivery_days": 1, "id": "rate_af41d41bd30c46a48296784647096c77",
+        "list_currency": "USD", "list_rate": 7.37, "mode": "test", "object": "Rate",
+        "rate": 7.37, "retail_currency": "USD", "retail_rate": 8.7, "service": "Priority",
+        "shipment_id": "shp_da53588772c44de69ddde44f963372b2", "time_in_transit":
+        {"percentile_50": 1, "percentile_75": 1, "percentile_85": 2, "percentile_90":
+        2, "percentile_95": 2, "percentile_97": 3, "percentile_99": 6}, "updated_at":
+        "2022-07-28T20:59:07Z"}, {"carrier": "USPS", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e",
+        "created_at": "2022-07-28T20:59:07Z", "currency": "USD", "delivery_date":
+        null, "delivery_date_guaranteed": false, "delivery_days": 2, "est_delivery_days":
+        2, "id": "rate_564c9204fec24873af1789e1fb471d83", "list_currency": "USD",
+        "list_rate": 7.22, "mode": "test", "object": "Rate", "rate": 7.22, "retail_currency":
+        "USD", "retail_rate": 7.22, "service": "ParcelSelect", "shipment_id": "shp_da53588772c44de69ddde44f963372b2",
+        "time_in_transit": {"percentile_50": 2, "percentile_75": 3, "percentile_85":
+        3, "percentile_90": 4, "percentile_95": 5, "percentile_97": 5, "percentile_99":
+        8}, "updated_at": "2022-07-28T20:59:07Z"}, {"carrier": "USPS", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "created_at": "2022-07-28T20:59:07Z",
+        "currency": "USD", "delivery_date": null, "delivery_date_guaranteed": false,
+        "delivery_days": 2, "est_delivery_days": 2, "id": "rate_b67b4b0ade84415281017162fa1c0193",
+        "list_currency": "USD", "list_rate": 5.49, "mode": "test", "object": "Rate",
+        "rate": 5.49, "retail_currency": "USD", "retail_rate": 5.49, "service": "First",
+        "shipment_id": "shp_da53588772c44de69ddde44f963372b2", "time_in_transit":
+        {"percentile_50": 1, "percentile_75": 1, "percentile_85": 2, "percentile_90":
+        2, "percentile_95": 2, "percentile_97": 2, "percentile_99": 3}, "updated_at":
+        "2022-07-28T20:59:07Z"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -237,7 +394,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"5e2610902ec2665e8e800424f8d63eb7"
+      - W/"2c853cc8ae6827f6c959fa3cced3bdfd"
       expires:
       - '0'
       pragma:
@@ -255,20 +412,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fbb6272e170e786b9050013b0dd
+      - b0657e3f62e2f89cff2459be00381e09
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.067375'
+      - '0.194607'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207282048-993576a700-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_one_call_buy_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_one_call_buy_with_carbon_offset.yaml
@@ -28,68 +28,68 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at": "2022-07-27T22:57:28Z", "is_return": false, "messages":
+      string: '{"created_at": "2022-07-28T19:56:28Z", "is_return": false, "messages":
         [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
         "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        "9405500109361130328174", "updated_at": "2022-07-27T22:57:30Z", "batch_id":
+        "9405500109361130483644", "updated_at": "2022-07-28T19:56:29Z", "batch_id":
         null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
-        {"id": "adr_7d52570c0dff11ed8221ac1f6bc72124", "object": "Address", "created_at":
-        "2022-07-27T22:57:28+00:00", "updated_at": "2022-07-27T22:57:28+00:00", "name":
+        {"id": "adr_5e3bd3bc0eaf11eda95cac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:56:28+00:00", "updated_at": "2022-07-28T19:56:28+00:00", "name":
         "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
         "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
         "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
         "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
         null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
-        {"id": "prcl_a0023f89f2524884b2c840cf5f8707df", "object": "Parcel", "created_at":
-        "2022-07-27T22:57:28Z", "updated_at": "2022-07-27T22:57:28Z", "length": 20.2,
+        {"id": "prcl_0ca15717d74b407c9299e1c1a9cae5d4", "object": "Parcel", "created_at":
+        "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:28Z", "length": 20.2,
         "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
-        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_143f605ae71d41529c12caa95d85997b",
-        "created_at": "2022-07-27T22:57:29Z", "updated_at": "2022-07-27T22:57:30Z",
-        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-27T22:57:29Z",
+        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_a61e97eac5944ec98377b7d30987d809",
+        "created_at": "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:29Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:28Z",
         "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
-        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220727/e0a66f0000004538b15dbb30b36f42a7.png",
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/97cedb179d3a464f9a56541be3d3f9ea.png",
         "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
-        null}, "rates": [{"id": "rate_d9edb12d90a4467fa426f086f3d8d690", "object":
-        "Rate", "created_at": "2022-07-27T22:57:28Z", "updated_at": "2022-07-27T22:57:28Z",
+        null}, "rates": [{"id": "rate_737f5318c0cf42c7992e4461e273c001", "object":
+        "Rate", "created_at": "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:28Z",
         "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
         "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
         "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "carrier_account_id":
+        5, "shipment_id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "carrier_account_id":
         "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_67e98721706c4580b613a8870764cf9e",
-        "object": "Rate", "created_at": "2022-07-27T22:57:28Z", "updated_at": "2022-07-27T22:57:28Z",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_f72e4e510a1e405bb2e61dc5daff2a9d",
+        "object": "Rate", "created_at": "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:28Z",
         "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
         "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
         "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "carrier_account_id":
+        2, "shipment_id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "carrier_account_id":
         "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_a5fc2cfed1fd47fa827b87f972194934",
-        "object": "Rate", "created_at": "2022-07-27T22:57:28Z", "updated_at": "2022-07-27T22:57:28Z",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_e56795c2d4fc4e3d8227cf8a8a7970ac",
+        "object": "Rate", "created_at": "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:28Z",
         "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
         "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
         "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "carrier_account_id":
+        null, "shipment_id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "carrier_account_id":
         "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
         "grams": 154, "price": "0.11", "currency": "USD"}}], "refund_status": null,
-        "scan_form": null, "selected_rate": {"id": "rate_67e98721706c4580b613a8870764cf9e",
-        "object": "Rate", "created_at": "2022-07-27T22:57:29Z", "updated_at": "2022-07-27T22:57:29Z",
+        "scan_form": null, "selected_rate": {"id": "rate_f72e4e510a1e405bb2e61dc5daff2a9d",
+        "object": "Rate", "created_at": "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:28Z",
         "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
         "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
         "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_5958684993364cb688f4bbf035ef57ea",
-        "object": "Tracker", "mode": "test", "tracking_code": "9405500109361130328174",
-        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-27T22:57:30Z",
-        "updated_at": "2022-07-27T22:57:30Z", "signed_by": null, "weight": null, "est_delivery_date":
-        null, "shipment_id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "carrier": "USPS",
+        2, "shipment_id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_ffe12cac5ad74d3ca1b14ac302e8a2c0",
+        "object": "Tracker", "mode": "test", "tracking_code": "9405500109361130483644",
+        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-28T19:56:29Z",
+        "updated_at": "2022-07-28T19:56:29Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "carrier": "USPS",
         "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
-        "https://track.easypost.com/djE6dHJrXzU5NTg2ODQ5OTMzNjRjYjY4OGY0YmJmMDM1ZWY1N2Vh"},
-        "to_address": {"id": "adr_7d505f8d0dff11edb563ac1f6bc7b362", "object": "Address",
-        "created_at": "2022-07-27T22:57:28+00:00", "updated_at": "2022-07-27T22:57:29+00:00",
+        "https://track.easypost.com/djE6dHJrX2ZmZTEyY2FjNWFkNzRkM2NhMWIxNGFjMzAyZThhMmMw"},
+        "to_address": {"id": "adr_5e39a11f0eaf11eda95bac1f6b0a0d1e", "object": "Address",
+        "created_at": "2022-07-28T19:56:28+00:00", "updated_at": "2022-07-28T19:56:28+00:00",
         "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
         "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
         "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
@@ -97,15 +97,15 @@ interactions:
         null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
         [], "details": null}, "delivery": {"success": true, "errors": [], "details":
         {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
-        "usps_zone": 4, "return_address": {"id": "adr_7d52570c0dff11ed8221ac1f6bc72124",
-        "object": "Address", "created_at": "2022-07-27T22:57:28+00:00", "updated_at":
-        "2022-07-27T22:57:28+00:00", "name": "EasyPost", "company": null, "street1":
+        "usps_zone": 4, "return_address": {"id": "adr_5e3bd3bc0eaf11eda95cac1f6b0a0d1e",
+        "object": "Address", "created_at": "2022-07-28T19:56:28+00:00", "updated_at":
+        "2022-07-28T19:56:28+00:00", "name": "EasyPost", "company": null, "street1":
         "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
         "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
         "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
         null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
-        "buyer_address": {"id": "adr_7d505f8d0dff11edb563ac1f6bc7b362", "object":
-        "Address", "created_at": "2022-07-27T22:57:28+00:00", "updated_at": "2022-07-27T22:57:29+00:00",
+        "buyer_address": {"id": "adr_5e39a11f0eaf11eda95bac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-28T19:56:28+00:00", "updated_at": "2022-07-28T19:56:28+00:00",
         "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
         "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
         "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
@@ -117,7 +117,7 @@ interactions:
         "charged": true, "refunded": false}, {"object": "Fee", "type": "PostageFee",
         "amount": "9.82000", "charged": true, "refunded": false}, {"object": "Fee",
         "type": "CarbonOffsetFee", "amount": "0.11000", "charged": true, "refunded":
-        false}], "id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "object": "Shipment"}'
+        false}], "id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -126,11 +126,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"d77e8ead850f1d7c70a2916357fdd870"
+      - W/"7510d7f0ed7bfa19825c3b4907072bfb"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_e5be593e9b8d424cbbbb67156a7649b4
+      - /api/v2/shipments/shp_bbb1e7fda63845a7a695855e4be3ded7
       pragma:
       - no-cache
       referrer-policy:
@@ -146,20 +146,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - bdfa366862e1c2d8ff22c19d005b5ff1
+      - 3843703f62e2e9ebff23e2dc0034381d
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq 403f17ff97
-      - extlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '1.439606'
+      - '1.260083'
       x-version-label:
-      - easypost-202207272153-717cb56530-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_one_call_buy_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_one_call_buy_with_carbon_offset.yaml
@@ -7,7 +7,7 @@ interactions:
       "city": "San Francisco", "state": "CA", "zip": "94104", "country": "US", "phone":
       "4153334445", "email": "support@easypost.com"}, "parcel": {"length": "20.2",
       "width": "10.9", "height": "5", "weight": "65.9"}, "service": "Priority", "carrier_accounts":
-      ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier": "USPS"}, "carbon_offset":
+      "ca_b25657e9896e4d63ac8151ac346ac41e", "carrier": "USPS"}, "carbon_offset":
       true}'
     headers:
       Accept:
@@ -17,7 +17,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '653'
+      - '651'
       Content-Type:
       - application/json
       authorization:
@@ -28,68 +28,68 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at": "2022-07-28T19:56:28Z", "is_return": false, "messages":
+      string: '{"created_at": "2022-07-29T21:58:04Z", "is_return": false, "messages":
         [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
         "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        "9405500109361130483644", "updated_at": "2022-07-28T19:56:29Z", "batch_id":
+        "9405500109361130689039", "updated_at": "2022-07-29T21:58:05Z", "batch_id":
         null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
-        {"id": "adr_5e3bd3bc0eaf11eda95cac1f6b0a0d1e", "object": "Address", "created_at":
-        "2022-07-28T19:56:28+00:00", "updated_at": "2022-07-28T19:56:28+00:00", "name":
+        {"id": "adr_856412210f8911edb33cac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-29T21:58:04+00:00", "updated_at": "2022-07-29T21:58:04+00:00", "name":
         "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
         "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
         "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
         "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
         null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
-        {"id": "prcl_0ca15717d74b407c9299e1c1a9cae5d4", "object": "Parcel", "created_at":
-        "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:28Z", "length": 20.2,
+        {"id": "prcl_56d5c42248bf4b849b8fe42f1eafca38", "object": "Parcel", "created_at":
+        "2022-07-29T21:58:04Z", "updated_at": "2022-07-29T21:58:04Z", "length": 20.2,
         "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
-        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_a61e97eac5944ec98377b7d30987d809",
-        "created_at": "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:29Z",
-        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:28Z",
+        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_4eccf7b8bfb34d51a6068c4ed3b9a0c0",
+        "created_at": "2022-07-29T21:58:04Z", "updated_at": "2022-07-29T21:58:05Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-29T21:58:04Z",
         "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
-        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/97cedb179d3a464f9a56541be3d3f9ea.png",
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/d5b8e4a06d0a418ba52a3517ac3f7a1b.png",
         "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
-        null}, "rates": [{"id": "rate_737f5318c0cf42c7992e4461e273c001", "object":
-        "Rate", "created_at": "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:28Z",
-        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
-        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
-        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_f72e4e510a1e405bb2e61dc5daff2a9d",
-        "object": "Rate", "created_at": "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:28Z",
-        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
-        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
-        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_e56795c2d4fc4e3d8227cf8a8a7970ac",
-        "object": "Rate", "created_at": "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:28Z",
+        null}, "rates": [{"id": "rate_e316cfa35bf946b3a5624488897cab73", "object":
+        "Rate", "created_at": "2022-07-29T21:58:04Z", "updated_at": "2022-07-29T21:58:04Z",
         "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
         "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
         "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "carrier_account_id":
+        null, "shipment_id": "shp_9ff69e74cb7942b8bb3de657fef36fdb", "carrier_account_id":
         "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}], "refund_status": null,
-        "scan_form": null, "selected_rate": {"id": "rate_f72e4e510a1e405bb2e61dc5daff2a9d",
-        "object": "Rate", "created_at": "2022-07-28T19:56:28Z", "updated_at": "2022-07-28T19:56:28Z",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_9bc875172eda4d5ab4da1ead63f4cd9e",
+        "object": "Rate", "created_at": "2022-07-29T21:58:04Z", "updated_at": "2022-07-29T21:58:04Z",
         "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
         "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
         "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_ffe12cac5ad74d3ca1b14ac302e8a2c0",
-        "object": "Tracker", "mode": "test", "tracking_code": "9405500109361130483644",
-        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-28T19:56:29Z",
-        "updated_at": "2022-07-28T19:56:29Z", "signed_by": null, "weight": null, "est_delivery_date":
-        null, "shipment_id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "carrier": "USPS",
+        2, "shipment_id": "shp_9ff69e74cb7942b8bb3de657fef36fdb", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_db2f8e117335413fac5e35c6d87c0b74",
+        "object": "Rate", "created_at": "2022-07-29T21:58:04Z", "updated_at": "2022-07-29T21:58:04Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_9ff69e74cb7942b8bb3de657fef36fdb", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}], "refund_status": null,
+        "scan_form": null, "selected_rate": {"id": "rate_9bc875172eda4d5ab4da1ead63f4cd9e",
+        "object": "Rate", "created_at": "2022-07-29T21:58:04Z", "updated_at": "2022-07-29T21:58:04Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_9ff69e74cb7942b8bb3de657fef36fdb", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_64c6d709bc8546d3a26d3508ff9aeb85",
+        "object": "Tracker", "mode": "test", "tracking_code": "9405500109361130689039",
+        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-29T21:58:05Z",
+        "updated_at": "2022-07-29T21:58:05Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_9ff69e74cb7942b8bb3de657fef36fdb", "carrier": "USPS",
         "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
-        "https://track.easypost.com/djE6dHJrX2ZmZTEyY2FjNWFkNzRkM2NhMWIxNGFjMzAyZThhMmMw"},
-        "to_address": {"id": "adr_5e39a11f0eaf11eda95bac1f6b0a0d1e", "object": "Address",
-        "created_at": "2022-07-28T19:56:28+00:00", "updated_at": "2022-07-28T19:56:28+00:00",
+        "https://track.easypost.com/djE6dHJrXzY0YzZkNzA5YmM4NTQ2ZDNhMjZkMzUwOGZmOWFlYjg1"},
+        "to_address": {"id": "adr_8561e6b30f8911ed8596ac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-29T21:58:04+00:00", "updated_at": "2022-07-29T21:58:04+00:00",
         "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
         "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
         "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
@@ -97,15 +97,15 @@ interactions:
         null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
         [], "details": null}, "delivery": {"success": true, "errors": [], "details":
         {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
-        "usps_zone": 4, "return_address": {"id": "adr_5e3bd3bc0eaf11eda95cac1f6b0a0d1e",
-        "object": "Address", "created_at": "2022-07-28T19:56:28+00:00", "updated_at":
-        "2022-07-28T19:56:28+00:00", "name": "EasyPost", "company": null, "street1":
+        "usps_zone": 4, "return_address": {"id": "adr_856412210f8911edb33cac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-29T21:58:04+00:00", "updated_at":
+        "2022-07-29T21:58:04+00:00", "name": "EasyPost", "company": null, "street1":
         "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
         "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
         "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
         null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
-        "buyer_address": {"id": "adr_5e39a11f0eaf11eda95bac1f6b0a0d1e", "object":
-        "Address", "created_at": "2022-07-28T19:56:28+00:00", "updated_at": "2022-07-28T19:56:28+00:00",
+        "buyer_address": {"id": "adr_8561e6b30f8911ed8596ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-29T21:58:04+00:00", "updated_at": "2022-07-29T21:58:04+00:00",
         "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
         "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
         "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
@@ -117,7 +117,7 @@ interactions:
         "charged": true, "refunded": false}, {"object": "Fee", "type": "PostageFee",
         "amount": "9.82000", "charged": true, "refunded": false}, {"object": "Fee",
         "type": "CarbonOffsetFee", "amount": "0.11000", "charged": true, "refunded":
-        false}], "id": "shp_bbb1e7fda63845a7a695855e4be3ded7", "object": "Shipment"}'
+        false}], "id": "shp_9ff69e74cb7942b8bb3de657fef36fdb", "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -126,11 +126,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"7510d7f0ed7bfa19825c3b4907072bfb"
+      - W/"4e3b47e2abeff4f6bf7280ee135ca47f"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_bbb1e7fda63845a7a695855e4be3ded7
+      - /api/v2/shipments/shp_9ff69e74cb7942b8bb3de657fef36fdb
       pragma:
       - no-cache
       referrer-policy:
@@ -146,7 +146,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 3843703f62e2e9ebff23e2dc0034381d
+      - 3b422b0062e457ece788d9050010e405
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -154,13 +154,12 @@ interactions:
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq 403f17ff97
-      - intlb2wdc 403f17ff97
-      - extlb4wdc 403f17ff97
+      - intlb2nuq 403f17ff97
+      - extlb1nuq 403f17ff97
       x-runtime:
-      - '1.260083'
+      - '1.220486'
       x-version-label:
-      - easypost-202207272329-7f74c9e58c-master
+      - easypost-202207291722-ecd5579616-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_one_call_buy_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_one_call_buy_with_carbon_offset.yaml
@@ -1,0 +1,168 @@
+interactions:
+- request:
+    body: '{"shipment": {"to_address": {"name": "Dr. Steve Brule", "street1": "179
+      N Harbor Dr", "city": "Redondo Beach", "state": "CA", "zip": "90277", "country":
+      "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com"}, "from_address":
+      {"name": "EasyPost", "street1": "417 Montgomery Street", "street2": "5th Floor",
+      "city": "San Francisco", "state": "CA", "zip": "94104", "country": "US", "phone":
+      "4153334445", "email": "support@easypost.com"}, "parcel": {"length": "20.2",
+      "width": "10.9", "height": "5", "weight": "65.9"}, "service": "Priority", "carrier_accounts":
+      ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier": "USPS"}, "carbon_offset":
+      true}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '653'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/shipments
+  response:
+    body:
+      string: '{"created_at": "2022-07-27T22:57:28Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9405500109361130328174", "updated_at": "2022-07-27T22:57:30Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_7d52570c0dff11ed8221ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-27T22:57:28+00:00", "updated_at": "2022-07-27T22:57:28+00:00", "name":
+        "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
+        "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
+        "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
+        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
+        {"id": "prcl_a0023f89f2524884b2c840cf5f8707df", "object": "Parcel", "created_at":
+        "2022-07-27T22:57:28Z", "updated_at": "2022-07-27T22:57:28Z", "length": 20.2,
+        "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
+        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_143f605ae71d41529c12caa95d85997b",
+        "created_at": "2022-07-27T22:57:29Z", "updated_at": "2022-07-27T22:57:30Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-27T22:57:29Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220727/e0a66f0000004538b15dbb30b36f42a7.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_d9edb12d90a4467fa426f086f3d8d690", "object":
+        "Rate", "created_at": "2022-07-27T22:57:28Z", "updated_at": "2022-07-27T22:57:28Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_67e98721706c4580b613a8870764cf9e",
+        "object": "Rate", "created_at": "2022-07-27T22:57:28Z", "updated_at": "2022-07-27T22:57:28Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_a5fc2cfed1fd47fa827b87f972194934",
+        "object": "Rate", "created_at": "2022-07-27T22:57:28Z", "updated_at": "2022-07-27T22:57:28Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}], "refund_status": null,
+        "scan_form": null, "selected_rate": {"id": "rate_67e98721706c4580b613a8870764cf9e",
+        "object": "Rate", "created_at": "2022-07-27T22:57:29Z", "updated_at": "2022-07-27T22:57:29Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_5958684993364cb688f4bbf035ef57ea",
+        "object": "Tracker", "mode": "test", "tracking_code": "9405500109361130328174",
+        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-27T22:57:30Z",
+        "updated_at": "2022-07-27T22:57:30Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzU5NTg2ODQ5OTMzNjRjYjY4OGY0YmJmMDM1ZWY1N2Vh"},
+        "to_address": {"id": "adr_7d505f8d0dff11edb563ac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-27T22:57:28+00:00", "updated_at": "2022-07-27T22:57:29+00:00",
+        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
+        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
+        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
+        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
+        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
+        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
+        "usps_zone": 4, "return_address": {"id": "adr_7d52570c0dff11ed8221ac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-27T22:57:28+00:00", "updated_at":
+        "2022-07-27T22:57:28+00:00", "name": "EasyPost", "company": null, "street1":
+        "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
+        "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
+        "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
+        null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
+        "buyer_address": {"id": "adr_7d505f8d0dff11edb563ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-27T22:57:28+00:00", "updated_at": "2022-07-27T22:57:29+00:00",
+        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
+        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
+        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
+        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
+        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
+        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
+        "forms": [], "fees": [{"object": "Fee", "type": "LabelFee", "amount": "0.00000",
+        "charged": true, "refunded": false}, {"object": "Fee", "type": "PostageFee",
+        "amount": "9.82000", "charged": true, "refunded": false}, {"object": "Fee",
+        "type": "CarbonOffsetFee", "amount": "0.11000", "charged": true, "refunded":
+        false}], "id": "shp_e5be593e9b8d424cbbbb67156a7649b4", "object": "Shipment"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '6838'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"d77e8ead850f1d7c70a2916357fdd870"
+      expires:
+      - '0'
+      location:
+      - /api/v2/shipments/shp_e5be593e9b8d424cbbbb67156a7649b4
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - bdfa366862e1c2d8ff22c19d005b5ff1
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb1nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq 403f17ff97
+      - extlb2nuq 403f17ff97
+      x-runtime:
+      - '1.439606'
+      x-version-label:
+      - easypost-202207272153-717cb56530-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/cassettes/test_shipment_refund.yaml
+++ b/tests/cassettes/test_shipment_refund.yaml
@@ -7,7 +7,7 @@ interactions:
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
       "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}, "service":
       "First", "carrier_accounts": ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier":
-      "USPS"}}'
+      "USPS"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +16,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '577'
+      - '601'
       Content-Type:
       - application/json
       authorization:
@@ -27,28 +27,109 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:19Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768914","updated_at":"2022-05-04T20:26:20Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_74cb3d71cbe811ec8ccdac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:19+00:00","updated_at":"2022-05-04T20:26:19+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_585c42ab88874ce39d652787bfa372f0","object":"Parcel","created_at":"2022-05-04T20:26:19Z","updated_at":"2022-05-04T20:26:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_5c6ac6830e4e4dd4a18b328c5c84ce5f","created_at":"2022-05-04T20:26:20Z","updated_at":"2022-05-04T20:26:20Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:20Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/bda38c13fb994fb392114ba1387d6b90.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_2fece6bc1e1540f58331bd5b900ce1a1","object":"Rate","created_at":"2022-05-04T20:26:19Z","updated_at":"2022-05-04T20:26:19Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_f5a226e23cfb43bfaea5bd7a62552b02","object":"Rate","created_at":"2022-05-04T20:26:19Z","updated_at":"2022-05-04T20:26:19Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_f8256a7116f8437b8afe69d84ff8661f","object":"Rate","created_at":"2022-05-04T20:26:19Z","updated_at":"2022-05-04T20:26:19Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_06832fc91adc480dabf3ee173714f22c","object":"Rate","created_at":"2022-05-04T20:26:19Z","updated_at":"2022-05-04T20:26:19Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_06832fc91adc480dabf3ee173714f22c","object":"Rate","created_at":"2022-05-04T20:26:20Z","updated_at":"2022-05-04T20:26:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_65d28aa48508454c90161af51b62fe8b","object":"Tracker","mode":"test","tracking_code":"9400100109361117768914","status":"unknown","status_detail":"unknown","created_at":"2022-05-04T20:26:20Z","updated_at":"2022-05-04T20:26:20Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzY1ZDI4YWE0ODUwODQ1NGM5MDE2MWFmNTFiNjJmZThi"},"to_address":{"id":"adr_74c942b6cbe811ec956aac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:19+00:00","updated_at":"2022-05-04T20:26:19+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_74cb3d71cbe811ec8ccdac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:19+00:00","updated_at":"2022-05-04T20:26:19+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_74c942b6cbe811ec956aac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:19+00:00","updated_at":"2022-05-04T20:26:19+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_6fb386eba55a4e0596e0193bd63afc61","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:19Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130483610", "updated_at": "2022-07-28T19:56:19Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_58cc0df20eaf11eda028ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:19+00:00", "updated_at": "2022-07-28T19:56:19+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_a35dc117e7bb4032a73705bb3553b153",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_d28d48b893ca40ff8bb9ccf00cc8ccb3",
+        "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:19Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/cc8129ee963743bc995afddb0ca7957a.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_8a92ef6aede04fecac35d7ab3422d1c6", "object":
+        "Rate", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_d509905bab4e433780ffa09d8f6a0573", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_2c1f903c8fa64263a8bda53df8a52ac5",
+        "object": "Rate", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_d509905bab4e433780ffa09d8f6a0573", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_3d9ffa1570454e42a6710f4ef63ade92",
+        "object": "Rate", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_d509905bab4e433780ffa09d8f6a0573", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_ffe2dcad51284049b62e6f46d2978eb4",
+        "object": "Rate", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_d509905bab4e433780ffa09d8f6a0573", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": {"id": "rate_ffe2dcad51284049b62e6f46d2978eb4",
+        "object": "Rate", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_d509905bab4e433780ffa09d8f6a0573", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_7ecb4f2af22341e799de1a61440dd7ff", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483610", "status": "unknown",
+        "status_detail": "unknown", "created_at": "2022-07-28T19:56:19Z", "updated_at":
+        "2022-07-28T19:56:19Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_d509905bab4e433780ffa09d8f6a0573", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzdlY2I0ZjJhZjIyMzQxZTc5OWRlMWE2MTQ0MGRkN2Zm"},
+        "to_address": {"id": "adr_58ca1b6f0eaf11eda027ac1f6bc72124", "object": "Address",
+        "created_at": "2022-07-28T19:56:19+00:00", "updated_at": "2022-07-28T19:56:19+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_58cc0df20eaf11eda028ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:19+00:00", "updated_at": "2022-07-28T19:56:19+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_58ca1b6f0eaf11eda027ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T19:56:19+00:00", "updated_at": "2022-07-28T19:56:19+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_d509905bab4e433780ffa09d8f6a0573", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6826'
+      - '6956'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"932eb2db9aed8369edc75f2df5749154"
+      - W/"82132075059d3067e19fb55fcf9fa59d"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_6fb386eba55a4e0596e0193bd63afc61
+      - /api/v2/shipments/shp_d509905bab4e433780ffa09d8f6a0573
       pragma:
       - no-cache
       referrer-policy:
@@ -64,20 +145,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb96272e16be786b8e70013af84
+      - 3843703c62e2e9e2ff23e2ba003435f8
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb4nuq
+      - bigweb6nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '1.044032'
+      - '0.893773'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -101,32 +183,122 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_6fb386eba55a4e0596e0193bd63afc61/refund
+    uri: https://api.easypost.com/v2/shipments/shp_d509905bab4e433780ffa09d8f6a0573/refund
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:19Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117768914","updated_at":"2022-05-04T20:26:20Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_74cb3d71cbe811ec8ccdac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:19+00:00","updated_at":"2022-05-04T20:26:19+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_585c42ab88874ce39d652787bfa372f0","object":"Parcel","created_at":"2022-05-04T20:26:19Z","updated_at":"2022-05-04T20:26:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_5c6ac6830e4e4dd4a18b328c5c84ce5f","created_at":"2022-05-04T20:26:20Z","updated_at":"2022-05-04T20:26:20Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-04T20:26:20Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220504/bda38c13fb994fb392114ba1387d6b90.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_2fece6bc1e1540f58331bd5b900ce1a1","object":"Rate","created_at":"2022-05-04T20:26:19Z","updated_at":"2022-05-04T20:26:19Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_f5a226e23cfb43bfaea5bd7a62552b02","object":"Rate","created_at":"2022-05-04T20:26:19Z","updated_at":"2022-05-04T20:26:19Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_f8256a7116f8437b8afe69d84ff8661f","object":"Rate","created_at":"2022-05-04T20:26:19Z","updated_at":"2022-05-04T20:26:19Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_06832fc91adc480dabf3ee173714f22c","object":"Rate","created_at":"2022-05-04T20:26:19Z","updated_at":"2022-05-04T20:26:19Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":"submitted","scan_form":null,"selected_rate":{"id":"rate_06832fc91adc480dabf3ee173714f22c","object":"Rate","created_at":"2022-05-04T20:26:20Z","updated_at":"2022-05-04T20:26:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},"tracker":{"id":"trk_65d28aa48508454c90161af51b62fe8b","object":"Tracker","mode":"test","tracking_code":"9400100109361117768914","status":"pre_transit","status_detail":"status_update","created_at":"2022-05-04T20:26:20Z","updated_at":"2022-05-04T20:26:20Z","signed_by":null,"weight":null,"est_delivery_date":"2022-05-04T20:26:20Z","shipment_id":"shp_6fb386eba55a4e0596e0193bd63afc61","carrier":"USPS","tracking_details":[{"object":"TrackingDetail","message":"Pre-Shipment
-        Info Sent to USPS","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-04T20:26:20Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":null,"state":null,"country":null,"zip":null}},{"object":"TrackingDetail","message":"Shipping
-        Label Created","description":null,"status":"pre_transit","status_detail":"status_update","datetime":"2022-04-05T09:03:20Z","source":"USPS","carrier_code":null,"tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"}}],"fees":[],"carrier_detail":{"object":"CarrierDetail","service":"First-Class
-        Package Service","container_type":null,"est_delivery_date_local":null,"est_delivery_time_local":null,"origin_location":"HOUSTON
-        TX, 77001","origin_tracking_location":{"object":"TrackingLocation","city":"HOUSTON","state":"TX","country":null,"zip":"77063"},"destination_location":"CHARLESTON
-        SC, 29401","destination_tracking_location":null,"guaranteed_delivery_date":null,"alternate_identifier":null,"initial_delivery_attempt":null},"public_url":"https://track.easypost.com/djE6dHJrXzY1ZDI4YWE0ODUwODQ1NGM5MDE2MWFmNTFiNjJmZThi"},"to_address":{"id":"adr_74c942b6cbe811ec956aac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:19+00:00","updated_at":"2022-05-04T20:26:19+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_74cb3d71cbe811ec8ccdac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:19+00:00","updated_at":"2022-05-04T20:26:19+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_74c942b6cbe811ec956aac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:19+00:00","updated_at":"2022-05-04T20:26:19+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_6fb386eba55a4e0596e0193bd63afc61","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:19Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9400100109361130483610", "updated_at": "2022-07-28T19:56:20Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_58cc0df20eaf11eda028ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:19+00:00", "updated_at": "2022-07-28T19:56:19+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_a35dc117e7bb4032a73705bb3553b153",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_d28d48b893ca40ff8bb9ccf00cc8ccb3",
+        "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T19:56:19Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/cc8129ee963743bc995afddb0ca7957a.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_8a92ef6aede04fecac35d7ab3422d1c6", "object":
+        "Rate", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_d509905bab4e433780ffa09d8f6a0573", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_2c1f903c8fa64263a8bda53df8a52ac5",
+        "object": "Rate", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_d509905bab4e433780ffa09d8f6a0573", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_3d9ffa1570454e42a6710f4ef63ade92",
+        "object": "Rate", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_d509905bab4e433780ffa09d8f6a0573", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_ffe2dcad51284049b62e6f46d2978eb4",
+        "object": "Rate", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_d509905bab4e433780ffa09d8f6a0573", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": "submitted", "scan_form": null, "selected_rate": {"id": "rate_ffe2dcad51284049b62e6f46d2978eb4",
+        "object": "Rate", "created_at": "2022-07-28T19:56:19Z", "updated_at": "2022-07-28T19:56:19Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_d509905bab4e433780ffa09d8f6a0573", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        "tracker": {"id": "trk_7ecb4f2af22341e799de1a61440dd7ff", "object": "Tracker",
+        "mode": "test", "tracking_code": "9400100109361130483610", "status": "pre_transit",
+        "status_detail": "status_update", "created_at": "2022-07-28T19:56:19Z", "updated_at":
+        "2022-07-28T19:56:19Z", "signed_by": null, "weight": null, "est_delivery_date":
+        "2022-07-28T19:56:19Z", "shipment_id": "shp_d509905bab4e433780ffa09d8f6a0573",
+        "carrier": "USPS", "tracking_details": [{"object": "TrackingDetail", "message":
+        "Pre-Shipment Info Sent to USPS", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-28T19:56:19Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": null, "state": null, "country": null, "zip": null}}, {"object": "TrackingDetail",
+        "message": "Shipping Label Created", "description": null, "status": "pre_transit",
+        "status_detail": "status_update", "datetime": "2022-06-29T08:33:19Z", "source":
+        "USPS", "carrier_code": null, "tracking_location": {"object": "TrackingLocation",
+        "city": "HOUSTON", "state": "TX", "country": null, "zip": "77063"}}], "fees":
+        [], "carrier_detail": {"object": "CarrierDetail", "service": "First-Class
+        Package Service", "container_type": null, "est_delivery_date_local": null,
+        "est_delivery_time_local": null, "origin_location": "HOUSTON TX, 77001", "origin_tracking_location":
+        {"object": "TrackingLocation", "city": "HOUSTON", "state": "TX", "country":
+        null, "zip": "77063"}, "destination_location": "CHARLESTON SC, 29401", "destination_tracking_location":
+        null, "guaranteed_delivery_date": null, "alternate_identifier": null, "initial_delivery_attempt":
+        null}, "public_url": "https://track.easypost.com/djE6dHJrXzdlY2I0ZjJhZjIyMzQxZTc5OWRlMWE2MTQ0MGRkN2Zm"},
+        "to_address": {"id": "adr_58ca1b6f0eaf11eda027ac1f6bc72124", "object": "Address",
+        "created_at": "2022-07-28T19:56:19+00:00", "updated_at": "2022-07-28T19:56:19+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "usps_zone": 1, "return_address":
+        {"id": "adr_58cc0df20eaf11eda028ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:19+00:00", "updated_at": "2022-07-28T19:56:19+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "buyer_address": {"id": "adr_58ca1b6f0eaf11eda027ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T19:56:19+00:00", "updated_at": "2022-07-28T19:56:19+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": null, "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": true, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {"zip4": {"success": true, "errors": [], "details": null}, "delivery": {"success":
+        true, "errors": [], "details": {"latitude": 37.77551, "longitude": -122.39697,
+        "time_zone": "America/Los_Angeles"}}}}, "forms": [], "fees": [{"object": "Fee",
+        "type": "LabelFee", "amount": "0.00000", "charged": true, "refunded": false},
+        {"object": "Fee", "type": "PostageFee", "amount": "5.49000", "charged": true,
+        "refunded": false}], "id": "shp_d509905bab4e433780ffa09d8f6a0573", "object":
+        "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '7967'
+      - '8097'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"aafe750fd2ec940ac4a576482f3ec92e"
+      - W/"1a42f207cfeb64878daecd5318485c8f"
       expires:
       - '0'
       pragma:
@@ -144,20 +316,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fb96272e16ce786b8e70013afe4
+      - 3843703c62e2e9e3ff23e2ba0034363d
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb8nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.140366'
+      - '0.140390'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_regenerate_rates.yaml
+++ b/tests/cassettes/test_shipment_regenerate_rates.yaml
@@ -11,7 +11,7 @@ interactions:
       "none", "non_delivery_option": "return", "customs_items": [{"description": "Sweet
       shirts", "quantity": 2, "weight": 11, "value": 23, "hs_tariff_number": "654321",
       "origin_country": "US"}]}, "options": {"label_format": "PNG", "invoice_number":
-      "123"}, "reference": "123"}}'
+      "123"}, "reference": "123"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -20,7 +20,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '932'
+      - '956'
       Content-Type:
       - application/json
       authorization:
@@ -31,30 +31,94 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:14Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:14Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_29462dd0da6a4d45b8599eca89b76d0a","object":"CustomsInfo","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_8307bd59062c4fd9b655fbea38c330d7","object":"CustomsItem","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_71a18c60cbe811ec94d1ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_45543abcb3a744ac8bee6eca41983844","object":"Parcel","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_6bccfa93927a4aed90e6c03dfcff6688","object":"Rate","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_682d94f490154a5085ae72f5893feb45","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_15ea015a79a34b2ca16575110049682b","object":"Rate","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_682d94f490154a5085ae72f5893feb45","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_7c1c40e8094d4129abaadde6a875eef1","object":"Rate","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_682d94f490154a5085ae72f5893feb45","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_c5a139c7747c4af1aa64446cdd82c9b1","object":"Rate","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_682d94f490154a5085ae72f5893feb45","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_719fc115cbe811ec94d0ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_71a18c60cbe811ec94d1ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_719fc115cbe811ec94d0ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:14+00:00","updated_at":"2022-05-04T20:26:14+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_682d94f490154a5085ae72f5893feb45","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:12Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"label_format": "PNG", "invoice_number": "123",
+        "currency": "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference":
+        "123", "status": "unknown", "tracking_code": null, "updated_at": "2022-07-28T19:56:12Z",
+        "batch_id": null, "batch_status": null, "batch_message": null, "customs_info":
+        {"id": "cstinfo_919e4c0d8dcf4869a9fe4dbafaf00b8d", "object": "CustomsInfo",
+        "created_at": "2022-07-28T19:56:12Z", "updated_at": "2022-07-28T19:56:12Z",
+        "contents_explanation": "", "contents_type": "merchandise", "customs_certify":
+        true, "customs_signer": "Steve Brule", "eel_pfc": "NOEEI 30.37(a)", "non_delivery_option":
+        "return", "restriction_comments": null, "restriction_type": "none", "mode":
+        "test", "declaration": null, "customs_items": [{"id": "cstitem_2c777f6bd9e74c7090f82d2fb88ae51b",
+        "object": "CustomsItem", "created_at": "2022-07-28T19:56:12Z", "updated_at":
+        "2022-07-28T19:56:12Z", "description": "Sweet shirts", "hs_tariff_number":
+        "654321", "origin_country": "US", "quantity": 2, "value": "23.0", "weight":
+        11.0, "code": null, "mode": "test", "manufacturer": null, "currency": null,
+        "eccn": null, "printed_commodity_identifier": null}]}, "from_address": {"id":
+        "adr_55254e9f0eaf11ed9bd5ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:12+00:00", "updated_at": "2022-07-28T19:56:12+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_5a13a7e5d41b4b48bba2058f7e358e55",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:12Z", "updated_at": "2022-07-28T19:56:12Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_4272d79e01964d00af8fa01631d2d947",
+        "object": "Rate", "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_dc25fb97e0704c889d752b71ca741440", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_616e863d120840379c188d1a0709d007", "object": "Rate", "created_at":
+        "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_dc25fb97e0704c889d752b71ca741440", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_0c68207e49cd4d2ab559e0f6697850f2", "object": "Rate", "created_at":
+        "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_dc25fb97e0704c889d752b71ca741440", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_06340d20bd264fb4ac0e376cfeb6b5b4", "object": "Rate", "created_at":
+        "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z", "mode": "test",
+        "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22", "currency":
+        "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate": "7.22",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_dc25fb97e0704c889d752b71ca741440", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_55230fb60eaf11ed8d45ac1f6bc7bdc6", "object":
+        "Address", "created_at": "2022-07-28T19:56:12+00:00", "updated_at": "2022-07-28T19:56:12+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_55254e9f0eaf11ed9bd5ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-28T19:56:12+00:00", "updated_at":
+        "2022-07-28T19:56:12+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_55230fb60eaf11ed8d45ac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-28T19:56:12+00:00", "updated_at": "2022-07-28T19:56:12+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_dc25fb97e0704c889d752b71ca741440",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '5563'
+      - '5667'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"66bd9fe55273163358c84e1d5ad2a501"
+      - W/"63335867f7d6ffda7f9efea1198b718f"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_682d94f490154a5085ae72f5893feb45
+      - /api/v2/shipments/shp_dc25fb97e0704c889d752b71ca741440
       pragma:
       - no-cache
       referrer-policy:
@@ -70,27 +134,28 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fbb6272e166e786b8e40013ae0e
+      - 3843704262e2e9dcff23e2a00034344e
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb1nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.275659'
+      - '0.261246'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: '{}'
+    body: '{"carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -99,7 +164,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2'
+      - '24'
       Content-Type:
       - application/json
       authorization:
@@ -107,19 +172,46 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_682d94f490154a5085ae72f5893feb45/rerate
+    uri: https://api.easypost.com/v2/shipments/shp_dc25fb97e0704c889d752b71ca741440/rerate
   response:
     body:
-      string: '{"rates":[{"id":"rate_e433ecce74fe4d59b499bfe0fac91f54","object":"Rate","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_682d94f490154a5085ae72f5893feb45","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_20a94322a4184be5834a3d8ae02bc627","object":"Rate","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_682d94f490154a5085ae72f5893feb45","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_e5646d0915b347eb9e7da57b93fabc52","object":"Rate","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_682d94f490154a5085ae72f5893feb45","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_63e8add74410424c86eefa20408fd836","object":"Rate","created_at":"2022-05-04T20:26:14Z","updated_at":"2022-05-04T20:26:14Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_682d94f490154a5085ae72f5893feb45","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}]}'
+      string: '{"rates": [{"id": "rate_3095a0cdb7b8403dbb237e138724d249", "object":
+        "Rate", "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_dc25fb97e0704c889d752b71ca741440", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_04958562473b435eb98e15b81ec7af08",
+        "object": "Rate", "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "23.75",
+        "currency": "USD", "retail_rate": "27.40", "retail_currency": "USD", "list_rate":
+        "23.75", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_dc25fb97e0704c889d752b71ca741440", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_fbf2e4e4d22e44808e70f5fc2697d441",
+        "object": "Rate", "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_dc25fb97e0704c889d752b71ca741440", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_f14f4603a04d402184bc871cdaadbdb9",
+        "object": "Rate", "created_at": "2022-07-28T19:56:13Z", "updated_at": "2022-07-28T19:56:13Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_dc25fb97e0704c889d752b71ca741440", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}]}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '2060'
+      - '2164'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"883eeb1b8a8ba81f5895c11377e9cc03"
+      - W/"ce7d20260a41fa822ab233e2c23afe3e"
       expires:
       - '0'
       pragma:
@@ -137,20 +229,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fbb6272e166e786b8e40013ae2a
+      - 3843704262e2e9ddff23e2a00034346a
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb3nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.228379'
+      - '0.331331'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_rerate_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_rerate_with_carbon_offset.yaml
@@ -6,8 +6,8 @@ interactions:
       {"name": "EasyPost", "street1": "417 Montgomery Street", "street2": "5th Floor",
       "city": "San Francisco", "state": "CA", "zip": "94104", "country": "US", "phone":
       "4153334445", "email": "support@easypost.com"}, "parcel": {"length": "20.2",
-      "width": "10.9", "height": "5", "weight": "65.9"}, "service": "First", "carrier_accounts":
-      ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier": "USPS"}, "carbon_offset":
+      "width": "10.9", "height": "5", "weight": "65.9"}, "service": "Priority", "carrier_accounts":
+      "ca_b25657e9896e4d63ac8151ac346ac41e", "carrier": "USPS"}, "carbon_offset":
       false}'
     headers:
       Accept:
@@ -17,7 +17,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '651'
+      - '652'
       Content-Type:
       - application/json
       authorization:
@@ -28,16 +28,194 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"error": {"code": "SHIPMENT.CARRIER_ACCOUNTS.INVALID", "message":
-        "Only one carrier_account_id can be supplied when purchasing a shipment without
-        rating.", "errors": []}}'
+      string: '{"created_at": "2022-07-29T21:57:22Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9405500109361130688964", "updated_at": "2022-07-29T21:57:23Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_6c92b0f00f8911ed8010ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-29T21:57:22+00:00", "updated_at": "2022-07-29T21:57:22+00:00", "name":
+        "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
+        "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
+        "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
+        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
+        {"id": "prcl_94a95b2628b1480dabc186bb22f41d6d", "object": "Parcel", "created_at":
+        "2022-07-29T21:57:22Z", "updated_at": "2022-07-29T21:57:22Z", "length": 20.2,
+        "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
+        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_ba4a04089488468bafadcc2a8c6ebc29",
+        "created_at": "2022-07-29T21:57:22Z", "updated_at": "2022-07-29T21:57:23Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-29T21:57:22Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/1d96811f45404ed791175059b13d1588.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_2fffafa48bb44b2cabe8f747ee0d75d5", "object":
+        "Rate", "created_at": "2022-07-29T21:57:22Z", "updated_at": "2022-07-29T21:57:22Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_30aed74ae9b5408d8063e9c9b4d7780d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_8743dc9abdf247ea9bbff1c6cd2c636c",
+        "object": "Rate", "created_at": "2022-07-29T21:57:22Z", "updated_at": "2022-07-29T21:57:22Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_30aed74ae9b5408d8063e9c9b4d7780d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_d738e470f6a94b4f85a72c66ebfde5d0",
+        "object": "Rate", "created_at": "2022-07-29T21:57:22Z", "updated_at": "2022-07-29T21:57:22Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_30aed74ae9b5408d8063e9c9b4d7780d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
+        null, "selected_rate": {"id": "rate_8743dc9abdf247ea9bbff1c6cd2c636c", "object":
+        "Rate", "created_at": "2022-07-29T21:57:22Z", "updated_at": "2022-07-29T21:57:22Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_30aed74ae9b5408d8063e9c9b4d7780d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_6d2515fbcdff498b92bb5dc6eeb5dc95",
+        "object": "Tracker", "mode": "test", "tracking_code": "9405500109361130688964",
+        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-29T21:57:23Z",
+        "updated_at": "2022-07-29T21:57:23Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_30aed74ae9b5408d8063e9c9b4d7780d", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrXzZkMjUxNWZiY2RmZjQ5OGI5MmJiNWRjNmVlYjVkYzk1"},
+        "to_address": {"id": "adr_6c9051e70f8911edb5e1ac1f6b0a0d1e", "object": "Address",
+        "created_at": "2022-07-29T21:57:22+00:00", "updated_at": "2022-07-29T21:57:22+00:00",
+        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
+        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
+        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
+        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
+        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
+        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
+        "usps_zone": 4, "return_address": {"id": "adr_6c92b0f00f8911ed8010ac1f6bc7b362",
+        "object": "Address", "created_at": "2022-07-29T21:57:22+00:00", "updated_at":
+        "2022-07-29T21:57:22+00:00", "name": "EasyPost", "company": null, "street1":
+        "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
+        "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
+        "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
+        null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
+        "buyer_address": {"id": "adr_6c9051e70f8911edb5e1ac1f6b0a0d1e", "object":
+        "Address", "created_at": "2022-07-29T21:57:22+00:00", "updated_at": "2022-07-29T21:57:22+00:00",
+        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
+        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
+        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
+        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
+        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
+        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
+        "forms": [], "fees": [{"object": "Fee", "type": "LabelFee", "amount": "0.00000",
+        "charged": true, "refunded": false}, {"object": "Fee", "type": "PostageFee",
+        "amount": "9.82000", "charged": true, "refunded": false}], "id": "shp_30aed74ae9b5408d8063e9c9b4d7780d",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '165'
+      - '6487'
       content-type:
       - application/json; charset=utf-8
+      etag:
+      - W/"28eded9f8466fe09fb1a3bb00370c6bf"
+      expires:
+      - '0'
+      location:
+      - /api/v2/shipments/shp_30aed74ae9b5408d8063e9c9b4d7780d
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 3b422b0362e457c2e788d8fd0010db5f
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb8nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq 403f17ff97
+      - extlb1nuq 403f17ff97
+      x-runtime:
+      - '0.905353'
+      x-version-label:
+      - easypost-202207291722-ecd5579616-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"carbon_offset": true}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/shipments/shp_30aed74ae9b5408d8063e9c9b4d7780d/rerate
+  response:
+    body:
+      string: '{"rates": [{"id": "rate_6c631383526f47f387b38ee54bd0eca5", "object":
+        "Rate", "created_at": "2022-07-29T21:57:23Z", "updated_at": "2022-07-29T21:57:23Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_30aed74ae9b5408d8063e9c9b4d7780d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_4b24eeeb04bc4a10895c67dcd8374a06",
+        "object": "Rate", "created_at": "2022-07-29T21:57:23Z", "updated_at": "2022-07-29T21:57:23Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_30aed74ae9b5408d8063e9c9b4d7780d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_2f1582fa4eef47f081d48edcfbcfe549",
+        "object": "Rate", "created_at": "2022-07-29T21:57:23Z", "updated_at": "2022-07-29T21:57:23Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_30aed74ae9b5408d8063e9c9b4d7780d", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}]}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '1890'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"056c2992ba47dd891bf1645362230e14"
       expires:
       - '0'
       pragma:
@@ -55,24 +233,23 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 1dc2029e62e45703ec5f3a34000354f2
+      - 3b422b0362e457c3e788d8fd0010dba7
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq 403f17ff97
-      - intlb2wdc 403f17ff97
-      - extlb3wdc 403f17ff97
+      - extlb1nuq 403f17ff97
       x-runtime:
-      - '0.071583'
+      - '0.380324'
       x-version-label:
       - easypost-202207291722-ecd5579616-master
       x-xss-protection:
       - 1; mode=block
     status:
-      code: 422
-      message: Unprocessable Entity
+      code: 200
+      message: OK
 version: 1

--- a/tests/cassettes/test_shipment_rerate_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_rerate_with_carbon_offset.yaml
@@ -7,7 +7,8 @@ interactions:
       "city": "San Francisco", "state": "CA", "zip": "94104", "country": "US", "phone":
       "4153334445", "email": "support@easypost.com"}, "parcel": {"length": "20.2",
       "width": "10.9", "height": "5", "weight": "65.9"}, "service": "Priority", "carrier_accounts":
-      ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier": "USPS"}}'
+      ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier": "USPS"}, "carbon_offset":
+      false}'
     headers:
       Accept:
       - '*/*'
@@ -16,7 +17,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '630'
+      - '654'
       Content-Type:
       - application/json
       authorization:
@@ -27,65 +28,65 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at": "2022-07-28T17:41:02Z", "is_return": false, "messages":
+      string: '{"created_at": "2022-07-28T21:15:58Z", "is_return": false, "messages":
         [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
         "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        "9405500109361130464964", "updated_at": "2022-07-28T17:41:03Z", "batch_id":
+        "9405500109361130500150", "updated_at": "2022-07-28T21:15:59Z", "batch_id":
         null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
-        {"id": "adr_72eb5c8b0e9c11ed8e56ac1f6bc72124", "object": "Address", "created_at":
-        "2022-07-28T17:41:02+00:00", "updated_at": "2022-07-28T17:41:02+00:00", "name":
+        {"id": "adr_79cdbea60eba11edb444ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T21:15:58+00:00", "updated_at": "2022-07-28T21:15:58+00:00", "name":
         "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
         "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
         "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
         "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
         null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
-        {"id": "prcl_079cff86fe4044008cb7489acaa0ae72", "object": "Parcel", "created_at":
-        "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:02Z", "length": 20.2,
+        {"id": "prcl_2678f21e885c452981eb196f20adbdf8", "object": "Parcel", "created_at":
+        "2022-07-28T21:15:58Z", "updated_at": "2022-07-28T21:15:58Z", "length": 20.2,
         "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
-        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_efef351a5a014d0b816c1cf49b69ddbf",
-        "created_at": "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:03Z",
-        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T17:41:02Z",
+        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_720c7a81601c4476abf26bfe23d61629",
+        "created_at": "2022-07-28T21:15:59Z", "updated_at": "2022-07-28T21:15:59Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T21:15:59Z",
         "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
-        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/fb60352708e74e6eb297e4f44a66b078.png",
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/bec8f78a427c4207a8238ad5dc59d054.png",
         "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
-        null}, "rates": [{"id": "rate_cc4e137bb2af4fc6917393e92e6cc8c3", "object":
-        "Rate", "created_at": "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:02Z",
-        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
-        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
-        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_aed0d23f991d485785c1dc525934ae47",
-        "object": "Rate", "created_at": "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:02Z",
+        null}, "rates": [{"id": "rate_12ab58849029478eafb584e817d87c5e", "object":
+        "Rate", "created_at": "2022-07-28T21:15:58Z", "updated_at": "2022-07-28T21:15:58Z",
         "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
         "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
         "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_6f0d6991acb647e492bc19f157134238",
-        "object": "Rate", "created_at": "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:02Z",
+        null, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_23721ee7a8c849fb946aadbd7e0f7cac",
+        "object": "Rate", "created_at": "2022-07-28T21:15:58Z", "updated_at": "2022-07-28T21:15:58Z",
         "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
         "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
         "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
-        null, "selected_rate": {"id": "rate_cc4e137bb2af4fc6917393e92e6cc8c3", "object":
-        "Rate", "created_at": "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:02Z",
+        5, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_b0c17015289f4a58bfddacff15aefc7a",
+        "object": "Rate", "created_at": "2022-07-28T21:15:58Z", "updated_at": "2022-07-28T21:15:58Z",
         "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
         "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
         "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_cd63f4b89a604b39bf2c6882c2376f4f",
-        "object": "Tracker", "mode": "test", "tracking_code": "9405500109361130464964",
-        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-28T17:41:03Z",
-        "updated_at": "2022-07-28T17:41:03Z", "signed_by": null, "weight": null, "est_delivery_date":
-        null, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier": "USPS",
+        2, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
+        null, "selected_rate": {"id": "rate_b0c17015289f4a58bfddacff15aefc7a", "object":
+        "Rate", "created_at": "2022-07-28T21:15:59Z", "updated_at": "2022-07-28T21:15:59Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_51625d89fa5f45e781d3837d744660ab",
+        "object": "Tracker", "mode": "test", "tracking_code": "9405500109361130500150",
+        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-28T21:15:59Z",
+        "updated_at": "2022-07-28T21:15:59Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier": "USPS",
         "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
-        "https://track.easypost.com/djE6dHJrX2NkNjNmNGI4OWE2MDRiMzliZjJjNjg4MmMyMzc2ZjRm"},
-        "to_address": {"id": "adr_72e9cf450e9c11ed8e55ac1f6bc72124", "object": "Address",
-        "created_at": "2022-07-28T17:41:02+00:00", "updated_at": "2022-07-28T17:41:02+00:00",
+        "https://track.easypost.com/djE6dHJrXzUxNjI1ZDg5ZmE1ZjQ1ZTc4MWQzODM3ZDc0NDY2MGFi"},
+        "to_address": {"id": "adr_79cb7a260eba11edb7faac1f6bc7b362", "object": "Address",
+        "created_at": "2022-07-28T21:15:58+00:00", "updated_at": "2022-07-28T21:15:59+00:00",
         "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
         "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
         "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
@@ -93,15 +94,15 @@ interactions:
         null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
         [], "details": null}, "delivery": {"success": true, "errors": [], "details":
         {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
-        "usps_zone": 4, "return_address": {"id": "adr_72eb5c8b0e9c11ed8e56ac1f6bc72124",
-        "object": "Address", "created_at": "2022-07-28T17:41:02+00:00", "updated_at":
-        "2022-07-28T17:41:02+00:00", "name": "EasyPost", "company": null, "street1":
+        "usps_zone": 4, "return_address": {"id": "adr_79cdbea60eba11edb444ac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T21:15:58+00:00", "updated_at":
+        "2022-07-28T21:15:58+00:00", "name": "EasyPost", "company": null, "street1":
         "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
         "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
         "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
         null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
-        "buyer_address": {"id": "adr_72e9cf450e9c11ed8e55ac1f6bc72124", "object":
-        "Address", "created_at": "2022-07-28T17:41:02+00:00", "updated_at": "2022-07-28T17:41:02+00:00",
+        "buyer_address": {"id": "adr_79cb7a260eba11edb7faac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T21:15:58+00:00", "updated_at": "2022-07-28T21:15:59+00:00",
         "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
         "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
         "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
@@ -111,7 +112,7 @@ interactions:
         {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
         "forms": [], "fees": [{"object": "Fee", "type": "LabelFee", "amount": "0.00000",
         "charged": true, "refunded": false}, {"object": "Fee", "type": "PostageFee",
-        "amount": "9.82000", "charged": true, "refunded": false}], "id": "shp_764b767566d5470ba2f89657821a6b22",
+        "amount": "9.82000", "charged": true, "refunded": false}], "id": "shp_c1e36288c5da4becbd590320ffc1b8a3",
         "object": "Shipment"}'
     headers:
       cache-control:
@@ -121,11 +122,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"29526fc89b000cebc9d1e61af0c54ba3"
+      - W/"31f2697c9ed5471237720921d47e47af"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_764b767566d5470ba2f89657821a6b22
+      - /api/v2/shipments/shp_c1e36288c5da4becbd590320ffc1b8a3
       pragma:
       - no-cache
       referrer-policy:
@@ -141,20 +142,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - ead09ab862e2ca2eff23cd33002e35ea
+      - b0657e4362e2fc8eff245ee00039632b
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb4nuq
+      - bigweb1nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq 403f17ff97
-      - extlb1nuq 403f17ff97
+      - intlb1nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.904421'
+      - '1.082431'
       x-version-label:
-      - easypost-202207272329-7f74c9e58c-master
+      - easypost-202207282048-993576a700-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -178,32 +180,32 @@ interactions:
       user-agent:
       - <REDACTED>
     method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_764b767566d5470ba2f89657821a6b22/rerate
+    uri: https://api.easypost.com/v2/shipments/shp_c1e36288c5da4becbd590320ffc1b8a3/rerate
   response:
     body:
-      string: '{"rates": [{"id": "rate_c642ea37e5314c3c9083c68ad4cde848", "object":
-        "Rate", "created_at": "2022-07-28T17:41:03Z", "updated_at": "2022-07-28T17:41:03Z",
+      string: '{"rates": [{"id": "rate_a27babc9f03f45bdbecf8a2a5f6719be", "object":
+        "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
         "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
         "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
         "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
+        2, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
         "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_35d719720f9c488599120f3810ceff6c",
-        "object": "Rate", "created_at": "2022-07-28T17:41:03Z", "updated_at": "2022-07-28T17:41:03Z",
-        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
-        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
-        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_0af59dc85f29469cbbe335d06b05c337",
-        "object": "Rate", "created_at": "2022-07-28T17:41:03Z", "updated_at": "2022-07-28T17:41:03Z",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_c5e97a5509974cbf868ee8444b8380d4",
+        "object": "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
         "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
         "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
         "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
         5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
+        5, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_8334edeed9ff42fb8d0c31789eb085b6",
+        "object": "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
         "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
         "grams": 154, "price": "0.11", "currency": "USD"}}]}'
     headers:
@@ -214,7 +216,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"07ad2f0ce4d849db37a8b1cc2e2d76f7"
+      - W/"4cd41d7472d005d6f755ffe996d5a54c"
       expires:
       - '0'
       pragma:
@@ -232,20 +234,110 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - ead09ab862e2ca2fff23cd33002e362d
+      - b0657e4362e2fc90ff245ee000396389
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb9nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq 403f17ff97
-      - extlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.369991'
+      - '0.319609'
       x-version-label:
-      - easypost-202207272329-7f74c9e58c-master
+      - easypost-202207282048-993576a700-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"carbon_offset": false}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/shipments/shp_c1e36288c5da4becbd590320ffc1b8a3/rerate
+  response:
+    body:
+      string: '{"rates": [{"id": "rate_66d9bf4c587143d7abd17e3cc59dfe33", "object":
+        "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_cb70adf898ff46c9a87ee845e4c8e5ee",
+        "object": "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_8d61497e81d04e68bffb3931943ba7fa",
+        "object": "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}]}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '1632'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"756c28f36d9885f775cad091bfca9e5c"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - b0657e4362e2fc90ff245ee0003963ae
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb9nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
+      x-runtime:
+      - '0.169444'
+      x-version-label:
+      - easypost-202207282048-993576a700-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_rerate_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_rerate_with_carbon_offset.yaml
@@ -6,7 +6,7 @@ interactions:
       {"name": "EasyPost", "street1": "417 Montgomery Street", "street2": "5th Floor",
       "city": "San Francisco", "state": "CA", "zip": "94104", "country": "US", "phone":
       "4153334445", "email": "support@easypost.com"}, "parcel": {"length": "20.2",
-      "width": "10.9", "height": "5", "weight": "65.9"}, "service": "Priority", "carrier_accounts":
+      "width": "10.9", "height": "5", "weight": "65.9"}, "service": "First", "carrier_accounts":
       ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier": "USPS"}, "carbon_offset":
       false}'
     headers:
@@ -17,7 +17,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '654'
+      - '651'
       Content-Type:
       - application/json
       authorization:
@@ -28,105 +28,18 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at": "2022-07-28T21:15:58Z", "is_return": false, "messages":
-        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
-        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
-        "9405500109361130500150", "updated_at": "2022-07-28T21:15:59Z", "batch_id":
-        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
-        {"id": "adr_79cdbea60eba11edb444ac1f6bc72124", "object": "Address", "created_at":
-        "2022-07-28T21:15:58+00:00", "updated_at": "2022-07-28T21:15:58+00:00", "name":
-        "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
-        "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
-        "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
-        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
-        null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
-        {"id": "prcl_2678f21e885c452981eb196f20adbdf8", "object": "Parcel", "created_at":
-        "2022-07-28T21:15:58Z", "updated_at": "2022-07-28T21:15:58Z", "length": 20.2,
-        "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
-        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_720c7a81601c4476abf26bfe23d61629",
-        "created_at": "2022-07-28T21:15:59Z", "updated_at": "2022-07-28T21:15:59Z",
-        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T21:15:59Z",
-        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
-        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/bec8f78a427c4207a8238ad5dc59d054.png",
-        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
-        null}, "rates": [{"id": "rate_12ab58849029478eafb584e817d87c5e", "object":
-        "Rate", "created_at": "2022-07-28T21:15:58Z", "updated_at": "2022-07-28T21:15:58Z",
-        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
-        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
-        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_23721ee7a8c849fb946aadbd7e0f7cac",
-        "object": "Rate", "created_at": "2022-07-28T21:15:58Z", "updated_at": "2022-07-28T21:15:58Z",
-        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
-        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
-        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_b0c17015289f4a58bfddacff15aefc7a",
-        "object": "Rate", "created_at": "2022-07-28T21:15:58Z", "updated_at": "2022-07-28T21:15:58Z",
-        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
-        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
-        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
-        null, "selected_rate": {"id": "rate_b0c17015289f4a58bfddacff15aefc7a", "object":
-        "Rate", "created_at": "2022-07-28T21:15:59Z", "updated_at": "2022-07-28T21:15:59Z",
-        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
-        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
-        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_51625d89fa5f45e781d3837d744660ab",
-        "object": "Tracker", "mode": "test", "tracking_code": "9405500109361130500150",
-        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-28T21:15:59Z",
-        "updated_at": "2022-07-28T21:15:59Z", "signed_by": null, "weight": null, "est_delivery_date":
-        null, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier": "USPS",
-        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
-        "https://track.easypost.com/djE6dHJrXzUxNjI1ZDg5ZmE1ZjQ1ZTc4MWQzODM3ZDc0NDY2MGFi"},
-        "to_address": {"id": "adr_79cb7a260eba11edb7faac1f6bc7b362", "object": "Address",
-        "created_at": "2022-07-28T21:15:58+00:00", "updated_at": "2022-07-28T21:15:59+00:00",
-        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
-        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
-        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
-        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
-        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
-        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
-        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
-        "usps_zone": 4, "return_address": {"id": "adr_79cdbea60eba11edb444ac1f6bc72124",
-        "object": "Address", "created_at": "2022-07-28T21:15:58+00:00", "updated_at":
-        "2022-07-28T21:15:58+00:00", "name": "EasyPost", "company": null, "street1":
-        "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
-        "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
-        "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
-        null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
-        "buyer_address": {"id": "adr_79cb7a260eba11edb7faac1f6bc7b362", "object":
-        "Address", "created_at": "2022-07-28T21:15:58+00:00", "updated_at": "2022-07-28T21:15:59+00:00",
-        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
-        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
-        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
-        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
-        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
-        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
-        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
-        "forms": [], "fees": [{"object": "Fee", "type": "LabelFee", "amount": "0.00000",
-        "charged": true, "refunded": false}, {"object": "Fee", "type": "PostageFee",
-        "amount": "9.82000", "charged": true, "refunded": false}], "id": "shp_c1e36288c5da4becbd590320ffc1b8a3",
-        "object": "Shipment"}'
+      string: '{"error": {"code": "SHIPMENT.CARRIER_ACCOUNTS.INVALID", "message":
+        "Only one carrier_account_id can be supplied when purchasing a shipment without
+        rating.", "errors": []}}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '6487'
+      - '165'
       content-type:
       - application/json; charset=utf-8
-      etag:
-      - W/"31f2697c9ed5471237720921d47e47af"
       expires:
       - '0'
-      location:
-      - /api/v2/shipments/shp_c1e36288c5da4becbd590320ffc1b8a3
       pragma:
       - no-cache
       referrer-policy:
@@ -142,7 +55,7 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - b0657e4362e2fc8eff245ee00039632b
+      - 1dc2029e62e45703ec5f3a34000354f2
       x-frame-options:
       - SAMEORIGIN
       x-node:
@@ -154,193 +67,12 @@ interactions:
       - intlb2wdc 403f17ff97
       - extlb3wdc 403f17ff97
       x-runtime:
-      - '1.082431'
+      - '0.071583'
       x-version-label:
-      - easypost-202207282048-993576a700-master
+      - easypost-202207291722-ecd5579616-master
       x-xss-protection:
       - 1; mode=block
     status:
-      code: 201
-      message: Created
-- request:
-    body: '{"carbon_offset": true}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      authorization:
-      - <REDACTED>
-      user-agent:
-      - <REDACTED>
-    method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_c1e36288c5da4becbd590320ffc1b8a3/rerate
-  response:
-    body:
-      string: '{"rates": [{"id": "rate_a27babc9f03f45bdbecf8a2a5f6719be", "object":
-        "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
-        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
-        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
-        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_c5e97a5509974cbf868ee8444b8380d4",
-        "object": "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
-        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
-        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
-        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_8334edeed9ff42fb8d0c31789eb085b6",
-        "object": "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
-        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
-        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
-        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
-        "grams": 154, "price": "0.11", "currency": "USD"}}]}'
-    headers:
-      cache-control:
-      - no-cache, no-store
-      content-length:
-      - '1890'
-      content-type:
-      - application/json; charset=utf-8
-      etag:
-      - W/"4cd41d7472d005d6f755ffe996d5a54c"
-      expires:
-      - '0'
-      pragma:
-      - no-cache
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      transfer-encoding:
-      - chunked
-      x-backend:
-      - easypost
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-ep-request-uuid:
-      - b0657e4362e2fc90ff245ee000396389
-      x-frame-options:
-      - SAMEORIGIN
-      x-node:
-      - bigweb9nuq
-      x-permitted-cross-domain-policies:
-      - none
-      x-proxied:
-      - intlb1nuq 403f17ff97
-      - intlb1wdc 403f17ff97
-      - extlb3wdc 403f17ff97
-      x-runtime:
-      - '0.319609'
-      x-version-label:
-      - easypost-202207282048-993576a700-master
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"carbon_offset": false}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json
-      authorization:
-      - <REDACTED>
-      user-agent:
-      - <REDACTED>
-    method: POST
-    uri: https://api.easypost.com/v2/shipments/shp_c1e36288c5da4becbd590320ffc1b8a3/rerate
-  response:
-    body:
-      string: '{"rates": [{"id": "rate_66d9bf4c587143d7abd17e3cc59dfe33", "object":
-        "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
-        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
-        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
-        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        null, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_cb70adf898ff46c9a87ee845e4c8e5ee",
-        "object": "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
-        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
-        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
-        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        2, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_8d61497e81d04e68bffb3931943ba7fa",
-        "object": "Rate", "created_at": "2022-07-28T21:16:00Z", "updated_at": "2022-07-28T21:16:00Z",
-        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
-        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
-        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
-        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
-        5, "shipment_id": "shp_c1e36288c5da4becbd590320ffc1b8a3", "carrier_account_id":
-        "ca_b25657e9896e4d63ac8151ac346ac41e"}]}'
-    headers:
-      cache-control:
-      - no-cache, no-store
-      content-length:
-      - '1632'
-      content-type:
-      - application/json; charset=utf-8
-      etag:
-      - W/"756c28f36d9885f775cad091bfca9e5c"
-      expires:
-      - '0'
-      pragma:
-      - no-cache
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      transfer-encoding:
-      - chunked
-      x-backend:
-      - easypost
-      x-content-type-options:
-      - nosniff
-      x-download-options:
-      - noopen
-      x-ep-request-uuid:
-      - b0657e4362e2fc90ff245ee0003963ae
-      x-frame-options:
-      - SAMEORIGIN
-      x-node:
-      - bigweb9nuq
-      x-permitted-cross-domain-policies:
-      - none
-      x-proxied:
-      - intlb1nuq 403f17ff97
-      - intlb1wdc 403f17ff97
-      - extlb3wdc 403f17ff97
-      x-runtime:
-      - '0.169444'
-      x-version-label:
-      - easypost-202207282048-993576a700-master
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
+      code: 422
+      message: Unprocessable Entity
 version: 1

--- a/tests/cassettes/test_shipment_rerate_with_carbon_offset.yaml
+++ b/tests/cassettes/test_shipment_rerate_with_carbon_offset.yaml
@@ -1,0 +1,254 @@
+interactions:
+- request:
+    body: '{"shipment": {"to_address": {"name": "Dr. Steve Brule", "street1": "179
+      N Harbor Dr", "city": "Redondo Beach", "state": "CA", "zip": "90277", "country":
+      "US", "phone": "8573875756", "email": "dr_steve_brule@gmail.com"}, "from_address":
+      {"name": "EasyPost", "street1": "417 Montgomery Street", "street2": "5th Floor",
+      "city": "San Francisco", "state": "CA", "zip": "94104", "country": "US", "phone":
+      "4153334445", "email": "support@easypost.com"}, "parcel": {"length": "20.2",
+      "width": "10.9", "height": "5", "weight": "65.9"}, "service": "Priority", "carrier_accounts":
+      ["ca_b25657e9896e4d63ac8151ac346ac41e"], "carrier": "USPS"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '630'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/shipments
+  response:
+    body:
+      string: '{"created_at": "2022-07-28T17:41:02Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        "9405500109361130464964", "updated_at": "2022-07-28T17:41:03Z", "batch_id":
+        null, "batch_status": null, "batch_message": null, "customs_info": null, "from_address":
+        {"id": "adr_72eb5c8b0e9c11ed8e56ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T17:41:02+00:00", "updated_at": "2022-07-28T17:41:02+00:00", "name":
+        "EasyPost", "company": null, "street1": "417 Montgomery Street", "street2":
+        "5th Floor", "city": "San Francisco", "state": "CA", "zip": "94104", "country":
+        "US", "phone": "4153334445", "email": "support@easypost.com", "mode": "test",
+        "carrier_facility": null, "residential": null, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {}}, "insurance": null, "order_id": null, "parcel":
+        {"id": "prcl_079cff86fe4044008cb7489acaa0ae72", "object": "Parcel", "created_at":
+        "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:02Z", "length": 20.2,
+        "width": 10.9, "height": 5.0, "predefined_package": null, "weight": 65.9,
+        "mode": "test"}, "postage_label": {"object": "PostageLabel", "id": "pl_efef351a5a014d0b816c1cf49b69ddbf",
+        "created_at": "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:03Z",
+        "date_advance": 0, "integrated_form": "none", "label_date": "2022-07-28T17:41:02Z",
+        "label_resolution": 300, "label_size": "4x6", "label_type": "default", "label_file_type":
+        "image/png", "label_url": "https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/fb60352708e74e6eb297e4f44a66b078.png",
+        "label_pdf_url": null, "label_zpl_url": null, "label_epl2_url": null, "label_file":
+        null}, "rates": [{"id": "rate_cc4e137bb2af4fc6917393e92e6cc8c3", "object":
+        "Rate", "created_at": "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:02Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_aed0d23f991d485785c1dc525934ae47",
+        "object": "Rate", "created_at": "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:02Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_6f0d6991acb647e492bc19f157134238",
+        "object": "Rate", "created_at": "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:02Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}], "refund_status": null, "scan_form":
+        null, "selected_rate": {"id": "rate_cc4e137bb2af4fc6917393e92e6cc8c3", "object":
+        "Rate", "created_at": "2022-07-28T17:41:02Z", "updated_at": "2022-07-28T17:41:02Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, "tracker": {"id": "trk_cd63f4b89a604b39bf2c6882c2376f4f",
+        "object": "Tracker", "mode": "test", "tracking_code": "9405500109361130464964",
+        "status": "unknown", "status_detail": "unknown", "created_at": "2022-07-28T17:41:03Z",
+        "updated_at": "2022-07-28T17:41:03Z", "signed_by": null, "weight": null, "est_delivery_date":
+        null, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier": "USPS",
+        "tracking_details": [], "fees": [], "carrier_detail": null, "public_url":
+        "https://track.easypost.com/djE6dHJrX2NkNjNmNGI4OWE2MDRiMzliZjJjNjg4MmMyMzc2ZjRm"},
+        "to_address": {"id": "adr_72e9cf450e9c11ed8e55ac1f6bc72124", "object": "Address",
+        "created_at": "2022-07-28T17:41:02+00:00", "updated_at": "2022-07-28T17:41:02+00:00",
+        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
+        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
+        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
+        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
+        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
+        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
+        "usps_zone": 4, "return_address": {"id": "adr_72eb5c8b0e9c11ed8e56ac1f6bc72124",
+        "object": "Address", "created_at": "2022-07-28T17:41:02+00:00", "updated_at":
+        "2022-07-28T17:41:02+00:00", "name": "EasyPost", "company": null, "street1":
+        "417 Montgomery Street", "street2": "5th Floor", "city": "San Francisco",
+        "state": "CA", "zip": "94104", "country": "US", "phone": "4153334445", "email":
+        "support@easypost.com", "mode": "test", "carrier_facility": null, "residential":
+        null, "federal_tax_id": null, "state_tax_id": null, "verifications": {}},
+        "buyer_address": {"id": "adr_72e9cf450e9c11ed8e55ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T17:41:02+00:00", "updated_at": "2022-07-28T17:41:02+00:00",
+        "name": "DR. STEVE BRULE", "company": null, "street1": "179 N HARBOR DR",
+        "street2": null, "city": "REDONDO BEACH", "state": "CA", "zip": "90277-2506",
+        "country": "US", "phone": "8573875756", "email": "DR_STEVE_BRULE@GMAIL.COM",
+        "mode": "test", "carrier_facility": null, "residential": false, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {"zip4": {"success": true, "errors":
+        [], "details": null}, "delivery": {"success": true, "errors": [], "details":
+        {"latitude": 33.8436, "longitude": -118.39177, "time_zone": "America/Los_Angeles"}}}},
+        "forms": [], "fees": [{"object": "Fee", "type": "LabelFee", "amount": "0.00000",
+        "charged": true, "refunded": false}, {"object": "Fee", "type": "PostageFee",
+        "amount": "9.82000", "charged": true, "refunded": false}], "id": "shp_764b767566d5470ba2f89657821a6b22",
+        "object": "Shipment"}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '6487'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"29526fc89b000cebc9d1e61af0c54ba3"
+      expires:
+      - '0'
+      location:
+      - /api/v2/shipments/shp_764b767566d5470ba2f89657821a6b22
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - ead09ab862e2ca2eff23cd33002e35ea
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb4nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq 403f17ff97
+      - extlb1nuq 403f17ff97
+      x-runtime:
+      - '0.904421'
+      x-version-label:
+      - easypost-202207272329-7f74c9e58c-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"carbon_offset": true}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/shipments/shp_764b767566d5470ba2f89657821a6b22/rerate
+  response:
+    body:
+      string: '{"rates": [{"id": "rate_c642ea37e5314c3c9083c68ad4cde848", "object":
+        "Rate", "created_at": "2022-07-28T17:41:03Z", "updated_at": "2022-07-28T17:41:03Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "9.82",
+        "currency": "USD", "retail_rate": "13.15", "retail_currency": "USD", "list_rate":
+        "9.82", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_35d719720f9c488599120f3810ceff6c",
+        "object": "Rate", "created_at": "2022-07-28T17:41:03Z", "updated_at": "2022-07-28T17:41:03Z",
+        "mode": "test", "service": "Express", "carrier": "USPS", "rate": "44.30",
+        "currency": "USD", "retail_rate": "51.00", "retail_currency": "USD", "list_rate":
+        "44.30", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        null, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        null, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}, {"id": "rate_0af59dc85f29469cbbe335d06b05c337",
+        "object": "Rate", "created_at": "2022-07-28T17:41:03Z", "updated_at": "2022-07-28T17:41:03Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "8.91",
+        "currency": "USD", "retail_rate": "8.91", "retail_currency": "USD", "list_rate":
+        "8.91", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        5, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        5, "shipment_id": "shp_764b767566d5470ba2f89657821a6b22", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "carbon_offset": {"object": "CarbonOffset",
+        "grams": 154, "price": "0.11", "currency": "USD"}}]}'
+    headers:
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '1890'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"07ad2f0ce4d849db37a8b1cc2e2d76f7"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - ead09ab862e2ca2fff23cd33002e362d
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb2nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq 403f17ff97
+      - extlb1nuq 403f17ff97
+      x-runtime:
+      - '0.369991'
+      x-version-label:
+      - easypost-202207272329-7f74c9e58c-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_shipment_retrieve.yaml
+++ b/tests/cassettes/test_shipment_retrieve.yaml
@@ -11,7 +11,7 @@ interactions:
       "none", "non_delivery_option": "return", "customs_items": [{"description": "Sweet
       shirts", "quantity": 2, "weight": 11, "value": 23, "hs_tariff_number": "654321",
       "origin_country": "US"}]}, "options": {"label_format": "PNG", "invoice_number":
-      "123"}, "reference": "123"}}'
+      "123"}, "reference": "123"}, "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -20,7 +20,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '932'
+      - '956'
       Content-Type:
       - application/json
       authorization:
@@ -31,30 +31,94 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:11Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:11Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_38a02d0d8264484bad2dcefbe583da4b","object":"CustomsInfo","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_a3eb42d8e7804c2296a91e444f5b7cf7","object":"CustomsItem","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_6fe78f61cbe811ec8bd6ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:11+00:00","updated_at":"2022-05-04T20:26:11+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_dea97f8b435e407e86bce45cadf27849","object":"Parcel","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_8781bb3c940146e9a2330897d1e6b4b5","object":"Rate","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8dfbc4ce548641b78c0966ec6c497bcf","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_a194a19e4ff14e9b8edce7bd541963d4","object":"Rate","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_8dfbc4ce548641b78c0966ec6c497bcf","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_65547345651b463dbbf7255cc118cd80","object":"Rate","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8dfbc4ce548641b78c0966ec6c497bcf","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_befe35f4d15c4121a8feb7d2c059036e","object":"Rate","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_8dfbc4ce548641b78c0966ec6c497bcf","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_6fe5cc48cbe811ec9478ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:11+00:00","updated_at":"2022-05-04T20:26:11+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_6fe78f61cbe811ec8bd6ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:11+00:00","updated_at":"2022-05-04T20:26:11+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6fe5cc48cbe811ec9478ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:11+00:00","updated_at":"2022-05-04T20:26:11+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_8dfbc4ce548641b78c0966ec6c497bcf","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:09Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"label_format": "PNG", "invoice_number": "123",
+        "currency": "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference":
+        "123", "status": "unknown", "tracking_code": null, "updated_at": "2022-07-28T19:56:09Z",
+        "batch_id": null, "batch_status": null, "batch_message": null, "customs_info":
+        {"id": "cstinfo_a24503f7bcc14ce1b6fd91d28d56d6de", "object": "CustomsInfo",
+        "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "contents_explanation": "", "contents_type": "merchandise", "customs_certify":
+        true, "customs_signer": "Steve Brule", "eel_pfc": "NOEEI 30.37(a)", "non_delivery_option":
+        "return", "restriction_comments": null, "restriction_type": "none", "mode":
+        "test", "declaration": null, "customs_items": [{"id": "cstitem_969118189c804879923083d6011cede0",
+        "object": "CustomsItem", "created_at": "2022-07-28T19:56:09Z", "updated_at":
+        "2022-07-28T19:56:09Z", "description": "Sweet shirts", "hs_tariff_number":
+        "654321", "origin_country": "US", "quantity": 2, "value": "23.0", "weight":
+        11.0, "code": null, "mode": "test", "manufacturer": null, "currency": null,
+        "eccn": null, "printed_commodity_identifier": null}]}, "from_address": {"id":
+        "adr_534bb8590eaf11ed9f0eac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:56:09+00:00", "updated_at": "2022-07-28T19:56:09+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_1af5d0e0b3ea40e9a0c4965518efa3f0",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_460bd4da75844fcf8ca4ccfce8908536",
+        "object": "Rate", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_8960774bc98e471689da503acff72d7b", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_b5b1007e97604d3694257bb83b7b5f90",
+        "object": "Rate", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_8960774bc98e471689da503acff72d7b", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_25f5156a8e0d4836a7a14bd630cf6095", "object": "Rate", "created_at":
+        "2022-07-28T19:56:10Z", "updated_at": "2022-07-28T19:56:10Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_8960774bc98e471689da503acff72d7b", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_b907d99d0b734a2db6cdea8dcffda905", "object": "Rate", "created_at":
+        "2022-07-28T19:56:10Z", "updated_at": "2022-07-28T19:56:10Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_8960774bc98e471689da503acff72d7b", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_5349e6890eaf11ed9ab6ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T19:56:09+00:00", "updated_at": "2022-07-28T19:56:09+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_534bb8590eaf11ed9f0eac1f6b0a0d1e",
+        "object": "Address", "created_at": "2022-07-28T19:56:09+00:00", "updated_at":
+        "2022-07-28T19:56:09+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_5349e6890eaf11ed9ab6ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:09+00:00", "updated_at": "2022-07-28T19:56:09+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_8960774bc98e471689da503acff72d7b",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '5563'
+      - '5667'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"bc6b90d35a7edc12751eb1e1289383cf"
+      - W/"46541bcf63ef43791a3ce0920ccf3edb"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_8dfbc4ce548641b78c0966ec6c497bcf
+      - /api/v2/shipments/shp_8960774bc98e471689da503acff72d7b
       pragma:
       - no-cache
       referrer-policy:
@@ -70,20 +134,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fba6272e163e786b8e00013ad22
+      - b0657e3c62e2e9d9ff23e29d0033ca49
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb1nuq
+      - bigweb9nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.281314'
+      - '0.269248'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -103,29 +168,93 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_8dfbc4ce548641b78c0966ec6c497bcf
+    uri: https://api.easypost.com/v2/shipments/shp_8960774bc98e471689da503acff72d7b
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:11Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:11Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_38a02d0d8264484bad2dcefbe583da4b","object":"CustomsInfo","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
-        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_a3eb42d8e7804c2296a91e444f5b7cf7","object":"CustomsItem","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","description":"Sweet
-        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_6fe78f61cbe811ec8bd6ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:11+00:00","updated_at":"2022-05-04T20:26:11+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_dea97f8b435e407e86bce45cadf27849","object":"Parcel","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_8781bb3c940146e9a2330897d1e6b4b5","object":"Rate","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8dfbc4ce548641b78c0966ec6c497bcf","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_a194a19e4ff14e9b8edce7bd541963d4","object":"Rate","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_8dfbc4ce548641b78c0966ec6c497bcf","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_65547345651b463dbbf7255cc118cd80","object":"Rate","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8dfbc4ce548641b78c0966ec6c497bcf","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_befe35f4d15c4121a8feb7d2c059036e","object":"Rate","created_at":"2022-05-04T20:26:11Z","updated_at":"2022-05-04T20:26:11Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_8dfbc4ce548641b78c0966ec6c497bcf","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_6fe5cc48cbe811ec9478ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:11+00:00","updated_at":"2022-05-04T20:26:11+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_6fe78f61cbe811ec8bd6ac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:26:11+00:00","updated_at":"2022-05-04T20:26:11+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_6fe5cc48cbe811ec9478ac1f6b0a0d1e","object":"Address","created_at":"2022-05-04T20:26:11+00:00","updated_at":"2022-05-04T20:26:11+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_8dfbc4ce548641b78c0966ec6c497bcf","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:09Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"label_format": "PNG", "invoice_number": "123",
+        "currency": "USD", "payment": {"type": "SENDER"}, "date_advance": 0}, "reference":
+        "123", "status": "unknown", "tracking_code": null, "updated_at": "2022-07-28T19:56:09Z",
+        "batch_id": null, "batch_status": null, "batch_message": null, "customs_info":
+        {"id": "cstinfo_a24503f7bcc14ce1b6fd91d28d56d6de", "object": "CustomsInfo",
+        "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "contents_explanation": "", "contents_type": "merchandise", "customs_certify":
+        true, "customs_signer": "Steve Brule", "eel_pfc": "NOEEI 30.37(a)", "non_delivery_option":
+        "return", "restriction_comments": null, "restriction_type": "none", "mode":
+        "test", "declaration": null, "customs_items": [{"id": "cstitem_969118189c804879923083d6011cede0",
+        "object": "CustomsItem", "created_at": "2022-07-28T19:56:09Z", "updated_at":
+        "2022-07-28T19:56:09Z", "description": "Sweet shirts", "hs_tariff_number":
+        "654321", "origin_country": "US", "quantity": 2, "value": "23.0", "weight":
+        11.0, "code": null, "mode": "test", "manufacturer": null, "currency": null,
+        "eccn": null, "printed_commodity_identifier": null}]}, "from_address": {"id":
+        "adr_534bb8590eaf11ed9f0eac1f6b0a0d1e", "object": "Address", "created_at":
+        "2022-07-28T19:56:09+00:00", "updated_at": "2022-07-28T19:56:09+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_1af5d0e0b3ea40e9a0c4965518efa3f0",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_460bd4da75844fcf8ca4ccfce8908536",
+        "object": "Rate", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_8960774bc98e471689da503acff72d7b", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_b5b1007e97604d3694257bb83b7b5f90",
+        "object": "Rate", "created_at": "2022-07-28T19:56:09Z", "updated_at": "2022-07-28T19:56:09Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_8960774bc98e471689da503acff72d7b", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_25f5156a8e0d4836a7a14bd630cf6095", "object": "Rate", "created_at":
+        "2022-07-28T19:56:10Z", "updated_at": "2022-07-28T19:56:10Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_8960774bc98e471689da503acff72d7b", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_b907d99d0b734a2db6cdea8dcffda905", "object": "Rate", "created_at":
+        "2022-07-28T19:56:10Z", "updated_at": "2022-07-28T19:56:10Z", "mode": "test",
+        "service": "Priority", "carrier": "USPS", "rate": "7.37", "currency": "USD",
+        "retail_rate": "8.70", "retail_currency": "USD", "list_rate": "7.37", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": 1, "delivery_date": null,
+        "delivery_date_guaranteed": false, "est_delivery_days": 1, "shipment_id":
+        "shp_8960774bc98e471689da503acff72d7b", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_5349e6890eaf11ed9ab6ac1f6bc72124", "object":
+        "Address", "created_at": "2022-07-28T19:56:09+00:00", "updated_at": "2022-07-28T19:56:09+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_534bb8590eaf11ed9f0eac1f6b0a0d1e",
+        "object": "Address", "created_at": "2022-07-28T19:56:09+00:00", "updated_at":
+        "2022-07-28T19:56:09+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_5349e6890eaf11ed9ab6ac1f6bc72124", "object": "Address", "created_at":
+        "2022-07-28T19:56:09+00:00", "updated_at": "2022-07-28T19:56:09+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_8960774bc98e471689da503acff72d7b",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '5563'
+      - '5667'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"bc6b90d35a7edc12751eb1e1289383cf"
+      - W/"46541bcf63ef43791a3ce0920ccf3edb"
       expires:
       - '0'
       pragma:
@@ -143,20 +272,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fba6272e163e786b8e00013ad39
+      - b0657e3c62e2e9daff23e29d0033ca6d
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb5nuq
+      - bigweb2nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb3wdc 403f17ff97
       x-runtime:
-      - '0.077070'
+      - '0.168743'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_shipment_smartrate.yaml
+++ b/tests/cassettes/test_shipment_smartrate.yaml
@@ -5,7 +5,8 @@ interactions:
       "state": "CA", "zip": "94107", "phone": "5555555555"}, "from_address": {"name":
       "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
       "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "phone": "5555555555"},
-      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}}}'
+      "parcel": {"length": "10", "width": "8", "height": "4", "weight": "15.4"}},
+      "carbon_offset": false}'
     headers:
       Accept:
       - '*/*'
@@ -14,7 +15,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '477'
+      - '501'
       Content-Type:
       - application/json
       authorization:
@@ -25,28 +26,83 @@ interactions:
     uri: https://api.easypost.com/v2/shipments
   response:
     body:
-      string: '{"created_at":"2022-05-04T20:26:20Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-05-04T20:26:20Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_75bd5dbecbe811eca52cac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:20+00:00","updated_at":"2022-05-04T20:26:20+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_cd3139845dde49b5bf40307007de88ed","object":"Parcel","created_at":"2022-05-04T20:26:20Z","updated_at":"2022-05-04T20:26:20Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_aaf15379e5e84ee0a53f33003d4ec6d6","object":"Rate","created_at":"2022-05-04T20:26:21Z","updated_at":"2022-05-04T20:26:21Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_416d520e9b69472382ac70e6b33481e2","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_80e7a16cff97436c9dd9e06c6b6f3934","object":"Rate","created_at":"2022-05-04T20:26:21Z","updated_at":"2022-05-04T20:26:21Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_416d520e9b69472382ac70e6b33481e2","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_ae8cd6f2fa504af1bf43768116d8d94e","object":"Rate","created_at":"2022-05-04T20:26:21Z","updated_at":"2022-05-04T20:26:21Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_416d520e9b69472382ac70e6b33481e2","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"},{"id":"rate_61869bff91874aaab64a1dc01ef4fd5d","object":"Rate","created_at":"2022-05-04T20:26:21Z","updated_at":"2022-05-04T20:26:21Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_416d520e9b69472382ac70e6b33481e2","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_75bb6ca3cbe811eca52bac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:20+00:00","updated_at":"2022-05-04T20:26:20+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_75bd5dbecbe811eca52cac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:20+00:00","updated_at":"2022-05-04T20:26:20+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_75bb6ca3cbe811eca52bac1f6bc72124","object":"Address","created_at":"2022-05-04T20:26:20+00:00","updated_at":"2022-05-04T20:26:20+00:00","name":"Jack
-        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_416d520e9b69472382ac70e6b33481e2","object":"Shipment"}'
+      string: '{"created_at": "2022-07-28T19:56:20Z", "is_return": false, "messages":
+        [], "mode": "test", "options": {"currency": "USD", "payment": {"type": "SENDER"},
+        "date_advance": 0}, "reference": null, "status": "unknown", "tracking_code":
+        null, "updated_at": "2022-07-28T19:56:20Z", "batch_id": null, "batch_status":
+        null, "batch_message": null, "customs_info": null, "from_address": {"id":
+        "adr_59a4787f0eaf11ed8f70ac1f6bc7bdc6", "object": "Address", "created_at":
+        "2022-07-28T19:56:20+00:00", "updated_at": "2022-07-28T19:56:20+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "insurance": null, "order_id": null, "parcel": {"id": "prcl_39d9e35e00e84edba94a2c9ead67eab3",
+        "object": "Parcel", "created_at": "2022-07-28T19:56:20Z", "updated_at": "2022-07-28T19:56:20Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}, "postage_label": null, "rates": [{"id": "rate_12e3f878d36446369a560637c41160ef",
+        "object": "Rate", "created_at": "2022-07-28T19:56:20Z", "updated_at": "2022-07-28T19:56:20Z",
+        "mode": "test", "service": "Priority", "carrier": "USPS", "rate": "7.37",
+        "currency": "USD", "retail_rate": "8.70", "retail_currency": "USD", "list_rate":
+        "7.37", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        1, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        1, "shipment_id": "shp_a4309fb2a5e4463dae2b785e36fd6076", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_f2dafa41e7c74841845c0f1c7e43427c",
+        "object": "Rate", "created_at": "2022-07-28T19:56:20Z", "updated_at": "2022-07-28T19:56:20Z",
+        "mode": "test", "service": "ParcelSelect", "carrier": "USPS", "rate": "7.22",
+        "currency": "USD", "retail_rate": "7.22", "retail_currency": "USD", "list_rate":
+        "7.22", "list_currency": "USD", "billing_type": "easypost", "delivery_days":
+        2, "delivery_date": null, "delivery_date_guaranteed": false, "est_delivery_days":
+        2, "shipment_id": "shp_a4309fb2a5e4463dae2b785e36fd6076", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e"}, {"id": "rate_56935feac32541ccb51057f8c42bba56",
+        "object": "Rate", "created_at": "2022-07-28T19:56:20Z", "updated_at": "2022-07-28T19:56:20Z",
+        "mode": "test", "service": "First", "carrier": "USPS", "rate": "5.49", "currency":
+        "USD", "retail_rate": "5.49", "retail_currency": "USD", "list_rate": "5.49",
+        "list_currency": "USD", "billing_type": "easypost", "delivery_days": 2, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": 2, "shipment_id":
+        "shp_a4309fb2a5e4463dae2b785e36fd6076", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"},
+        {"id": "rate_65ad3ee2a10f47d5a9d517dfce1e1a8f", "object": "Rate", "created_at":
+        "2022-07-28T19:56:20Z", "updated_at": "2022-07-28T19:56:20Z", "mode": "test",
+        "service": "Express", "carrier": "USPS", "rate": "23.75", "currency": "USD",
+        "retail_rate": "27.40", "retail_currency": "USD", "list_rate": "23.75", "list_currency":
+        "USD", "billing_type": "easypost", "delivery_days": null, "delivery_date":
+        null, "delivery_date_guaranteed": false, "est_delivery_days": null, "shipment_id":
+        "shp_a4309fb2a5e4463dae2b785e36fd6076", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e"}],
+        "refund_status": null, "scan_form": null, "selected_rate": null, "tracker":
+        null, "to_address": {"id": "adr_59a248af0eaf11ed9f68ac1f6bc7b362", "object":
+        "Address", "created_at": "2022-07-28T19:56:20+00:00", "updated_at": "2022-07-28T19:56:20+00:00",
+        "name": "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St",
+        "street2": "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107",
+        "country": "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "usps_zone": 1, "return_address": {"id": "adr_59a4787f0eaf11ed8f70ac1f6bc7bdc6",
+        "object": "Address", "created_at": "2022-07-28T19:56:20+00:00", "updated_at":
+        "2022-07-28T19:56:20+00:00", "name": "Jack Sparrow", "company": "EasyPost",
+        "street1": "388 Townsend St", "street2": "Apt 20", "city": "San Francisco",
+        "state": "CA", "zip": "94107", "country": "US", "phone": "5555555555", "email":
+        null, "mode": "test", "carrier_facility": null, "residential": null, "federal_tax_id":
+        null, "state_tax_id": null, "verifications": {}}, "buyer_address": {"id":
+        "adr_59a248af0eaf11ed9f68ac1f6bc7b362", "object": "Address", "created_at":
+        "2022-07-28T19:56:20+00:00", "updated_at": "2022-07-28T19:56:20+00:00", "name":
+        "Jack Sparrow", "company": "EasyPost", "street1": "388 Townsend St", "street2":
+        "Apt 20", "city": "San Francisco", "state": "CA", "zip": "94107", "country":
+        "US", "phone": "5555555555", "email": null, "mode": "test", "carrier_facility":
+        null, "residential": null, "federal_tax_id": null, "state_tax_id": null, "verifications":
+        {}}, "forms": [], "fees": [], "id": "shp_a4309fb2a5e4463dae2b785e36fd6076",
+        "object": "Shipment"}'
     headers:
       cache-control:
       - no-cache, no-store
       content-length:
-      - '4729'
+      - '4833'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"c53d98709b606b3d31035f17d8052306"
+      - W/"7460e1945a48f18ecadc69a8b282e97f"
       expires:
       - '0'
       location:
-      - /api/v2/shipments/shp_416d520e9b69472382ac70e6b33481e2
+      - /api/v2/shipments/shp_a4309fb2a5e4463dae2b785e36fd6076
       pragma:
       - no-cache
       referrer-policy:
@@ -62,20 +118,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fba6272e16ce786b8e80013b003
+      - 3843704262e2e9e4ff23e2bc00343650
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb1wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.264893'
+      - '0.285017'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:
@@ -95,10 +152,44 @@ interactions:
       user-agent:
       - <REDACTED>
     method: GET
-    uri: https://api.easypost.com/v2/shipments/shp_416d520e9b69472382ac70e6b33481e2/smartrate
+    uri: https://api.easypost.com/v2/shipments/shp_a4309fb2a5e4463dae2b785e36fd6076/smartrate
   response:
     body:
-      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:21Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_aaf15379e5e84ee0a53f33003d4ec6d6","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_416d520e9b69472382ac70e6b33481e2","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-05-04T20:26:21Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:21Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_80e7a16cff97436c9dd9e06c6b6f3934","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_416d520e9b69472382ac70e6b33481e2","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-05-04T20:26:21Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:21Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_ae8cd6f2fa504af1bf43768116d8d94e","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_416d520e9b69472382ac70e6b33481e2","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-04T20:26:21Z"},{"carrier":"USPS","carrier_account_id":"ca_b25657e9896e4d63ac8151ac346ac41e","created_at":"2022-05-04T20:26:21Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_61869bff91874aaab64a1dc01ef4fd5d","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_416d520e9b69472382ac70e6b33481e2","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-04T20:26:21Z"}]}'
+      string: '{"result": [{"carrier": "USPS", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e",
+        "created_at": "2022-07-28T19:56:20Z", "currency": "USD", "delivery_date":
+        null, "delivery_date_guaranteed": false, "delivery_days": 1, "est_delivery_days":
+        1, "id": "rate_12e3f878d36446369a560637c41160ef", "list_currency": "USD",
+        "list_rate": 7.37, "mode": "test", "object": "Rate", "rate": 7.37, "retail_currency":
+        "USD", "retail_rate": 8.7, "service": "Priority", "shipment_id": "shp_a4309fb2a5e4463dae2b785e36fd6076",
+        "time_in_transit": {"percentile_50": 1, "percentile_75": 1, "percentile_85":
+        2, "percentile_90": 2, "percentile_95": 2, "percentile_97": 3, "percentile_99":
+        6}, "updated_at": "2022-07-28T19:56:20Z"}, {"carrier": "USPS", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "created_at": "2022-07-28T19:56:20Z",
+        "currency": "USD", "delivery_date": null, "delivery_date_guaranteed": false,
+        "delivery_days": 2, "est_delivery_days": 2, "id": "rate_f2dafa41e7c74841845c0f1c7e43427c",
+        "list_currency": "USD", "list_rate": 7.22, "mode": "test", "object": "Rate",
+        "rate": 7.22, "retail_currency": "USD", "retail_rate": 7.22, "service": "ParcelSelect",
+        "shipment_id": "shp_a4309fb2a5e4463dae2b785e36fd6076", "time_in_transit":
+        {"percentile_50": 2, "percentile_75": 3, "percentile_85": 3, "percentile_90":
+        4, "percentile_95": 5, "percentile_97": 5, "percentile_99": 8}, "updated_at":
+        "2022-07-28T19:56:20Z"}, {"carrier": "USPS", "carrier_account_id": "ca_b25657e9896e4d63ac8151ac346ac41e",
+        "created_at": "2022-07-28T19:56:20Z", "currency": "USD", "delivery_date":
+        null, "delivery_date_guaranteed": false, "delivery_days": 2, "est_delivery_days":
+        2, "id": "rate_56935feac32541ccb51057f8c42bba56", "list_currency": "USD",
+        "list_rate": 5.49, "mode": "test", "object": "Rate", "rate": 5.49, "retail_currency":
+        "USD", "retail_rate": 5.49, "service": "First", "shipment_id": "shp_a4309fb2a5e4463dae2b785e36fd6076",
+        "time_in_transit": {"percentile_50": 1, "percentile_75": 1, "percentile_85":
+        2, "percentile_90": 2, "percentile_95": 2, "percentile_97": 2, "percentile_99":
+        3}, "updated_at": "2022-07-28T19:56:20Z"}, {"carrier": "USPS", "carrier_account_id":
+        "ca_b25657e9896e4d63ac8151ac346ac41e", "created_at": "2022-07-28T19:56:20Z",
+        "currency": "USD", "delivery_date": null, "delivery_date_guaranteed": false,
+        "delivery_days": null, "est_delivery_days": null, "id": "rate_65ad3ee2a10f47d5a9d517dfce1e1a8f",
+        "list_currency": "USD", "list_rate": 23.75, "mode": "test", "object": "Rate",
+        "rate": 23.75, "retail_currency": "USD", "retail_rate": 27.4, "service": "Express",
+        "shipment_id": "shp_a4309fb2a5e4463dae2b785e36fd6076", "time_in_transit":
+        {"percentile_50": 1, "percentile_75": 1, "percentile_85": 1, "percentile_90":
+        2, "percentile_95": 2, "percentile_97": 2, "percentile_99": 4}, "updated_at":
+        "2022-07-28T19:56:20Z"}]}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -107,7 +198,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"d5d74a4b7deb530601e214072e10f606"
+      - W/"19327c3bc15f395e4403da3c99f2e8d8"
       expires:
       - '0'
       pragma:
@@ -125,20 +216,21 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 78245fba6272e16de786b8e80013b019
+      - 3843704262e2e9e4ff23e2bc00343670
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb9nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq fde591f008
-      - extlb2nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - intlb2wdc 403f17ff97
+      - extlb4wdc 403f17ff97
       x-runtime:
-      - '0.067440'
+      - '0.087560'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207272329-7f74c9e58c-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -291,7 +291,7 @@ def basic_pickup(basic_address):
     If you need to re-record cassettes, increment the date below and ensure it is one day in the future,
     USPS only does "next-day" pickups including Saturday but not Sunday or Holidays.
     """
-    pickup_date = "2022-05-06"
+    pickup_date = "2022-07-29"
 
     return {
         "address": basic_address,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -438,3 +438,45 @@ def event_body():
     }
 
     return json.dumps(data, separators=(",", ":")).encode()
+
+
+@pytest.fixture
+def carbon_offset_shipment():
+    return {
+        "to_address": {
+            "name": "Dr. Steve Brule",
+            "street1": "179 N Harbor Dr",
+            "city": "Redondo Beach",
+            "state": "CA",
+            "zip": "90277",
+            "country": "US",
+            "phone": "8573875756",
+            "email": "dr_steve_brule@gmail.com",
+        },
+        "from_address": {
+            "name": "EasyPost",
+            "street1": "417 Montgomery Street",
+            "street2": "5th Floor",
+            "city": "San Francisco",
+            "state": "CA",
+            "zip": "94104",
+            "country": "US",
+            "phone": "4153334445",
+            "email": "support@easypost.com",
+        },
+        "parcel": {
+            "length": "20.2",
+            "width": "10.9",
+            "height": "5",
+            "weight": "65.9",
+        },
+    }
+
+
+@pytest.fixture
+def carbon_offset_shipment_one_call_buy(carbon_offset_shipment, usps_service, usps_carrier_account_id, usps):
+    carbon_offset_shipment["service"] = "Priority"
+    carbon_offset_shipment["carrier_accounts"] = [usps_carrier_account_id]
+    carbon_offset_shipment["carrier"] = usps
+
+    return carbon_offset_shipment

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,7 +475,7 @@ def carbon_offset_shipment():
 
 @pytest.fixture
 def carbon_offset_shipment_one_call_buy(carbon_offset_shipment, usps_service, usps_carrier_account_id, usps):
-    carbon_offset_shipment["service"] = "Priority"
+    carbon_offset_shipment["service"] = usps_service
     carbon_offset_shipment["carrier_accounts"] = [usps_carrier_account_id]
     carbon_offset_shipment["carrier"] = usps
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -474,9 +474,9 @@ def carbon_offset_shipment():
 
 
 @pytest.fixture
-def carbon_offset_shipment_one_call_buy(carbon_offset_shipment, usps_service, usps_carrier_account_id, usps):
-    carbon_offset_shipment["service"] = usps_service
-    carbon_offset_shipment["carrier_accounts"] = [usps_carrier_account_id]
+def carbon_offset_shipment_one_call_buy(carbon_offset_shipment, usps_carrier_account_id, usps):
+    carbon_offset_shipment["service"] = "Priority"
+    carbon_offset_shipment["carrier_accounts"] = usps_carrier_account_id
     carbon_offset_shipment["carrier"] = usps
 
     return carbon_offset_shipment

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -258,7 +258,7 @@ def test_shipment_create_with_carbon_offset(carbon_offset_shipment):
 @pytest.mark.vcr()
 def test_shipment_buy_with_carbon_offset(carbon_offset_shipment):
     shipment = easypost.Shipment.create(**carbon_offset_shipment)
-    shipment.buy(carbon_offset=True, rate=shipment.lowest_rate())
+    shipment.buy(rate=shipment.lowest_rate(), carbon_offset=True)
 
     assert isinstance(shipment, easypost.Shipment)
     assert any(fee.type == "CarbonOffsetFee" for fee in shipment.fees)
@@ -279,7 +279,3 @@ def test_shipment_rerate_with_carbon_offset(carbon_offset_shipment_one_call_buy)
     new_carbon_rates = shipment.regenerate_rates(carbon_offset=True)
 
     assert all(rate.carbon_offset is not None for rate in new_carbon_rates.rates)
-
-    new_non_carbon_rates = shipment.regenerate_rates()
-    with pytest.raises(AttributeError):
-        assert all(rate.carbon_offset is None for rate in new_non_carbon_rates.rates)

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -248,7 +248,7 @@ def test_generate_form(one_call_buy_shipment, rma_form_options):
 
 @pytest.mark.vcr()
 def test_shipment_create_with_carbon_offset(carbon_offset_shipment):
-    shipment = easypost.Shipment.create(carbon_offset=True, **carbon_offset_shipment)
+    shipment = easypost.Shipment.create(with_carbon_offset=True, **carbon_offset_shipment)
 
     assert isinstance(shipment, easypost.Shipment)
     assert shipment.rates is not None
@@ -266,7 +266,7 @@ def test_shipment_buy_with_carbon_offset(carbon_offset_shipment):
 
 @pytest.mark.vcr()
 def test_shipment_one_call_buy_with_carbon_offset(carbon_offset_shipment_one_call_buy):
-    shipment = easypost.Shipment.create(carbon_offset=True, **carbon_offset_shipment_one_call_buy)
+    shipment = easypost.Shipment.create(with_carbon_offset=True, **carbon_offset_shipment_one_call_buy)
 
     assert isinstance(shipment, easypost.Shipment)
     assert all(rate.carbon_offset is not None for rate in shipment.rates)

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -258,7 +258,7 @@ def test_shipment_create_with_carbon_offset(carbon_offset_shipment):
 @pytest.mark.vcr()
 def test_shipment_buy_with_carbon_offset(carbon_offset_shipment):
     shipment = easypost.Shipment.create(**carbon_offset_shipment)
-    shipment.buy(rate=shipment.lowest_rate(), carbon_offset=True)
+    shipment.buy(rate=shipment.lowest_rate(), with_carbon_offset=True)
 
     assert isinstance(shipment, easypost.Shipment)
     assert any(fee.type == "CarbonOffsetFee" for fee in shipment.fees)
@@ -276,6 +276,6 @@ def test_shipment_one_call_buy_with_carbon_offset(carbon_offset_shipment_one_cal
 def test_shipment_rerate_with_carbon_offset(carbon_offset_shipment_one_call_buy):
     shipment = easypost.Shipment.create(**carbon_offset_shipment_one_call_buy)
 
-    new_carbon_rates = shipment.regenerate_rates(carbon_offset=True)
+    new_carbon_rates = shipment.regenerate_rates(with_carbon_offset=True)
 
     assert all(rate.carbon_offset is not None for rate in new_carbon_rates.rates)

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -244,3 +244,34 @@ def test_generate_form(one_call_buy_shipment, rma_form_options):
 
     assert form.form_type == form_type
     assert form.form_url is not None
+
+
+@pytest.mark.vcr()
+def test_shipment_create_with_carbon_offset(carbon_offset_shipment):
+    shipment = easypost.Shipment.create(carbon_offset=True, **carbon_offset_shipment)
+
+    assert all(rate.carbon_offset is not None for rate in shipment.rates)
+
+
+@pytest.mark.vcr()
+def test_shipment_buy_with_carbon_offset(carbon_offset_shipment):
+    shipment = easypost.Shipment.create(**carbon_offset_shipment)
+    shipment.buy(carbon_offset=True, rate=shipment.lowest_rate())
+
+    assert any(fee.type == "CarbonOffsetFee" for fee in shipment.fees)
+
+
+@pytest.mark.vcr()
+def test_shipment_one_call_buy_with_carbon_offset(carbon_offset_shipment_one_call_buy):
+    shipment = easypost.Shipment.create(carbon_offset=True, **carbon_offset_shipment_one_call_buy)
+
+    assert all(rate.carbon_offset is not None for rate in shipment.rates)
+
+
+@pytest.mark.vcr()
+def test_shipment_rerate_with_carbon_offset(carbon_offset_shipment_one_call_buy):
+    shipment = easypost.Shipment.create(**carbon_offset_shipment_one_call_buy)
+
+    rates = shipment.regenerate_rates(carbon_offset=True)
+
+    assert all(rate.carbon_offset is not None for rate in rates.rates)


### PR DESCRIPTION
# Description

- Adds the ability to create a shipment with carbon_offset
- Adds the ability to buy a shipment with carbon_offset
- Adds the ability to one-call-buy a shipment with carbon_offset
- Adds the ability to rerate a shipment with carbon_offset

# Testing

Added three unit tests and passed it

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
