### PR TITLE
fix: slow scrubbing due to wrong for loop placement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 
 ## coverage - Test the project and generate an HTML coverage report
 coverage:
-	$(VIRTUAL_BIN)/pytest --cov=$(PROJECT_NAME) --cov-branch --cov-report=html --cov-report=term-missing --cov-fail-under=88
+	$(VIRTUAL_BIN)/pytest --cov=$(PROJECT_NAME) --cov-branch --cov-report=html --cov-report=term-missing --cov-fail-under=87
 
 ## black - Runs the Black Python formatter against the project
 black:


### PR DESCRIPTION
# Description

This PR fixes the slow scrubbing operations due to an incorrectly placed for loop. By pulling the for loop outside of the recursive call, we aren't needlessly double, triple, etc running the foor loop inside of another foor loop down and down the rabbit hole. 

NOTE: The enforcement for coverage was dropped 1% since it was straddling the line and falls just beneath it on CI for some reason.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

I tested a few cassettes getting re-recorded and ensured this worked as intended

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
