### PR TITLE
fix: concatenates error.message if it is a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+- Concatenates `error.message` if it incorrectly comes back from the API as a list
+
 ## v7.6.0 (2022-09-21)
 
 - Adds support to pass `end_shipper_id` on the buy call of a Shipment

--- a/easypost/error.py
+++ b/easypost/error.py
@@ -8,13 +8,15 @@ from typing import (
 class Error(Exception):
     def __init__(
         self,
-        message: Optional[str] = None,
+        message: Optional[
+            Union[str, list]
+        ] = None,  # message should be a string but can sometimes incorrectly come back as a list
         http_status: Optional[int] = None,
         http_body: Optional[Union[str, bytes]] = None,
         original_exception: Optional[Exception] = None,
     ):
         super(Error, self).__init__(message)
-        self.message = message
+        self.message = ", ".join(message) if type(message) == list else message
         self.http_status = http_status
         self.http_body = http_body
         self.original_exception = original_exception

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -21,3 +21,12 @@ def test_error_no_json():
     error = easypost.Error(http_body="bad json")
 
     assert error.json_body is None
+
+
+def test_error_list_message():
+    """Tests that we concatenate error messages that are a list (they should be a string from the
+    API but aren't always so we protect against that here).
+    """
+    error = easypost.Error(message=["Error1", "Error2"])
+
+    assert error.message == "Error1, Error2"


### PR DESCRIPTION
# Description

Concatenates `error.message` if it incorrectly comes back from the API as a list
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Adds a new unit test to ensure this works
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
