### PR TITLE
feat: adds end_shipper_id on the buy call of a Shipment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+- Adds support to pass `end_shipper_id` on the buy call of a Shipment
+
 ## v7.5.0 (2022-08-25)
 
 - Adds the `EndShipper` class with `create`, `retrieve`, `all`, and `save` functions

--- a/easypost/shipment.py
+++ b/easypost/shipment.py
@@ -47,11 +47,15 @@ class Shipment(AllResource):
         response, _ = requestor.request(method=RequestMethod.GET, url=url)
         return response.get("result", [])
 
-    def buy(self, with_carbon_offset: Optional[bool] = False, **params) -> "Shipment":
+    def buy(
+        self, with_carbon_offset: Optional[bool] = False, end_shipper_id: Optional[str] = None, **params
+    ) -> "Shipment":
         """Buy a shipment."""
         requestor = Requestor(local_api_key=self._api_key)
         url = "%s/%s" % (self.instance_url(), "buy")
         params["carbon_offset"] = with_carbon_offset
+        if end_shipper_id:
+            params["end_shipper_id"] = end_shipper_id
 
         response, api_key = requestor.request(method=RequestMethod.POST, url=url, params=params)
         self.refresh_from(values=response, api_key=api_key)

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import pytest
 
 import easypost
+from easypost.requestor import RequestMethod
 
 
 @pytest.mark.vcr()
@@ -279,3 +282,33 @@ def test_shipment_rerate_with_carbon_offset(one_call_buy_shipment):
     new_carbon_rates = shipment.regenerate_rates(with_carbon_offset=True)
 
     assert all(rate.carbon_offset is not None for rate in new_carbon_rates.rates)
+
+
+@patch(
+    "easypost.requestor.Requestor.request",
+    return_value=[
+        {"mock-request": None},
+        "mock-api-key",
+    ],
+)
+def test_shipment_buy_with_end_shipper_id(mock_request):
+    """Because this requires an API call in prod, we mock the request instead of using
+    VCR to ensure test user accounts don't get charged for real postage since we can only
+    guarantee a USPS carrier account will be configured for a user.
+    """
+    shipment_id = "shp_123"
+    end_shipper_id = "es_123"
+    rate_id = "rate_123"
+
+    mock_shipment = easypost.Shipment(easypost_id=shipment_id)
+    mock_shipment.buy(rate={"id": rate_id}, end_shipper_id=end_shipper_id)
+
+    mock_request.assert_called_once_with(
+        method=RequestMethod.POST,
+        url=f"/shipments/{shipment_id}/buy",
+        params={
+            "rate": {"id": rate_id},
+            "carbon_offset": False,
+            "end_shipper_id": end_shipper_id,
+        },
+    )


### PR DESCRIPTION
# Description

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

Adds support to pass `end_shipper_id` in the `buy` function of a Shipment object.

# Testing

Mocks the call to our API since we can't use VCR due to the fact that buying with an EndShipper ID requires a prod key which will buy real postage and we don't want to charge users.

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
