### PR TITLE
feat: adds cassette expirations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ git submodule update --remote
 
 ### Testing
 
-The test suite in this project was specifically built to produce consistent results on every run, regardless of when they run or who is running them. This project uses [VCR](https://github.com/kevin1024/vcrpy) to record and replay HTTP requests and responses via "cassettes". When the suite is run, the HTTP requests and responses for each test function will be saved to a cassette if they do not exist already and replayed from this saved file if they do, which saves the need to make live API calls on every test run.
+The test suite in this project was specifically built to produce consistent results on every run, regardless of when they run or who is running them. This project uses [VCR](https://github.com/kevin1024/vcrpy) to record and replay HTTP requests and responses via "cassettes". When the suite is run, the HTTP requests and responses for each test function will be saved to a cassette if they do not exist already and replayed from this saved file if they do, which saves the need to make live API calls on every test run. If you receive errors about a cassette expiring, delete and re-record the cassette to ensure the data is up-to-date.
 
 **Sensitive Data:** We've made every attempt to include scrubbers for sensitive data when recording cassettes so that PII or sensitive info does not persist in version control; however, please ensure when recording or re-recording cassettes that prior to committing your changes, no PII or sensitive information gets persisted by inspecting the cassette.
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -24,7 +24,6 @@ def test_event_retrieve(page_size):
     assert str.startswith(event.id, "evt_")
 
 
-@pytest.mark.vcr()
 def test_event_receive(event_json):
     event = easypost.Event.receive(event_json)
 


### PR DESCRIPTION
# Description

Adds a test utility that checks for expired cassettes on each run and throws errors if cassettes must be re-recorded due to old age to ensure the data is always up-to-date within a half year.
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

I set the days to ~40 and errors were thrown, setting it to 180 has the suite pass 
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
