### PR TITLE
chore: remove unused enumeration in cassette scrubbing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,7 +157,7 @@ def scrub_response_bodies(scrubbers: List[Tuple[str, Any]]) -> Any:
                 data[key] = replacement
             else:
                 # Nested scrubbing
-                for index, item in enumerate(data):
+                for item in data:
                     element = data[item]
                     if isinstance(element, list):
                         for nested_index, nested_item in enumerate(element):


### PR DESCRIPTION
# Description

Removes an unused enumeration for cassette scrubbing
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
