### PR TITLE
simplify: coveralls reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,10 @@ jobs:
         run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make coverage
       - name: Coveralls
         if: github.ref == 'refs/heads/master'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: venv/bin/coveralls --service=github
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: "./coverage.lcov"
       - name: Run security analysis
         run: make scan
   docs:

--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,13 @@
 .Trashes
 .virtualenv
 *.class
-*.egg
 *.egg-info
 *.pyc
 *.sublime-*
+/build
+/dist
 /MANIFEST
+coverage.lcov
 dist
 docs
 Icon

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ clean:
 
 ## coverage - Test the project and generate an HTML coverage report
 coverage:
-	$(VIRTUAL_BIN)/pytest --cov=$(PROJECT_NAME) --cov-branch --cov-report=html --cov-report=term-missing --cov-fail-under=87
+	$(VIRTUAL_BIN)/pytest --cov=$(PROJECT_NAME) --cov-branch --cov-report=html --cov-report=lcov --cov-report=term-missing --cov-fail-under=88
 
 ## docs - Generates docs for the library
 docs:

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,11 @@ DEV_REQUIREMENTS = [
     "black==23.*",
     "build==0.10.*",
     "urllib3==1.*",  # TODO: Pinned because vcrpy did a dumb and didn't pin urllib3
-    "coveralls == 3.*",
     "flake8==5.*",  # TODO: flake8 v6 requires Python 3.8.1+
     "isort==5.*",
     "mypy==1.3.*",
     "pdoc==13.*",
-    "pytest-cov==3.*",
+    "pytest-cov==4.*",
     "pytest-vcr==1.*",
     "pytest==7.*",
     "twine==4.*",


### PR DESCRIPTION
# Description

The previous implementation of coveralls used a Python package to generate `lcov` reports because `pytest-cov` previously didn't support it; however, just a month ago support was added. This PR removes the unneeded `coveralls` dependency and uses the same flow as our other repos to report which is much simpler

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
