### PR TITLE
chore: remove pypy tests and plumbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ["pypy-3.6", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        pythonversion: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: set up python
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: ${{ matrix.pythonversion }}
       - name: Install Dependencies
-        run: make ${{ matrix.pythonversion == 'pypy-3.6' && 'install-pypy' || 'install' }}
+        run: make install
       - name: Run Tests
         run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make test
       - name: Run security analysis

--- a/Makefile
+++ b/Makefile
@@ -36,17 +36,9 @@ format: black isort
 format-check: black-check isort-check lint mypy
 
 ## install - Install the project locally
-install: | venv install-dev
-
-## install-dev - Install dev requirements
-install-dev: | venv
+install:
+	$(PYTHON_BINARY) -m venv $(VIRTUAL_ENV)
 	$(VIRTUAL_BIN)/pip install -e ."[dev]"
-	git submodule init
-	git submodule update
-
-## install-pypy - Install dev requirements for pypy
-install-pypy: | venv
-	$(VIRTUAL_BIN)/pip install -e ."[pypy_dev]"
 	git submodule init
 	git submodule update
 
@@ -83,8 +75,4 @@ scan:
 test:
 	$(VIRTUAL_BIN)/pytest
 
-## venv - Create the virtual environment
-venv:
-	$(PYTHON_BINARY) -m venv $(VIRTUAL_ENV)
-
-.PHONY: help build clean coverage black black-check format format-check install install-dev install-pypy isort isort-check lint mypy publish release scan test
+.PHONY: help build clean coverage black black-check format format-check install isort isort-check lint mypy publish release scan test

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ EasyPost, the simple shipping solution. You can sign up for an account at <https
 
 ## Install
 
+The library is tested against Python3 and should be compatible with PyPy3.
+
 ```bash
 pip install easypost
 ```

--- a/easypost/__init__.py
+++ b/easypost/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 import easypost.beta
 from easypost.address import Address
 from easypost.batch import Batch

--- a/easypost/beta/__init__.py
+++ b/easypost/beta/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from easypost.beta.referral import Referral

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@ REQUIREMENTS = [
 DEV_REQUIREMENTS = [
     "bandit==1.7.1",  # Bandit 1.7.2 drops support for Python 3.6
     "black==22.*",
-    "flake8==4.*",
+    "flake8==5.*",
     "isort==5.*",
+    "mypy==0.971",
     "pytest-cov==3.*",
     "pytest-vcr==1.*",
     "pytest==7.*",
@@ -22,11 +23,6 @@ DEV_REQUIREMENTS = [
     "types-urllib3",
     "vcrpy==4.*",
     "wheel==0.37.*",
-]
-
-# packages incompatible with PyPy go here
-CPYTHON_DEV_REQUIREMENTS = [
-    "mypy==0.942",
 ]
 
 with open("README.md", encoding="utf-8") as f:
@@ -47,8 +43,7 @@ setup(
     ),
     install_requires=REQUIREMENTS,
     extras_require={
-        "dev": DEV_REQUIREMENTS + CPYTHON_DEV_REQUIREMENTS,
-        "pypy_dev": DEV_REQUIREMENTS,  # no cpython requirements
+        "dev": DEV_REQUIREMENTS,
     },
     package_data={
         "easypost": ["py.typed"],


### PR DESCRIPTION
# Description

After weeks of checking, I see no usage for PyPy and deem it safe to remove the tests/plumbing for it. The library will continue to work with PyPy but we will no longer explicitly test for it. Doing so was slow and required some odd workarounds on CI to run them properly. This will reduce our testing complexity on CI while allowing us to maintain a single set of dependencies. If ever we really needed to be testing against this, we can always add it back in; however, I haven't heard of any complaints on the matter in the past.<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Overhauled the dependencies to work as expected along with the build.
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
