### PR TITLE
fix: looser verify and verify_strict param type allowance

### DIFF
--- a/easypost/address.py
+++ b/easypost/address.py
@@ -2,6 +2,7 @@ from typing import (
     Any,
     Dict,
     Optional,
+    Union,
 )
 
 from easypost.easypost_object import convert_to_easypost_object
@@ -20,21 +21,19 @@ class Address(AllResource, CreateResource):
     def create(
         cls,
         api_key: Optional[str] = None,
-        verify: Optional[Dict[str, Any]] = None,
-        verify_strict: Dict[str, Any] = None,
+        verify: Optional[Union[Dict[str, Any], str, bool]] = None,
+        verify_strict: Optional[Union[Dict[str, Any], str, bool]] = None,
         **params
     ) -> "Address":
         """Create an address."""
         requestor = Requestor(local_api_key=api_key)
         url = cls.class_url()
 
-        wrapped_params = {cls.snakecase_name(): params}
-        for key, value in (("verify", verify), ("verify_strict", verify_strict)):
-            if not value:
-                continue
-            elif isinstance(value, (bool, str)):
-                value = [value]
-            wrapped_params[key] = value
+        wrapped_params = {cls.snakecase_name(): params}  # type: Dict[str, Any]
+        if verify:
+            wrapped_params["verify"] = verify
+        if verify_strict:
+            wrapped_params["verify_strict"] = verify_strict
 
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=wrapped_params)
         return convert_to_easypost_object(response=response, api_key=api_key)

--- a/tests/cassettes/test_address_create_verify_array.yaml
+++ b/tests/cassettes/test_address_create_verify_array.yaml
@@ -2,7 +2,7 @@ interactions:
 - request:
     body: '{"address": {"street1": "417 montgomery street", "street2": "FL 5", "city":
       "San Francisco", "state": "CA", "zip": "94104", "country": "US", "company":
-      "EasyPost", "phone": "415-123-4567"}, "verify": true}'
+      "EasyPost", "phone": "415-123-4567"}, "verify": [true]}'
     headers:
       Accept:
       - '*/*'
@@ -11,7 +11,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '205'
+      - '207'
       Content-Type:
       - application/json
       authorization:
@@ -22,8 +22,8 @@ interactions:
     uri: https://api.easypost.com/v2/addresses
   response:
     body:
-      string: '{"id": "adr_3b3317ee0f6511eda18eac1f6b0a0d1e", "object": "Address",
-        "created_at": "2022-07-29T17:38:17+00:00", "updated_at": "2022-07-29T17:38:17+00:00",
+      string: '{"id": "adr_3b80da120f6511eda1aaac1f6b0a0d1e", "object": "Address",
+        "created_at": "2022-07-29T17:38:18+00:00", "updated_at": "2022-07-29T17:38:18+00:00",
         "name": null, "company": "EASYPOST", "street1": "417 MONTGOMERY ST FL 5",
         "street2": "", "city": "SAN FRANCISCO", "state": "CA", "zip": "94104-1129",
         "country": "US", "phone": "<REDACTED>", "email": "<REDACTED>", "mode": "test",
@@ -42,11 +42,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"f161e91a2e4f595eed6e976ffb33bf73"
+      - W/"056ef1431c18520073dbf5f8b1a6dcc8"
       expires:
       - '0'
       location:
-      - /api/v2/addresses/adr_3b3317ee0f6511eda18eac1f6b0a0d1e
+      - /api/v2/addresses/adr_3b80da120f6511eda1aaac1f6b0a0d1e
       pragma:
       - no-cache
       referrer-policy:
@@ -62,18 +62,18 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 2415913f62e41b09e786b3e10005fc45
+      - 2415913c62e41b0ae786b3fa0005fc74
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb2nuq
+      - bigweb3nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
       - intlb1nuq 403f17ff97
       - extlb2nuq 403f17ff97
       x-runtime:
-      - '0.043328'
+      - '0.045200'
       x-version-label:
       - easypost-202207282305-ef64fb0c25-master
       x-xss-protection:

--- a/tests/cassettes/test_address_create_verify_strict.yaml
+++ b/tests/cassettes/test_address_create_verify_strict.yaml
@@ -2,7 +2,7 @@ interactions:
 - request:
     body: '{"address": {"name": "Jack Sparrow", "company": "EasyPost", "street1":
       "388 Townsend St", "street2": "Apt 20", "city": "San Francisco", "state": "CA",
-      "zip": "94107", "phone": "5555555555"}, "verify_strict": [true]}'
+      "zip": "94107", "phone": "5555555555"}, "verify_strict": true}'
     headers:
       Accept:
       - '*/*'
@@ -11,7 +11,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '215'
+      - '213'
       Content-Type:
       - application/json
       authorization:
@@ -22,9 +22,15 @@ interactions:
     uri: https://api.easypost.com/v2/addresses
   response:
     body:
-      string: '{"id":"adr_5089554ccbe811ec833eac1f6bc7b362","object":"Address","created_at":"2022-05-04T20:25:18+00:00","updated_at":"2022-05-04T20:25:18+00:00","name":"JACK
-        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}}'
+      string: '{"id": "adr_3b5a65d70f6511ed98f4ac1f6bc72124", "object": "Address",
+        "created_at": "2022-07-29T17:38:18+00:00", "updated_at": "2022-07-29T17:38:18+00:00",
+        "name": "JACK SPARROW", "company": "EASYPOST", "street1": "388 TOWNSEND ST
+        APT 20", "street2": "", "city": "SAN FRANCISCO", "state": "CA", "zip": "94107-1670",
+        "country": "US", "phone": "<REDACTED>", "email": "<REDACTED>", "mode": "test",
+        "carrier_facility": null, "residential": true, "federal_tax_id": null, "state_tax_id":
+        null, "verifications": {"zip4": {"success": true, "errors": [], "details":
+        null}, "delivery": {"success": true, "errors": [], "details": {"latitude":
+        37.77551, "longitude": -122.39697, "time_zone": "America/Los_Angeles"}}}}'
     headers:
       cache-control:
       - no-cache, no-store
@@ -33,11 +39,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"c6e8a2eecd3fff24b2ca9757bfaf800e"
+      - W/"22ac1cfa3f1fbe071cad5da66ce774e5"
       expires:
       - '0'
       location:
-      - /api/v2/addresses/adr_5089554ccbe811ec833eac1f6bc7b362
+      - /api/v2/addresses/adr_3b5a65d70f6511ed98f4ac1f6bc72124
       pragma:
       - no-cache
       referrer-policy:
@@ -53,20 +59,20 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 62b330b86272e12ee786b81d001613ec
+      - 2415913a62e41b09e786b3f90005fc61
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb8nuq
+      - bigweb5nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb2nuq fde591f008
-      - extlb1nuq c51cdb8bf2
+      - intlb2nuq 403f17ff97
+      - extlb2nuq 403f17ff97
       x-runtime:
-      - '0.043825'
+      - '0.045077'
       x-version-label:
-      - easypost-202205041833-02730cc398-master
+      - easypost-202207282305-ef64fb0c25-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -13,15 +13,49 @@ def test_address_create(basic_address):
 
 
 @pytest.mark.vcr()
+def test_address_create_verify(incorrect_address_to_verify):
+    """Test creating an address with the verify param.
+
+    We purposefully pass in slightly incorrect data to get the corrected address back once verified.
+    """
+    incorrect_address_to_verify["verify"] = True
+
+    address = easypost.Address.create(**incorrect_address_to_verify)
+
+    assert isinstance(address, easypost.Address)
+    assert str.startswith(address.id, "adr_")
+    assert address.street1 == "417 MONTGOMERY ST FL 5"
+
+
+@pytest.mark.vcr()
 def test_address_create_verify_strict(basic_address):
+    """Test creating an address with the verify_strict param.
+
+    We purposefully pass in slightly incorrect data to get the corrected address back once verified.
+    """
     address_data = basic_address
-    address_data["verify_strict"] = [True]
+    address_data["verify_strict"] = True
 
     address = easypost.Address.create(**address_data)
 
     assert isinstance(address, easypost.Address)
     assert str.startswith(address.id, "adr_")
     assert address.street1 == "388 TOWNSEND ST APT 20"
+
+
+@pytest.mark.vcr()
+def test_address_create_verify_array(incorrect_address_to_verify):
+    """Test creating an address with the verify param as an array.
+
+    We purposefully pass in slightly incorrect data to get the corrected address back once verified.
+    """
+    incorrect_address_to_verify["verify"] = [True]
+
+    address = easypost.Address.create(**incorrect_address_to_verify)
+
+    assert isinstance(address, easypost.Address)
+    assert str.startswith(address.id, "adr_")
+    assert address.street1 == "417 MONTGOMERY ST FL 5"
 
 
 @pytest.mark.vcr()
@@ -46,37 +80,8 @@ def test_address_all(page_size):
 
 
 @pytest.mark.vcr()
-def test_address_create_verify(incorrect_address_to_verify):
-    """Test creating a verified address.
-
-    We purposefully pass in slightly incorrect data to get the corrected address back once verified.
-    """
-    incorrect_address_to_verify["verify"] = [True]
-
-    address = easypost.Address.create(**incorrect_address_to_verify)
-
-    assert isinstance(address, easypost.Address)
-    assert str.startswith(address.id, "adr_")
-    assert address.street1 == "417 MONTGOMERY ST FL 5"
-
-
-@pytest.mark.vcr()
-def test_address_create_and_verify(incorrect_address_to_verify):
-    """Test creating a verified address.
-
-    We purposefully pass in slightly incorrect data to get the corrected address back once verified.
-    """
-    incorrect_address_to_verify["verify"] = [True]
-
-    address = easypost.Address.create_and_verify(**incorrect_address_to_verify)
-
-    assert isinstance(address, easypost.Address)
-    assert str.startswith(address.id, "adr_")
-    assert address.street1 == "417 MONTGOMERY ST FL 5"
-
-
-@pytest.mark.vcr()
 def test_address_verify(basic_address):
+    """Test verifying an already created address."""
     address = easypost.Address.create(**basic_address)
     address.verify()
 


### PR DESCRIPTION
# Description

Allows for looser `verify` and `verify_strict` params because strings and bools are valid syntax (which is what we have documented). Also corrects the type hints for these. 
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Updates old tests to use booleans to match our docs
- Adds a new test to ensure array syntax still works. 
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
