### PR TITLE
feat: add carrier metadata beta endpoint

### DIFF
--- a/easypost/beta/__init__.py
+++ b/easypost/beta/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa
+from easypost.beta.carrier_metadata import CarrierMetadata
 from easypost.beta.rate import Rate
 from easypost.beta.referral import Referral

--- a/easypost/beta/carrier_metadata.py
+++ b/easypost/beta/carrier_metadata.py
@@ -1,0 +1,26 @@
+from typing import (
+    Any,
+    List,
+    Optional,
+)
+
+from easypost.easypost_object import convert_to_easypost_object
+from easypost.requestor import (
+    RequestMethod,
+    Requestor,
+)
+
+
+class CarrierMetadata:
+    @classmethod
+    def retrieve_carrier_metadata(
+        cls, api_key: Optional[str] = None, carriers: Optional[List[str]] = None, types: Optional[List[str]] = None
+    ) -> List[dict[str, Any]]:
+        """Get carrier metadata for all carriers on the EasyPost platform."""
+        requestor = Requestor(local_api_key=api_key)
+        params = {
+            "carriers": ",".join(carriers) if carriers else None,
+            "types": ",".join(types) if types else None,
+        }
+        response, api_key = requestor.request(method=RequestMethod.GET, url="/metadata", params=params, beta=True)
+        return convert_to_easypost_object(response=response.get("carriers", []), api_key=api_key)

--- a/easypost/beta/carrier_metadata.py
+++ b/easypost/beta/carrier_metadata.py
@@ -1,5 +1,6 @@
 from typing import (
     Any,
+    Dict,
     List,
     Optional,
 )
@@ -15,7 +16,7 @@ class CarrierMetadata:
     @classmethod
     def retrieve_carrier_metadata(
         cls, api_key: Optional[str] = None, carriers: Optional[List[str]] = None, types: Optional[List[str]] = None
-    ) -> List[dict[str, Any]]:
+    ) -> List[Dict[str, Any]]:
         """Get carrier metadata for all carriers on the EasyPost platform."""
         requestor = Requestor(local_api_key=api_key)
         params = {

--- a/tests/cassettes/test_beta_retrieve_carrier_metadata.yaml
+++ b/tests/cassettes/test_beta_retrieve_carrier_metadata.yaml
@@ -1,0 +1,1792 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: GET
+    uri: https://api.easypost.com/beta/metadata
+  response:
+    body:
+      string: '{"carriers": [{"human_readable": "Amazon MWS", "name": "amazonmws",
+        "predefined_packages": [], "service_levels": [{"carrier": "amazonmws", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "UPS Rates"}, {"carrier": "amazonmws", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "USPS Rates"}, {"carrier":
+        "amazonmws", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "FedEx Rates"}, {"carrier": "amazonmws", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "UPS Labels"}, {"carrier": "amazonmws", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "USPS Labels"}, {"carrier":
+        "amazonmws", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "FedEx Labels"}, {"carrier": "amazonmws", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "UPS Tracking"}, {"carrier": "amazonmws", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "USPS Tracking"},
+        {"carrier": "amazonmws", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "FedEx Tracking"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "APC", "name": "apc", "predefined_packages":
+        [], "service_levels": [{"carrier": "apc", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "parcelConnectBookService"},
+        {"carrier": "apc", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "parcelConnectExpeditedDDP"}, {"carrier":
+        "apc", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "parcelConnectExpeditedDDU"}, {"carrier": "apc", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "parcelConnectPriorityDDP"}, {"carrier": "apc", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "parcelConnectPriorityDDPDelcon"},
+        {"carrier": "apc", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "parcelConnectPriorityDDU"}, {"carrier":
+        "apc", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "parcelConnectPriorityDDUDelcon"}, {"carrier": "apc", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "parcelConnectPriorityDDUPQW"}, {"carrier": "apc", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "parcelConnectStandardDDU"},
+        {"carrier": "apc", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "parcelConnectStandardDDUPQW"}, {"carrier":
+        "apc", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "parcelConnectPacketDDU"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "Asendia USA", "name": "asendiausa", "predefined_packages":
+        [], "service_levels": [{"carrier": "asendiausa", "description": null, "dimensions":
+        [], "human_readable": "ADS", "max_weight": null, "name": "ADS"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "Air
+        Freight Inbound", "max_weight": null, "name": "AirFreightInbound"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "Air
+        Freight Outbound", "max_weight": null, "name": "AirFreightOutbound"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "Asendia
+        Domestic Bound Printed Matter Expedited", "max_weight": null, "name": "AsendiaDomesticBoundPrinterMatterExpedited"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Asendia Domestic Bound Printed Matter Ground", "max_weight": null, "name":
+        "AsendiaDomesticBoundPrinterMatterGround"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "Asendia Domestic Flats Expedited",
+        "max_weight": null, "name": "AsendiaDomesticFlatsExpedited"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "Asendia
+        Domestic Flats Ground", "max_weight": null, "name": "AsendiaDomesticFlatsGround"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Asendia Domestic Parcel Ground Over 1 Lb", "max_weight": null, "name": "AsendiaDomesticParcelGroundOver1lb"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Asendia Domestic Parcel Ground Under 1 Lb", "max_weight": null, "name": "AsendiaDomesticParcelGroundUnder1lb"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Asendia Domestic Parcel MAX Over 1 Lb", "max_weight": null, "name": "AsendiaDomesticParcelMAXOver1lb"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Asendia Domestic Parcel MAX Under 1 Lb", "max_weight": null, "name": "AsendiaDomesticParcelMAXUnder1lb"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Asendia Domestic Parcel Over 1 Lb Expedited", "max_weight": null, "name":
+        "AsendiaDomesticParcelOver1lbExpedited"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "Asendia Domestic Parcel Under 1
+        Lb Expedited", "max_weight": null, "name": "AsendiaDomesticParcelUnder1lbExpedited"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Asendia Domestic Promo Parcel Expedited", "max_weight": null, "name": "AsendiaDomesticPromoParcelExpedited"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Asendia Domestic Promo Parcel Ground", "max_weight": null, "name": "AsendiaDomesticPromoParcelGround"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Bulk Freight", "max_weight": null, "name": "BulkFreight"}, {"carrier": "asendiausa",
+        "description": null, "dimensions": [], "human_readable": "Business Mail Canada
+        Lettermail", "max_weight": null, "name": "BusinessMailCanadaLettermail"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Business Mail Canada Lettermail Machineable", "max_weight": null, "name":
+        "BusinessMailCanadaLettermailMachineable"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "Business Mail Economy", "max_weight":
+        null, "name": "BusinessMailEconomy"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "Business Mail Economy LP Wholesale",
+        "max_weight": null, "name": "BusinessMailEconomyLPWholesale"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "Business
+        Mail Economy SP Wholesale", "max_weight": null, "name": "BusinessMailEconomySPWholesale"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Business Mail International Priority Airmail", "max_weight": null, "name":
+        "BusinessMailIPA"}, {"carrier": "asendiausa", "description": null, "dimensions":
+        [], "human_readable": "Business Mail International Surface Air Lift", "max_weight":
+        null, "name": "BusinessMailISAL"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "Business Mail Priority", "max_weight":
+        null, "name": "BusinessMailPriority"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "Business Mail Priority LP Wholesale",
+        "max_weight": null, "name": "BusinessMailPriorityLPWholesale"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "Business
+        Mail Priority SP Wholesale", "max_weight": null, "name": "BusinessMailPrioritySPWholesale"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Marketing Mail Canada Personalized Letter Carrier Presort", "max_weight":
+        null, "name": "MarketingMailCanadaPersonalizedLCP"}, {"carrier": "asendiausa",
+        "description": null, "dimensions": [], "human_readable": "Marketing Mail Canada
+        Personalized Machineable", "max_weight": null, "name": "MarketingMailCanadaPersonalizedMachineable"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Marketing Mail Canada Personalized Non-Dangerous Goods", "max_weight": null,
+        "name": "MarketingMailCanadaPersonalizedNDG"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "Marketing Mail Economy", "max_weight":
+        null, "name": "MarketingMailEconomy"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "Marketing Mail International Priority
+        Airmail", "max_weight": null, "name": "MarketingMailIPA"}, {"carrier": "asendiausa",
+        "description": null, "dimensions": [], "human_readable": "MarketingMail International
+        Surface Air Lift", "max_weight": null, "name": "MarketingMailISAL"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "Marketing
+        Mail Priority", "max_weight": null, "name": "MarketingMailPriority"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "Publications
+        Canada Letter Carrier Presort", "max_weight": null, "name": "PublicationsCanadaLCP"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Publications Canada Non-Dangerous Goods", "max_weight": null, "name": "PublicationsCanadaNDG"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Publications Economy", "max_weight": null, "name": "PublicationsEconomy"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "Publications International Priority Airmail", "max_weight": null, "name":
+        "PublicationsIPA"}, {"carrier": "asendiausa", "description": null, "dimensions":
+        [], "human_readable": "Publications International Surface Air Lift", "max_weight":
+        null, "name": "PublicationsISAL"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "Publications Priority", "max_weight":
+        null, "name": "PublicationsPriority"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "ePAQ Elite", "max_weight": null,
+        "name": "ePAQElite"}, {"carrier": "asendiausa", "description": null, "dimensions":
+        [], "human_readable": "ePAQ Elite Custom", "max_weight": null, "name": "ePAQEliteCustom"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQElite Delivered At Place", "max_weight": null, "name": "ePAQEliteDAP"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Elite Delivered Duty Paid", "max_weight": null, "name": "ePAQEliteDDP"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Elite Delivered Duty Paid Oversized", "max_weight": null, "name": "ePAQEliteDDPOversized"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Elite DPD", "max_weight": null, "name": "ePAQEliteDPD"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Elite Direct Access Canada Delivered Duty Paid", "max_weight": null, "name":
+        "ePAQEliteDirectAccessCanadaDDP"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "ePAQ Elite Oversized", "max_weight":
+        null, "name": "ePAQEliteOversized"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "ePAQ Plus", "max_weight": null,
+        "name": "ePAQPlus"}, {"carrier": "asendiausa", "description": null, "dimensions":
+        [], "human_readable": "ePAQ Plus Custom", "max_weight": null, "name": "ePAQPlusCustom"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Plus Customs Pre-Paid", "max_weight": null, "name": "ePAQPlusCustomsPrepaid"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Plus Delivered At Place", "max_weight": null, "name": "ePAQPlusDAP"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Plus Delivered Duty Paid", "max_weight": null, "name": "ePAQPlusDDP"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Plus Economy", "max_weight": null, "name": "ePAQPlusEconomy"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Plus Wholesale", "max_weight": null, "name": "ePAQPlusWholesale"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Plus ePacket", "max_weight": null, "name": "ePAQPlusePacket"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Plus ePacket Canada Customs Pre-Paid", "max_weight": null, "name": "ePAQPlusePacketCanadaCustomsPrePaid"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Plus ePacket Canada Delivered Duty Paid", "max_weight": null, "name":
+        "ePAQPlusePacketCanadaDDP"}, {"carrier": "asendiausa", "description": null,
+        "dimensions": [], "human_readable": "ePAQ Returns Domestic", "max_weight":
+        null, "name": "ePAQReturnsDomestic"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "ePAQ Returns International", "max_weight":
+        null, "name": "ePAQReturnsInternational"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "ePAQ Select", "max_weight": null,
+        "name": "ePAQSelect"}, {"carrier": "asendiausa", "description": null, "dimensions":
+        [], "human_readable": "ePAQ Select Custom", "max_weight": null, "name": "ePAQSelectCustom"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Select Customs Pre-Paid By Shopper", "max_weight": null, "name": "ePAQSelectCustomsPrepaidByShopper"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Select Delivered At Place", "max_weight": null, "name": "ePAQSelectDAP"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Select Delivered Duty Paid", "max_weight": null, "name": "ePAQSelectDDP"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Select Delivered Duty Paid Direct Access", "max_weight": null, "name":
+        "ePAQSelectDDPDirectAccess"}, {"carrier": "asendiausa", "description": null,
+        "dimensions": [], "human_readable": "ePAQ Select Direct Access", "max_weight":
+        null, "name": "ePAQSelectDirectAccess"}, {"carrier": "asendiausa", "description":
+        null, "dimensions": [], "human_readable": "ePAQ Select Direct Access Canada
+        Delivered Duty Paid", "max_weight": null, "name": "ePAQSelectDirectAccessCanadaDDP"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Select Economy", "max_weight": null, "name": "ePAQSelectEconomy"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Select Oversized", "max_weight": null, "name": "ePAQSelectOversized"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Select Oversized Delivered Duty Paid", "max_weight": null, "name": "ePAQSelectOversizedDDP"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Select PMEI", "max_weight": null, "name": "ePAQSelectPMEI"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Select PMEI Canada Customs Pre-Paid", "max_weight": null, "name": "ePAQSelectPMEICanadaCustomsPrePaid"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Select PMEIPC Postage", "max_weight": null, "name": "ePAQSelectPMEIPCPostage"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Select Priority Mail International", "max_weight": null, "name": "ePAQSelectPMI"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Select Priority Mail International Canada Customs Pre-Paid", "max_weight":
+        null, "name": "ePAQSelectPMICanadaCustomsPrepaid"}, {"carrier": "asendiausa",
+        "description": null, "dimensions": [], "human_readable": "ePAQ Select Priority
+        Mail International Canada Delivered Duty Paid", "max_weight": null, "name":
+        "ePAQSelectPMICanadaDDP"}, {"carrier": "asendiausa", "description": null,
+        "dimensions": [], "human_readable": "ePAQ Select Priority Mail International
+        Non-Presort", "max_weight": null, "name": "ePAQSelectPMINonPresort"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Select PMIPC Postage", "max_weight": null, "name": "ePAQSelectPMIPCPostage"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Standard", "max_weight": null, "name": "ePAQStandard"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Standard Custom", "max_weight": null, "name": "ePAQStandardCustom"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Standard Economy", "max_weight": null, "name": "ePAQStandardEconomy"}, {"carrier":
+        "asendiausa", "description": null, "dimensions": [], "human_readable": "ePAQ
+        Standard International Priority Airmail", "max_weight": null, "name": "ePAQStandardIPA"},
+        {"carrier": "asendiausa", "description": null, "dimensions": [], "human_readable":
+        "ePAQ Standard International Surface Air Lift", "max_weight": null, "name":
+        "ePAQStandardISAL"}, {"carrier": "asendiausa", "description": null, "dimensions":
+        [], "human_readable": "ePaq Select PMEI Non-Presort", "max_weight": null,
+        "name": "ePaqSelectPMEINonPresort"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "Australia Post", "name": "australiapost", "predefined_packages":
+        [{"carrier": "australiapost", "description": null, "dimensions": [], "human_readable":
+        "Carton", "max_weight": null, "name": "CARTON"}, {"carrier": "australiapost",
+        "description": null, "dimensions": [], "human_readable": "Pallet", "max_weight":
+        null, "name": "PALLET"}, {"carrier": "australiapost", "description": null,
+        "dimensions": [], "human_readable": "Satchel", "max_weight": null, "name":
+        "SATCHEL"}, {"carrier": "australiapost", "description": null, "dimensions":
+        [], "human_readable": "Bag", "max_weight": null, "name": "BAG"}, {"carrier":
+        "australiapost", "description": null, "dimensions": [], "human_readable":
+        "Envelope", "max_weight": null, "name": "ENVELOPE"}, {"carrier": "australiapost",
+        "description": null, "dimensions": [], "human_readable": "Item", "max_weight":
+        null, "name": "ITEM"}, {"carrier": "australiapost", "description": null, "dimensions":
+        [], "human_readable": "Jiffy Bag", "max_weight": null, "name": "JIFFYBAG"},
+        {"carrier": "australiapost", "description": "Up to 500kg", "dimensions": [],
+        "human_readable": "Skid", "max_weight": null, "name": "SKID"}], "service_levels":
+        [{"carrier": "australiapost", "description": "Specific service availability
+        is determined by your AustraliaPost account.", "dimensions": [], "human_readable":
+        "Parcel Post", "max_weight": null, "name": "ParcelPost"}, {"carrier": "australiapost",
+        "description": "Specific service availability is determined by your AustraliaPost
+        account.", "dimensions": [], "human_readable": "Express Post", "max_weight":
+        null, "name": "ExpressPost"}, {"carrier": "australiapost", "description":
+        "Specific service availability is determined by your AustraliaPost account.International
+        returns not supported.", "dimensions": [], "human_readable": "International",
+        "max_weight": null, "name": "International"}, {"carrier": "australiapost",
+        "description": "Specific service availability is determined by your AustraliaPost
+        account.", "dimensions": [], "human_readable": "Commercial", "max_weight":
+        null, "name": "Commercial"}], "shipment_options": [], "supported_features":
+        [{"carrier": "australiapost", "description": null, "name": "labels", "supported":
+        true}, {"carrier": "australiapost", "description": null, "name": "orders",
+        "supported": true}, {"carrier": "australiapost", "description": null, "name":
+        "pickups", "supported": false}, {"carrier": "australiapost", "description":
+        null, "name": "refunds", "supported": true}, {"carrier": "australiapost",
+        "description": "Domestic only.", "name": "returns", "supported": true}, {"carrier":
+        "australiapost", "description": null, "name": "scanforms", "supported": true},
+        {"carrier": "australiapost", "description": null, "name": "rating", "supported":
+        true}, {"carrier": "australiapost", "description": null, "name": "tracking",
+        "supported": true}, {"carrier": "australiapost", "description": "Not available
+        with Print as You Go.", "name": "bill_on_label_purchase", "supported": true},
+        {"carrier": "australiapost", "description": null, "name": "bill_on_delivery",
+        "supported": false}, {"carrier": "australiapost", "description": null, "name":
+        "bill_on_scan", "supported": false}, {"carrier": "australiapost", "description":
+        "Daily manifesting when using Print as You Go.", "name": "bill_on_manifest",
+        "supported": true}, {"carrier": "australiapost", "description": null, "name":
+        "commercial_invoices", "supported": null}, {"carrier": "australiapost", "description":
+        null, "name": "delivers_to_po_box", "supported": null}, {"carrier": "australiapost",
+        "description": null, "name": "sort_codes", "supported": false}, {"carrier":
+        "australiapost", "description": null, "name": "test_environment", "supported":
+        true}]}, {"human_readable": "AxlehireV3", "name": "axlehirev3", "predefined_packages":
+        [], "service_levels": [{"carrier": "axlehirev3", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "AxleHireDelivery"}],
+        "shipment_options": [], "supported_features": []}, {"human_readable": "Better
+        Trucks", "name": "bettertrucks", "predefined_packages": [], "service_levels":
+        [{"carrier": "bettertrucks", "description": null, "dimensions": [], "human_readable":
+        "Next Day", "max_weight": null, "name": "NEXT_DAY"}, {"carrier": "bettertrucks",
+        "description": null, "dimensions": [], "human_readable": "Express", "max_weight":
+        null, "name": "EXPRESS"}], "shipment_options": [], "supported_features": []},
+        {"human_readable": "Canada Post", "name": "canadapost", "predefined_packages":
+        [], "service_levels": [{"carrier": "canadapost", "description": null, "dimensions":
+        [], "human_readable": "Delivered Tonight", "max_weight": null, "name": "DeliveredTonight"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Regular Parcel", "max_weight": null, "name": "RegularParcel"}, {"carrier":
+        "canadapost", "description": null, "dimensions": [], "human_readable": "Expedited
+        Parcel", "max_weight": null, "name": "ExpeditedParcel"}, {"carrier": "canadapost",
+        "description": null, "dimensions": [], "human_readable": "Xpresspost", "max_weight":
+        null, "name": "Xpresspost"}, {"carrier": "canadapost", "description": null,
+        "dimensions": [], "human_readable": "Xpresspost Certified", "max_weight":
+        null, "name": "XpresspostCertified"}, {"carrier": "canadapost", "description":
+        null, "dimensions": [], "human_readable": "Priority", "max_weight": null,
+        "name": "Priority"}, {"carrier": "canadapost", "description": null, "dimensions":
+        [], "human_readable": "Library Books", "max_weight": null, "name": "LibraryBooks"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Expedited Parcel USA", "max_weight": null, "name": "ExpeditedParcelUSA"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Priority Worldwide Envelope USA", "max_weight": null, "name": "PriorityWorldwideEnvelopeUSA"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Priority Worldwide Pak USA", "max_weight": null, "name": "PriorityWorldwidePakUSA"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Priority Worldwide Parcel USA", "max_weight": null, "name": "PriorityWorldwideParcelUSA"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Small Packet USA Air", "max_weight": null, "name": "SmallPacketUSAAir"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Tracked Packet USA", "max_weight": null, "name": "TrackedPacketUSA"}, {"carrier":
+        "canadapost", "description": null, "dimensions": [], "human_readable": "Tracked
+        Packet USA LVM", "max_weight": null, "name": "TrackedPacketUSALVM"}, {"carrier":
+        "canadapost", "description": null, "dimensions": [], "human_readable": "Xpresspost
+        USA", "max_weight": null, "name": "XpresspostUSA"}, {"carrier": "canadapost",
+        "description": null, "dimensions": [], "human_readable": "Xpresspost International",
+        "max_weight": null, "name": "XpresspostInternational"}, {"carrier": "canadapost",
+        "description": null, "dimensions": [], "human_readable": "International Parcel
+        Air", "max_weight": null, "name": "InternationalParcelAir"}, {"carrier": "canadapost",
+        "description": null, "dimensions": [], "human_readable": "International Parcel
+        Surface", "max_weight": null, "name": "InternationalParcelSurface"}, {"carrier":
+        "canadapost", "description": null, "dimensions": [], "human_readable": "Priority
+        Worldwide Envelope Intl", "max_weight": null, "name": "PriorityWorldwideEnvelopeIntl"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Priority Worldwide Pak Intl", "max_weight": null, "name": "PriorityWorldwidePakIntl"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Priority Worldwide Parcel Intl", "max_weight": null, "name": "PriorityWorldwideParcelIntl"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Small Packet International Air", "max_weight": null, "name": "SmallPacketInternationalAir"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Small Packet International Surface", "max_weight": null, "name": "SmallPacketInternationalSurface"},
+        {"carrier": "canadapost", "description": null, "dimensions": [], "human_readable":
+        "Tracked Packet International", "max_weight": null, "name": "TrackedPacketInternational"}],
+        "shipment_options": [], "supported_features": [{"carrier": "canadapost", "description":
+        null, "name": "labels", "supported": true}, {"carrier": "canadapost", "description":
+        null, "name": "orders", "supported": false}, {"carrier": "canadapost", "description":
+        null, "name": "pickups", "supported": true}, {"carrier": "canadapost", "description":
+        null, "name": "refunds", "supported": true}, {"carrier": "canadapost", "description":
+        null, "name": "returns", "supported": true}, {"carrier": "canadapost", "description":
+        null, "name": "scanforms", "supported": true}, {"carrier": "canadapost", "description":
+        null, "name": "rating", "supported": true}, {"carrier": "canadapost", "description":
+        null, "name": "tracking", "supported": true}, {"carrier": "canadapost", "description":
+        null, "name": "bill_on_label_purchase", "supported": false}, {"carrier": "canadapost",
+        "description": null, "name": "bill_on_delivery", "supported": true}, {"carrier":
+        "canadapost", "description": null, "name": "bill_on_scan", "supported": false},
+        {"carrier": "canadapost", "description": null, "name": "bill_on_manifest",
+        "supported": true}, {"carrier": "canadapost", "description": null, "name":
+        "commercial_invoices", "supported": true}, {"carrier": "canadapost", "description":
+        null, "name": "delivers_to_po_box", "supported": null}, {"carrier": "canadapost",
+        "description": null, "name": "sort_codes", "supported": false}, {"carrier":
+        "canadapost", "description": null, "name": "test_environment", "supported":
+        true}]}, {"human_readable": "Canpar", "name": "canpar", "predefined_packages":
+        [], "service_levels": [{"carrier": "canpar", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Ground"}, {"carrier":
+        "canpar", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "SelectLetter"}, {"carrier": "canpar", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "SelectPak"},
+        {"carrier": "canpar", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Select"}, {"carrier": "canpar", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "OvernightLetter"}, {"carrier": "canpar", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "OvernightPak"}, {"carrier":
+        "canpar", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Overnight"}, {"carrier": "canpar", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "SelectUSA"}, {"carrier":
+        "canpar", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "USAPak"}, {"carrier": "canpar", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "USALetter"}, {"carrier":
+        "canpar", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "USA"}, {"carrier": "canpar", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "International"}],
+        "shipment_options": [], "supported_features": []}, {"human_readable": "CDL
+        Last Mile Solutions", "name": "cdllastmilesolutions", "predefined_packages":
+        [], "service_levels": [{"carrier": "cdllastmilesolutions", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "DISTRIBUTION"}, {"carrier": "cdllastmilesolutions", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "Same
+        Day"}], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "Chronopost", "name": "chronopost", "predefined_packages": [], "service_levels":
+        [], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "CloudSort", "name": "cloudsort", "predefined_packages": [], "service_levels":
+        [], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "Courier Express", "name": "courierexpress", "predefined_packages": [], "service_levels":
+        [{"carrier": "courierexpress", "description": null, "dimensions": [], "human_readable":
+        "Basic Parcel", "max_weight": null, "name": "BASIC_PARCEL"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "Couriers Please", "name":
+        "couriersplease", "predefined_packages": [], "service_levels": [{"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Road Express", "max_weight": null, "name": "RoadExpress"}, {"carrier": "couriersplease",
+        "description": null, "dimensions": [], "human_readable": "Agg Exp Authority
+        To Leave P10", "max_weight": null, "name": "AggExpAtlP10"}, {"carrier": "couriersplease",
+        "description": null, "dimensions": [], "human_readable": "Agg Exp Authority
+        To Leave P25", "max_weight": null, "name": "AggExpAtlP25"}, {"carrier": "couriersplease",
+        "description": null, "dimensions": [], "human_readable": "Agg Exp Authority
+        To Leave Base & Kilo", "max_weight": null, "name": "AggExpAtlBaseandKilo"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Exp Authority To Leave 09", "max_weight": null, "name": "AggExpAtlP0"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Exp Authority To Leave P1", "max_weight": null, "name": "AggExpAtlP1"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Exp Authority To Leave P3", "max_weight": null, "name": "AggExpAtlP3"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Exp Authority To Leave P5", "max_weight": null, "name": "AggExpAtlP5"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Drop Off Hubbed Based & Kilo", "max_weight": null, "name": "AggDropOffHubbedBaseandKilo"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Drop Off Hubbed P0", "max_weight": null, "name": "AggDropOffHubbedP0"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Drop Off Hubbed P1", "max_weight": null, "name": "AggDropOffHubbedP1"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Drop Off Hubbed P3", "max_weight": null, "name": "AggDropOffHubbedP3"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Drop Off Hubbed P5", "max_weight": null, "name": "AggDropOffHubbedP5"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg STD Authority To Leave P10", "max_weight": null, "name": "AggStdAtlP10"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg STD Authority To Leave Base & Kilo", "max_weight": null, "name": "AggStdAtlBaseandKilo"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg STD Authority To Leave P0", "max_weight": null, "name": "AggStdAtlP0"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg STD Authority To Leave P1", "max_weight": null, "name": "AggStdAtlP1"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg STD Authority To Leave P3", "max_weight": null, "name": "AggStdAtlP3"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg STD Authority To Leave P5", "max_weight": null, "name": "AggStdAtlP5"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Ecommerce Base & Kilo", "max_weight": null, "name": "AggEcomBaseandKilo"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Ecommerce Base & Kilo", "max_weight": null, "name": "AggEcomP0"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Ecommerce P1", "max_weight": null, "name": "AggEcomP1"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Ecommerce P3", "max_weight": null, "name": "AggEcomP3"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Ecommerce P5", "max_weight": null, "name": "AggEcomP5"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Drop Off Hubbed P10", "max_weight": null, "name": "AggDropOffHubbedP10"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Drop Off Hubbed P25", "max_weight": null, "name": "AggDropOffHubbedP25"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg STD Authority To Leave P25", "max_weight": null, "name": "AggStdAtlP25"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Ecommerce P10", "max_weight": null, "name": "AggEcomP10"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Agg Ecommerce P25", "max_weight": null, "name": "AggEcomP25"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Australian City Express", "max_weight": null, "name": "AustralianCityExpress"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Drop Ship 500 Gram Parcel", "max_weight": null, "name": "DropShip500GramParcel"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Drop Ship 1 Kilogram Parcel", "max_weight": null, "name": "DropShip1KgParcel"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Drop Ship 3Kilogram Parcel", "max_weight": null, "name": "DropShip3KgParcel"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Drop Ship 5 Kilogram Parcel", "max_weight": null, "name": "DropShip5KgParcel"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Domestic Priority", "max_weight": null, "name": "DomesticPriority"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Drop Ship 10 Kilogram Parcel", "max_weight": null, "name": "DropShip10KgParcel"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Drop Ship 20 Kilogram Parcel", "max_weight": null, "name": "DropShip20KgParcel"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Domestic Priority Signature", "max_weight": null, "name": "DomesticPrioritySignature"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Gold Domestic", "max_weight": null, "name": "GoldDomestic"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Road Express No Delivery", "max_weight": null, "name": "RoadExpressNoDelivery"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Road Express No Pick Up", "max_weight": null, "name": "RoadExpressNoPickUp"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "500 Gram Parcel", "max_weight": null, "name": "500GramParcel"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "500 Gram Parcel Authority To Leave", "max_weight": null, "name": "500GramParcelATL"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "1 Kilogram Parcel", "max_weight": null, "name": "1KgParcel"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "10 Kilogram Parcel", "max_weight": null, "name": "10KgParcel"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "10 Kilogram Parcel Authority To Leave", "max_weight": null, "name": "10KgParcelATL"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "15 Kilogram Parcel", "max_weight": null, "name": "15KgParcel"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "15 Kilogram Authority To Leave", "max_weight": null, "name": "15KgParcelATL"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "1 Kilogram Parcel Authority To Leave", "max_weight": null, "name": "1KgParcelATL"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "2 Kilogram Parcel", "max_weight": null, "name": "2KgParcel"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "25 Kilogram Parcel", "max_weight": null, "name": "25KgParcel"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "25 Kilogram Parcel Authority To Leaave", "max_weight": null, "name": "25KgParcelATL"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "2 Kilogram Parcel Authority To Leave", "max_weight": null, "name": "2KgParcelATL"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "3 Kilogram Parcel", "max_weight": null, "name": "3KgParcel"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "3 Kilogram Parcel Authority To Leave", "max_weight": null, "name": "3KgParcelATL"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "5 Kilogram Parcel", "max_weight": null, "name": "5KgParcel"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "5 Kilogram Parcel Authority To Leave", "max_weight": null, "name": "5Kg Parcel
+        ATL"}, {"carrier": "couriersplease", "description": null, "dimensions": [],
+        "human_readable": "Australian City Express Signature", "max_weight": null,
+        "name": "AustralianCityExpressSignature"}, {"carrier": "couriersplease", "description":
+        null, "dimensions": [], "human_readable": "Domestic Saver Signature", "max_weight":
+        null, "name": "DomesticSaverSignature"}, {"carrier": "couriersplease", "description":
+        null, "dimensions": [], "human_readable": "Domestic Off Peak", "max_weight":
+        null, "name": "DomesticOffPeak"}, {"carrier": "couriersplease", "description":
+        null, "dimensions": [], "human_readable": "Domestic Saver", "max_weight":
+        null, "name": "DomesticSaver"}, {"carrier": "couriersplease", "description":
+        null, "dimensions": [], "human_readable": "Dometic Off Peak Signature", "max_weight":
+        null, "name": "DomesticOffPeakSignature"}, {"carrier": "couriersplease", "description":
+        null, "dimensions": [], "human_readable": "Gold Domestic Signature", "max_weight":
+        null, "name": "GoldDomesticSignature"}, {"carrier": "couriersplease", "description":
+        null, "dimensions": [], "human_readable": "1 Kilogram Satchel Authority To
+        Leave", "max_weight": null, "name": "1KgSatchelATL"}, {"carrier": "couriersplease",
+        "description": null, "dimensions": [], "human_readable": "1 Kilogram Satchel",
+        "max_weight": null, "name": "1KgSatchel"}, {"carrier": "couriersplease", "description":
+        null, "dimensions": [], "human_readable": "3 Kilogram Satchel", "max_weight":
+        null, "name": "3KgSatchel"}, {"carrier": "couriersplease", "description":
+        null, "dimensions": [], "human_readable": "5 Kilogram Satchel", "max_weight":
+        null, "name": "5KgSatchel"}, {"carrier": "couriersplease", "description":
+        null, "dimensions": [], "human_readable": "3 Kilogram Satchel Authority To
+        Leave", "max_weight": null, "name": "3KgSatchelATL"}, {"carrier": "couriersplease",
+        "description": null, "dimensions": [], "human_readable": "5 Kilogram Satchel
+        Authority To Leave", "max_weight": null, "name": "5KgSatchelATL"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "500 Gram Satchel Authority To Leave", "max_weight": null, "name": "500GramSatchelATL"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "500 Gram Satchel", "max_weight": null, "name": "500GramSatchel"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "5 Kilogram Satchel", "max_weight": null, "name": "5KSatchel"}, {"carrier":
+        "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "Express International Priority", "max_weight": null, "name": "ExpressInternationalPriority"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "International Saver", "max_weight": null, "name": "InternationalSaver"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "International Express Import", "max_weight": null, "name": "InternationalExpressImport"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "International Express", "max_weight": null, "name": "InternationalExpress"},
+        {"carrier": "couriersplease", "description": null, "dimensions": [], "human_readable":
+        "500gm Parcel", "max_weight": null, "name": "500gmParcel"}, {"carrier": "couriersplease",
+        "description": null, "dimensions": [], "human_readable": "1 Kilogram Parcel",
+        "max_weight": null, "name": "1kgParcel"}, {"carrier": "couriersplease", "description":
+        null, "dimensions": [], "human_readable": "3 Kilogram Parcel", "max_weight":
+        null, "name": "3kgParcel"}, {"carrier": "couriersplease", "description": null,
+        "dimensions": [], "human_readable": "5 Kilogram Parcel", "max_weight": null,
+        "name": "5kgParcel"}], "shipment_options": [], "supported_features": []},
+        {"human_readable": "DAI Post", "name": "daipost", "predefined_packages": [],
+        "service_levels": [{"carrier": "daipost", "description": null, "dimensions":
+        [], "human_readable": "Parcel Epacket", "max_weight": null, "name": "ParcelMax"},
+        {"carrier": "daipost", "description": null, "dimensions": [], "human_readable":
+        "International Economy", "max_weight": null, "name": "InternationalEconomy"},
+        {"carrier": "daipost", "description": null, "dimensions": [], "human_readable":
+        "International Standard", "max_weight": null, "name": "InternationalStandard"},
+        {"carrier": "daipost", "description": null, "dimensions": [], "human_readable":
+        "International Express", "max_weight": null, "name": "InternationalExpress"},
+        {"carrier": "daipost", "description": null, "dimensions": [], "human_readable":
+        "Domestic Tracked", "max_weight": null, "name": "DomesticTracked"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "DeliverIt", "name": "deliverit",
+        "predefined_packages": [], "service_levels": [{"carrier": "deliverit", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Afternoon"}, {"carrier": "deliverit", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Early-It"}, {"carrier":
+        "deliverit", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "Economy"}, {"carrier": "deliverit", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Noon-It"}, {"carrier": "deliverit", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "Saturday"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "Deutsche Post", "name":
+        "deutschepost", "predefined_packages": [], "service_levels": [{"carrier":
+        "deutschepost", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "PacketPlus"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "Deutsche Post UK", "name": "deutschepostuk", "predefined_packages":
+        [], "service_levels": [{"carrier": "deutschepostuk", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "PriorityPacketPlus"},
+        {"carrier": "deutschepostuk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "PriorityPacket"}, {"carrier": "deutschepostuk",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "PriorityPacketTracked"}, {"carrier": "deutschepostuk", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "BusinessMailRegistered"}, {"carrier": "deutschepostuk", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "StandardPacket"},
+        {"carrier": "deutschepostuk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "BusinessMailStandard"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "DHL eCommerce Asia", "name":
+        "dhlecommerceasia", "predefined_packages": [], "service_levels": [{"carrier":
+        "dhlecommerceasia", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Packet"}, {"carrier": "dhlecommerceasia",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "PacketPlus"}, {"carrier": "dhlecommerceasia", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "ParcelDirect"}, {"carrier": "dhlecommerceasia", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "ParcelDirectExpedited"}],
+        "shipment_options": [], "supported_features": []}, {"human_readable": "DHL
+        eCommerce Solutions", "name": "dhlecommercesolutions", "predefined_packages":
+        [], "service_levels": [{"carrier": "dhlecommercesolutions", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "DHLParcelExpedited"}, {"carrier": "dhlecommercesolutions", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "DHLParcelExpeditedMax"}, {"carrier": "dhlecommercesolutions", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "DHLParcelGround"}, {"carrier": "dhlecommercesolutions", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "DHLBPMExpedited"},
+        {"carrier": "dhlecommercesolutions", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "DHLBPMGround"}, {"carrier":
+        "dhlecommercesolutions", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "DHLParcelInternationalDirect"}, {"carrier":
+        "dhlecommercesolutions", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "DHLParcelInternationalStandard"}, {"carrier":
+        "dhlecommercesolutions", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "DHLPacketInternational"}, {"carrier": "dhlecommercesolutions",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "DHLParcelInternationalDirectPriority"}, {"carrier": "dhlecommercesolutions",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "DHLParcelInternationalDirectStandard"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "DHL Express", "name": "dhlexpress",
+        "predefined_packages": [{"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "JumboDocument"},
+        {"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "JumboParcel"}, {"carrier": "dhlexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Document"}, {"carrier": "dhlexpress", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "DHLFlyer"},
+        {"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Domestic"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "ExpressDocument"}, {"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "DHLExpressEnvelope"},
+        {"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "JumboBox"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "JumboJuniorDocument"}, {"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "JuniorJumboBox"},
+        {"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "JumboJuniorParcel"}, {"carrier": "dhlexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "OtherDHLPackaging"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Parcel"}, {"carrier": "dhlexpress", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "YourPackaging"}], "service_levels":
+        [{"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "BreakBulkEconomy"}, {"carrier": "dhlexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "BreakBulkExpress"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "DomesticEconomySelect"}, {"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "DomesticExpress"},
+        {"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "DomesticExpress1030"}, {"carrier": "dhlexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "DomesticExpress1200"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "EconomySelect"}, {"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "EconomySelectNonDoc"},
+        {"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "EuroPack"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "EuropackNonDoc"}, {"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Express1030"}, {"carrier":
+        "dhlexpress", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "Express1030NonDoc"}, {"carrier": "dhlexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Express1200NonDoc"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Express1200"}, {"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Express900"}, {"carrier":
+        "dhlexpress", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "Express900NonDoc"}, {"carrier": "dhlexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ExpressEasy"}, {"carrier": "dhlexpress", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "ExpressEasyNonDoc"},
+        {"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ExpressEnvelope"}, {"carrier": "dhlexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ExpressWorldwide"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "ExpressWorldwideB2C"}, {"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "ExpressWorldwideB2CNonDoc"},
+        {"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ExpressWorldwideECX"}, {"carrier": "dhlexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ExpressWorldwideNonDoc"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "FreightWorldwide"}, {"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "GlobalmailBusiness"},
+        {"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "JetLine"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "JumboBox"}, {"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "LogisticsServices"},
+        {"carrier": "dhlexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "SameDay"}, {"carrier": "dhlexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "SecureLine"}, {"carrier": "dhlexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "SprintLine"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "DHL Paket", "name": "dhlpaket",
+        "predefined_packages": [], "service_levels": [{"carrier": "dhlpaket", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "EuroPaket"}, {"carrier": "dhlpaket", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "Paket"}, {"carrier":
+        "dhlpaket", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "PaketConnect"}, {"carrier": "dhlpaket", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "PaketInternational"}, {"carrier": "dhlpaket", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Retoure"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "DHL SmartMail", "name":
+        "dhlsmartmail", "predefined_packages": [], "service_levels": [], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "DPD", "name": "dpd", "predefined_packages":
+        [], "service_levels": [{"carrier": "dpd", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "DPDCLASSIC"}, {"carrier":
+        "dpd", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "DPD8:30"}, {"carrier": "dpd", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "DPD10:00"}, {"carrier":
+        "dpd", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "DPD12:00"}, {"carrier": "dpd", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "DPD18:00"}, {"carrier":
+        "dpd", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "DPDEXPRESS"}, {"carrier": "dpd", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "DPDPARCELLETTER"},
+        {"carrier": "dpd", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "DPDPARCELLETTERPLUS"}, {"carrier": "dpd",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "DPDINTERNATIONALMAIL"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "DPDUK", "name": "dpduk", "predefined_packages": [{"carrier":
+        "dpduk", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Parcel"}, {"carrier": "dpduk", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Pallet"}, {"carrier":
+        "dpduk", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ExpressPak"}, {"carrier": "dpduk", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "FreightParcel"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Freight"}], "service_levels": [{"carrier":
+        "dpduk", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "AirExpressInternationalAir"}, {"carrier": "dpduk", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "AirClassicInternationalAir"}, {"carrier": "dpduk", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "ParcelSunday"}, {"carrier":
+        "dpduk", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "FreightParcelSunday"}, {"carrier": "dpduk", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "PalletSunday"}, {"carrier": "dpduk", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "PalletDpdClassic"}, {"carrier":
+        "dpduk", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ExpresspakDpdClassic"}, {"carrier": "dpduk", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "ExpresspakSunday"}, {"carrier": "dpduk", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "ParcelDpdClassic"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ParcelDpdTwoDay"}, {"carrier": "dpduk",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ParcelDpdNextDay"}, {"carrier": "dpduk", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "ParcelDpd12"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ParcelDpd10"}, {"carrier": "dpduk", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "ParcelReturnToShop"}, {"carrier": "dpduk", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "ParcelSaturday"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ParcelSaturday12"}, {"carrier": "dpduk",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ParcelSaturday10"}, {"carrier": "dpduk", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "ParcelSunday12"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "FreightParcelDpdClassic"}, {"carrier":
+        "dpduk", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "FreightParcelSunday12"}, {"carrier": "dpduk", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "ExpresspakDpdNextDay"}, {"carrier": "dpduk", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "ExpresspakDpd12"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ExpresspakDpd10"}, {"carrier": "dpduk",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ExpresspakSaturday"}, {"carrier": "dpduk", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "ExpresspakSaturday12"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ExpresspakSaturday10"}, {"carrier": "dpduk",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ExpresspakSunday12"}, {"carrier": "dpduk", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "PalletSunday12"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "PalletDpdTwoDay"}, {"carrier": "dpduk",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "PalletDpdNextDay"}, {"carrier": "dpduk", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "PalletDpd12"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "PalletDpd10"}, {"carrier": "dpduk", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "PalletSaturday"}, {"carrier": "dpduk", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "PalletSaturday12"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "PalletSaturday10"}, {"carrier": "dpduk",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "FreightParcelDpdTwoDay"}, {"carrier": "dpduk", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "FreightParcelDpdNextDay"}, {"carrier": "dpduk", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "FreightParcelDpd12"},
+        {"carrier": "dpduk", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "FreightParcelDpd10"}, {"carrier": "dpduk",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "FreightParcelSaturday"}, {"carrier": "dpduk", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "FreightParcelSaturday12"}, {"carrier": "dpduk", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "FreightParcelSaturday10"}],
+        "shipment_options": [], "supported_features": []}, {"human_readable": "ePostGlobal",
+        "name": "epostglobal", "predefined_packages": [], "service_levels": [{"carrier":
+        "epostglobal", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "CourierServiceDDP"}, {"carrier": "epostglobal",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "CourierServiceDDU"}, {"carrier": "epostglobal", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "DomesticEconomyParcel"}, {"carrier": "epostglobal", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "DomesticParcelBPM"},
+        {"carrier": "epostglobal", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "DomesticPriorityParcel"}, {"carrier": "epostglobal",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "DomesticPriorityParcelBPM"}, {"carrier": "epostglobal", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "EMIService"}, {"carrier": "epostglobal", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "EconomyParcelService"},
+        {"carrier": "epostglobal", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "IPAService"}, {"carrier": "epostglobal",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ISALService"}, {"carrier": "epostglobal", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "PMIService"},
+        {"carrier": "epostglobal", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "PriorityParcelDDP"}, {"carrier": "epostglobal",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "PriorityParcelDDU"}, {"carrier": "epostglobal", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "PriorityParcelDeliveryConfirmationDDP"}, {"carrier": "epostglobal", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "PriorityParcelDeliveryConfirmationDDU"}, {"carrier": "epostglobal", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "ePacketService"}], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "Estafeta", "name": "estafeta", "predefined_packages": [{"carrier": "estafeta",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ENVELOPE"}, {"carrier": "estafeta", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "PARCEL"}], "service_levels":
+        [{"carrier": "estafeta", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "NextDayBy930"}, {"carrier": "estafeta",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "NextDayBy1130"}, {"carrier": "estafeta", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "NextDay"},
+        {"carrier": "estafeta", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Ground"}, {"carrier": "estafeta", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "TwoDay"}, {"carrier": "estafeta", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "LTL"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "Evri", "name": "evri",
+        "predefined_packages": [], "service_levels": [{"carrier": "evri", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Courier2Home"}, {"carrier": "evri", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "Courier2HomeNextDay"},
+        {"carrier": "evri", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Shop2Home"}, {"carrier": "evri", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Shop2HomeNextDay"}, {"carrier": "evri", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Shop2Shop"}, {"carrier":
+        "evri", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Shop2ShopNextDay"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "Fastway", "name": "fastway", "predefined_packages":
+        [{"carrier": "fastway", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Parcel"}, {"carrier": "fastway", "description":
+        "(Satchel)", "dimensions": [], "human_readable": null, "max_weight": null,
+        "name": "A2"}, {"carrier": "fastway", "description": "(Satchel)", "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "A3"}, {"carrier":
+        "fastway", "description": "(Satchel, not available in Australia)", "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "A4"}, {"carrier":
+        "fastway", "description": "(Satchel, not available in South Africa)", "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "A5"}, {"carrier":
+        "fastway", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "BOXSML"}, {"carrier": "fastway", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "BOXMED"}, {"carrier": "fastway", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "BOXLRG"}], "service_levels": [{"carrier":
+        "fastway", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "Parcel"}, {"carrier": "fastway", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Satchel"}], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "FedEx", "name": "fedex", "predefined_packages": [{"carrier": "fedex", "description":
+        "Up to approximately 60 pages", "dimensions": ["9.5in x 12.5in"], "human_readable":
+        null, "max_weight": 8.0, "name": "FedExEnvelope"}, {"carrier": "fedex", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "FedExBox"}, {"carrier": "fedex", "description": null, "dimensions": ["12in
+        x 15.5in"], "human_readable": null, "max_weight": 88.0, "name": "FedExPak"},
+        {"carrier": "fedex", "description": "Triangular box for plans, posters, fabric
+        rolls, charts and blueprints", "dimensions": ["38in x 6in x 6in x 6in"], "human_readable":
+        null, "max_weight": 320.0, "name": "FedExTube"}, {"carrier": "fedex", "description":
+        "To qualify for the flat rate, weight cannot exceed 10 kg", "dimensions":
+        ["15.81in x 12.94in x 10.19in"], "human_readable": null, "max_weight": 352.0,
+        "name": "FedEx10kgBox"}, {"carrier": "fedex", "description": "To qualify for
+        the flat rate, weight cannot exceed 25 kg.", "dimensions": ["21.56in x 16.56in
+        x 13.19in"], "human_readable": null, "max_weight": 880.0, "name": "FedEx25kgBox"},
+        {"carrier": "fedex", "description": null, "dimensions": ["12.25in x 10.9in
+        x 1.5in", "8.75in x 2.63in x 11.25in"], "human_readable": null, "max_weight":
+        320.0, "name": "FedExSmallBox"}, {"carrier": "fedex", "description": null,
+        "dimensions": ["13.25in x 11.5in x 2.38in", "8.75in x 4.38in x 11.25in"],
+        "human_readable": null, "max_weight": 320.0, "name": "FedExMediumBox"}, {"carrier":
+        "fedex", "description": null, "dimensions": ["17.88in x 12.38in x 3in", "8.75in
+        x 7.75in x 11.25in"], "human_readable": null, "max_weight": 320.0, "name":
+        "FedExLargeBox"}, {"carrier": "fedex", "description": null, "dimensions":
+        ["11.88in x 10.75in x 11in", "15.25in x 14.13in x 6in"], "human_readable":
+        null, "max_weight": 320.0, "name": "FedExExtraLargeBox"}], "service_levels":
+        [{"carrier": "fedex", "description": "2 business days by 4:30pm, Saturday
+        delivery", "dimensions": null, "human_readable": "FedEx 2 Day", "max_weight":
+        null, "name": "FEDEX_2_DAY"}, {"carrier": "fedex", "description": "2 business
+        days by 10:30am", "dimensions": null, "human_readable": "FedEx 2 Day (AM)",
+        "max_weight": null, "name": "FEDEX_2_DAY_AM"}, {"carrier": "fedex", "description":
+        "3 business days by 4:30pm", "dimensions": null, "human_readable": "FedEx
+        Express Saver", "max_weight": null, "name": "FEDEX_EXPRESS_SAVER"}, {"carrier":
+        "fedex", "description": "1-6 days", "dimensions": null, "human_readable":
+        "FedEx Ground", "max_weight": null, "name": "FEDEX_GROUND"}, {"carrier": "fedex",
+        "description": "2-5 business days", "dimensions": null, "human_readable":
+        "FedEx International (Connect Plus)", "max_weight": null, "name": "FEDEX_INTERNATIONAL_CONNECT_PLUS"},
+        {"carrier": "fedex", "description": "By 8am the next business day, Saturday
+        delivery", "dimensions": null, "human_readable": "FedEx First (Overnight)",
+        "max_weight": null, "name": "FIRST_OVERNIGHT"}, {"carrier": "fedex", "description":
+        "1-5 days", "dimensions": null, "human_readable": "FedEx Ground (Home Delivery)",
+        "max_weight": null, "name": "GROUND_HOME_DELIVERY"}, {"carrier": "fedex",
+        "description": "4-5 business days", "dimensions": null, "human_readable":
+        "FedEx International (Economy)", "max_weight": null, "name": "INTERNATIONAL_ECONOMY"},
+        {"carrier": "fedex", "description": "1-3 business days, time definite to select
+        markets", "dimensions": null, "human_readable": "FedEx International First",
+        "max_weight": null, "name": "INTERNATIONAL_FIRST"}, {"carrier": "fedex", "description":
+        "1-3 business days, time definite to select markets", "dimensions": null,
+        "human_readable": "FedEx International (First)", "max_weight": null, "name":
+        "INTERNATIONAL_PRIORITY"}, {"carrier": "fedex", "description": "By 10:30am
+        the next business day, Saturday delivery", "dimensions": null, "human_readable":
+        "FedEx Priority Overnight", "max_weight": null, "name": "PRIORITY_OVERNIGHT"},
+        {"carrier": "fedex", "description": "2-7 business days; Sunday Delivery to
+        select markets", "dimensions": null, "human_readable": "FedEx Smart Post",
+        "max_weight": null, "name": "SMART_POST"}, {"carrier": "fedex", "description":
+        "By 4:30pm the next business day", "dimensions": null, "human_readable": "FedEx
+        Standard Overnight", "max_weight": null, "name": "STANDARD_OVERNIGHT"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "FedEx Cross Border", "name":
+        "fedexcrossborder", "predefined_packages": [], "service_levels": [{"carrier":
+        "fedexcrossborder", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "CBEC"}, {"carrier": "fedexcrossborder",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "CBECL"}, {"carrier": "fedexcrossborder", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "CBECP"}],
+        "shipment_options": [], "supported_features": []}, {"human_readable": "FedEx
+        Mailview", "name": "fedexmailview", "predefined_packages": [], "service_levels":
+        [], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "FedEx SmartPost", "name": "fedexsmartpost", "predefined_packages": [], "service_levels":
+        [{"carrier": "fedexsmartpost", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "SMART_POST"}], "shipment_options": [],
+        "supported_features": []}, {"human_readable": "FirstMile", "name": "firstmile",
+        "predefined_packages": [], "service_levels": [{"carrier": "firstmile", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "XParcelGround"}, {"carrier": "firstmile", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "XParcelExpedited"},
+        {"carrier": "firstmile", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "XParcelExpeditedPlus"}, {"carrier": "firstmile",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "XParcelPriority"}, {"carrier": "firstmile", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "XParcelReturns"}], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "GSO", "name": "gso", "predefined_packages": [], "service_levels": [{"carrier":
+        "gso", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "EarlyPriorityOvernight"}, {"carrier": "gso", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "PriorityOvernight"}, {"carrier": "gso", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "CaliforniaParcelService"},
+        {"carrier": "gso", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "SaturdayDeliveryService"}, {"carrier":
+        "gso", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "EarlySaturdayService"}, {"carrier": "gso", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "Ground"},
+        {"carrier": "gso", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Overnight"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "Hailify", "name": "hailify", "predefined_packages":
+        [], "service_levels": [{"carrier": "hailify", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Xpress"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "Interlink Express", "name":
+        "interlinkexpress", "predefined_packages": [{"carrier": "interlinkexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Parcel"}, {"carrier": "interlinkexpress", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "Pallet"},
+        {"carrier": "interlinkexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ExpressPak"}, {"carrier": "interlinkexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "FreightParcel"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Freight"}], "service_levels": [{"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkAirClassicInternationalAir"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkAirExpressInternationalAir"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak1By10:30"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak1By12"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak1NextDay"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak1Saturday"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak1SaturdayBy10:30"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak1SaturdayBy12"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak1Sunday"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak1SundayBy12"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak5By10"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak5By10:30"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak5By12"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak5NextDay"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak5Saturday"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak5SaturdayBy10"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak5SaturdayBy10:30"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak5SaturdayBy12"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak5Sunday"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkExpresspak5SundayBy12"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkFreightBy10"}, {"carrier": "interlinkexpress", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "InterlinkFreightBy12"},
+        {"carrier": "interlinkexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "InterlinkFreightNextDay"}, {"carrier":
+        "interlinkexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "InterlinkFreightSaturday"}, {"carrier":
+        "interlinkexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "InterlinkFreightSaturdayBy10"}, {"carrier":
+        "interlinkexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "InterlinkFreightSaturdayBy12"}, {"carrier":
+        "interlinkexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "InterlinkFreightSunday"}, {"carrier": "interlinkexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "InterlinkFreightSundayBy12"}, {"carrier": "interlinkexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "InterlinkParcelBy10"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkParcelBy10:30"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkParcelBy12"}, {"carrier": "interlinkexpress", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "InterlinkParcelDpdEuropeByRoad"},
+        {"carrier": "interlinkexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "InterlinkParcelNextDay"}, {"carrier": "interlinkexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "InterlinkParcelReturn"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkParcelReturnToShop"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkParcelSaturday"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkParcelSaturdayBy10"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkParcelSaturdayBy10:30"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkParcelSaturdayBy12"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkParcelShipToShop"}, {"carrier": "interlinkexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InterlinkParcelSunday"}, {"carrier": "interlinkexpress", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "InterlinkParcelSundayBy12"},
+        {"carrier": "interlinkexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "InterlinkParcelTwoDay"}, {"carrier": "interlinkexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "InterlinkPickupParcelDpdEuropeByRoad"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "JP Post", "name": "jppost",
+        "predefined_packages": [], "service_levels": [], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "Kuroneko Yamato", "name": "kuronekoyamato", "predefined_packages":
+        [], "service_levels": [], "shipment_options": [], "supported_features": []},
+        {"human_readable": "La Poste", "name": "laposte", "predefined_packages": [],
+        "service_levels": [], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "LaserShip", "name": "lasershipv2", "predefined_packages": [{"carrier": "lasershipv2",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Envelope"}, {"carrier": "lasershipv2", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "Custom"}],
+        "service_levels": [{"carrier": "lasershipv2", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "SameDay"}, {"carrier":
+        "lasershipv2", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "NextDay"}, {"carrier": "lasershipv2", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Weekend"}], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "Loomis Express", "name": "loomisexpress", "predefined_packages": [], "service_levels":
+        [{"carrier": "loomisexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "LoomisGround"}, {"carrier": "loomisexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "LoomisExpress1800"}, {"carrier": "loomisexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "LoomisExpress1200"}, {"carrier": "loomisexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "LoomisExpress900"}],
+        "shipment_options": [], "supported_features": []}, {"human_readable": "LSO",
+        "name": "lso", "predefined_packages": [], "service_levels": [{"carrier": "lso",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "GroundEarly"}, {"carrier": "lso", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "GroundBasic"}, {"carrier":
+        "lso", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "PriorityBasic"}, {"carrier": "lso", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "PriorityEarly"},
+        {"carrier": "lso", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "PrioritySaturday"}, {"carrier": "lso",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Priority2ndDay"}, {"carrier": "lso", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "SameDay"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "Maergo", "name": "maergo",
+        "predefined_packages": [], "service_levels": [{"carrier": "maergo", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Standard"}], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "Newgistics", "name": "newgistics", "predefined_packages": [], "service_levels":
+        [{"carrier": "newgistics", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ParcelSelect"}, {"carrier": "newgistics",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ParcelSelectLightweight"}, {"carrier": "newgistics", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Ground"}, {"carrier": "newgistics", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "Express"}, {"carrier":
+        "newgistics", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "FirstClassMail"}, {"carrier": "newgistics", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "PriorityMail"}, {"carrier": "newgistics", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "BoundPrintedMatter"}],
+        "shipment_options": [], "supported_features": []}, {"human_readable": "Ontrac",
+        "name": "ontrac", "predefined_packages": [{"carrier": "ontrac", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Letter"}], "service_levels": [{"carrier": "ontrac", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "Sunrise"},
+        {"carrier": "ontrac", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Gold"}, {"carrier": "ontrac", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "OnTracGround"}, {"carrier": "ontrac", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "SameDay"}, {"carrier":
+        "ontrac", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "PalletizedFreight"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "Optima", "name": "optima", "predefined_packages":
+        [], "service_levels": [{"carrier": "optima", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "NxtDay"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "OSM Worldwide", "name":
+        "osmworldwide", "predefined_packages": [{"carrier": "osmworldwide", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "parcel"}, {"carrier": "osmworldwide", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "irregularparcel"},
+        {"carrier": "osmworldwide", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "softpack"}], "service_levels": [{"carrier":
+        "osmworldwide", "description": null, "dimensions": [], "human_readable": "First",
+        "max_weight": null, "name": "First"}, {"carrier": "osmworldwide", "description":
+        null, "dimensions": [], "human_readable": "Parcel Select Lightweight", "max_weight":
+        null, "name": "ParcelSelectLightweight"}, {"carrier": "osmworldwide", "description":
+        null, "dimensions": [], "human_readable": "Priority", "max_weight": null,
+        "name": "Priority"}, {"carrier": "osmworldwide", "description": null, "dimensions":
+        [], "human_readable": "BPM", "max_weight": null, "name": "BPM"}, {"carrier":
+        "osmworldwide", "description": null, "dimensions": [], "human_readable": "Parcel
+        Select", "max_weight": null, "name": "ParcelSelect"}, {"carrier": "osmworldwide",
+        "description": null, "dimensions": [], "human_readable": "Media Mail", "max_weight":
+        null, "name": "MediaMail"}, {"carrier": "osmworldwide", "description": null,
+        "dimensions": [], "human_readable": "Marketing Parcel", "max_weight": null,
+        "name": "MarketingParcel"}, {"carrier": "osmworldwide", "description": null,
+        "dimensions": [], "human_readable": "Marketing Parcel Tracked", "max_weight":
+        null, "name": "MarketingParcelTracked"}], "shipment_options": [], "supported_features":
+        [{"carrier": "osmworldwide", "description": null, "name": "labels", "supported":
+        true}, {"carrier": "osmworldwide", "description": null, "name": "orders",
+        "supported": false}, {"carrier": "osmworldwide", "description": null, "name":
+        "pickups", "supported": false}, {"carrier": "osmworldwide", "description":
+        null, "name": "refunds", "supported": false}, {"carrier": "osmworldwide",
+        "description": null, "name": "returns", "supported": false}, {"carrier": "osmworldwide",
+        "description": "Manifesting", "name": "scanforms", "supported": true}, {"carrier":
+        "osmworldwide", "description": null, "name": "rating", "supported": true},
+        {"carrier": "osmworldwide", "description": null, "name": "tracking", "supported":
+        true}, {"carrier": "osmworldwide", "description": null, "name": "sort_codes",
+        "supported": true}]}, {"human_readable": "Parcelforce", "name": "parcelforce",
+        "predefined_packages": [], "service_levels": [{"carrier": "parcelforce", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Express9"}, {"carrier": "parcelforce", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Express9Secure"},
+        {"carrier": "parcelforce", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Express9CourierPack"}, {"carrier": "parcelforce",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Express10"}, {"carrier": "parcelforce", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "Express10Secure"},
+        {"carrier": "parcelforce", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Express10Exchange"}, {"carrier": "parcelforce",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Express10SecureExchange"}, {"carrier": "parcelforce", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Express10CourierPack"}, {"carrier": "parcelforce", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "ExpressAM"}, {"carrier":
+        "parcelforce", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "ExpressAMSecure"}, {"carrier": "parcelforce",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ExpressAMExchange"}, {"carrier": "parcelforce", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "ExpressAMSecureExchange"}, {"carrier": "parcelforce", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "ExpressAMCourierPack"},
+        {"carrier": "parcelforce", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ExpressPM"}, {"carrier": "parcelforce",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ExpressPMSecure"}, {"carrier": "parcelforce", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Express24"}, {"carrier": "parcelforce", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Express24Large"},
+        {"carrier": "parcelforce", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Express24Secure"}, {"carrier": "parcelforce",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Express24Exchange"}, {"carrier": "parcelforce", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Express24SecureExchange"}, {"carrier": "parcelforce", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "Express24CourierPack"},
+        {"carrier": "parcelforce", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Express48"}, {"carrier": "parcelforce",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Express48Large"}, {"carrier": "parcelforce", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "ParcelRiderPlus"}, {"carrier": "parcelforce", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "GlobalBulkDirect"},
+        {"carrier": "parcelforce", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "GlobalExpress"}, {"carrier": "parcelforce",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "GlobalExpressEnvelopeDelivery"}, {"carrier": "parcelforce",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "GlobalExpressPackDelivery"}, {"carrier": "parcelforce", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "GlobalValue"}, {"carrier": "parcelforce", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "GlobalPriority"},
+        {"carrier": "parcelforce", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "GlobalPriorityReturns"}, {"carrier": "parcelforce",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "EuroPriorityHome"}, {"carrier": "parcelforce", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "EuroPriorityBusiness"}, {"carrier": "parcelforce", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "IrelandExpress"}],
+        "shipment_options": [], "supported_features": []}, {"human_readable": "PARCLL",
+        "name": "parcll", "predefined_packages": [], "service_levels": [{"carrier":
+        "parcll", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ECOWE (Economy West)"}, {"carrier": "parcll", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "ECOCE (Economy Central)"}, {"carrier": "parcll", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "ECONE (Economy Northeast)"},
+        {"carrier": "parcll", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "ECOEA (Economy East)"}, {"carrier": "parcll",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ECOSO (Economy South)"}, {"carrier": "parcll", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "EXPWE (Expedited West)"}, {"carrier": "parcll", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "EXPBNE (Expedited
+        Northeast)"}, {"carrier": "parcll", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "REGWE (Regional West)"},
+        {"carrier": "parcll", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "REGCE (Regional Central)"}, {"carrier":
+        "parcll", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "REGNE (Regional Northeast)"}, {"carrier": "parcll", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "REGEA (Regional East)"}, {"carrier": "parcll", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "REGSO (Regional South)"},
+        {"carrier": "parcll", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "CAECOWE (US to CA Economy)"}, {"carrier":
+        "parcll", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "CAECOCE (US to CA Economy)"}, {"carrier": "parcll", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "CAECONE (US to CA Economy)"}, {"carrier": "parcll", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "EUECOWE
+        (US to Europe Economy)"}], "shipment_options": [], "supported_features": []},
+        {"human_readable": "Passport", "name": "passportglobal", "predefined_packages":
+        [], "service_levels": [], "shipment_options": [], "supported_features": []},
+        {"human_readable": "PostNL", "name": "postnl", "predefined_packages": [],
+        "service_levels": [], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "Purolator", "name": "purolator", "predefined_packages": [{"carrier": "purolator",
+        "description": null, "dimensions": [], "human_readable": "CustomerPackaging",
+        "max_weight": null, "name": "CUSTOMERPACKAGING"}, {"carrier": "purolator",
+        "description": null, "dimensions": [], "human_readable": "ExpressPack", "max_weight":
+        null, "name": "EXPRESSPACK"}, {"carrier": "purolator", "description": null,
+        "dimensions": [], "human_readable": "ExpressBox", "max_weight": null, "name":
+        "EXPRESSBOX"}, {"carrier": "purolator", "description": null, "dimensions":
+        [], "human_readable": "ExpressEnvelope", "max_weight": null, "name": "EXPRESSENVELOPE"}],
+        "service_levels": [{"carrier": "purolator", "description": null, "dimensions":
+        [], "human_readable": "Purolator Express", "max_weight": null, "name": "PurolatorExpress"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express 12PM", "max_weight": null, "name": "PurolatorExpress12PM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack 12PM", "max_weight": null, "name": "PurolatorExpressPack12PM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box 12PM", "max_weight": null, "name": "PurolatorExpressBox12PM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope 12PM", "max_weight": null, "name": "PurolatorExpressEnvelope12PM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express 10:30AM", "max_weight": null, "name": "PurolatorExpress1030AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express 9AM", "max_weight": null, "name": "PurolatorExpress9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box", "max_weight": null, "name": "PurolatorExpressBox"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box 10:30AM", "max_weight": null, "name": "PurolatorExpressBox1030AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box 9AM", "max_weight": null, "name": "PurolatorExpressBox9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box Evening", "max_weight": null, "name": "PurolatorExpressBoxEvening"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box International", "max_weight": null, "name": "PurolatorExpressBoxInternational"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box US", "max_weight": null, "name": "PurolatorExpressBoxUS"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope", "max_weight": null, "name": "PurolatorExpressEnvelope"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope 10:30AM", "max_weight": null, "name": "PurolatorExpressEnvelope1030AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope 9AM", "max_weight": null, "name": "PurolatorExpressEnvelope9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope Evening", "max_weight": null, "name": "PurolatorExpressEnvelopeEvening"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope International", "max_weight": null, "name": "PurolatorExpressEnvelopeInternational"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope US", "max_weight": null, "name": "PurolatorExpressEnvelopeUS"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Evening", "max_weight": null, "name": "PurolatorExpressEvening"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express International", "max_weight": null, "name": "PurolatorExpressInternational"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express International 10:30AM", "max_weight": null, "name": "PurolatorExpressInternational1030AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express International 12:00", "max_weight": null, "name": "PurolatorExpressInternational1200"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express International 9AM", "max_weight": null, "name": "PurolatorExpressInternational9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box International 10:30AM", "max_weight": null, "name":
+        "PurolatorExpressBoxInternational1030AM"}, {"carrier": "purolator", "description":
+        null, "dimensions": [], "human_readable": "Purolator Express Box International
+        12:00", "max_weight": null, "name": "PurolatorExpressBoxInternational1200"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box International 9AM", "max_weight": null, "name": "PurolatorExpressBoxInternational9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope International 10:30AM", "max_weight": null, "name":
+        "PurolatorExpressEnvelopeInternational1030AM"}, {"carrier": "purolator", "description":
+        null, "dimensions": [], "human_readable": "Purolator Express Envelope International
+        12:00", "max_weight": null, "name": "PurolatorExpressEnvelopeInternational1200"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope International 9AM", "max_weight": null, "name":
+        "PurolatorExpressEnvelopeInternational9AM"}, {"carrier": "purolator", "description":
+        null, "dimensions": [], "human_readable": "Purolator Express Pack International
+        10:30AM", "max_weight": null, "name": "PurolatorExpressPackInternational1030AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack International 12:00", "max_weight": null, "name":
+        "PurolatorExpressPackInternational1200"}, {"carrier": "purolator", "description":
+        null, "dimensions": [], "human_readable": "Purolator Express Pack International
+        9AM", "max_weight": null, "name": "PurolatorExpressPackInternational9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack", "max_weight": null, "name": "PurolatorExpressPack"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack 10:30AM", "max_weight": null, "name": "PurolatorExpressPack1030AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack 9AM", "max_weight": null, "name": "PurolatorExpressPack9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack Evening", "max_weight": null, "name": "PurolatorExpressPackEvening"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack International", "max_weight": null, "name": "PurolatorExpressPackInternational"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack US", "max_weight": null, "name": "PurolatorExpressPackUS"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express US", "max_weight": null, "name": "PurolatorExpressUS"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express US 10:30AM", "max_weight": null, "name": "PurolatorExpressUS1030AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express US 12:00", "max_weight": null, "name": "PurolatorExpressUS1200"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express US 9AM", "max_weight": null, "name": "PurolatorExpressUS9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box US 10:30AM", "max_weight": null, "name": "PurolatorExpressBoxUS1030AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box US 12:00", "max_weight": null, "name": "PurolatorExpressBoxUS1200"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Box US 9AM", "max_weight": null, "name": "PurolatorExpressBoxUS9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope US 10:30AM", "max_weight": null, "name": "PurolatorExpressEnvelopeUS1030AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope US 12:00", "max_weight": null, "name": "PurolatorExpressEnvelopeUS1200"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Envelope US 9AM", "max_weight": null, "name": "PurolatorExpressEnvelopeUS9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack US 10:30AM", "max_weight": null, "name": "PurolatorExpressPackUS1030AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack US 12:00", "max_weight": null, "name": "PurolatorExpressPackUS1200"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Express Pack US 9AM", "max_weight": null, "name": "PurolatorExpressPackUS9AM"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Ground", "max_weight": null, "name": "PurolatorGround"}, {"carrier":
+        "purolator", "description": null, "dimensions": [], "human_readable": "Purolator
+        Ground 10:30AM", "max_weight": null, "name": "PurolatorGround1030AM"}, {"carrier":
+        "purolator", "description": null, "dimensions": [], "human_readable": "Purolator
+        Ground 9AM", "max_weight": null, "name": "PurolatorGround9AM"}, {"carrier":
+        "purolator", "description": null, "dimensions": [], "human_readable": "Purolator
+        Ground 12PM", "max_weight": null, "name": "PurolatorGround12PM"}, {"carrier":
+        "purolator", "description": null, "dimensions": [], "human_readable": "Purolator
+        Ground Distribution", "max_weight": null, "name": "PurolatorGroundDistribution"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Ground Evening", "max_weight": null, "name": "PurolatorGroundEvening"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Ground US", "max_weight": null, "name": "PurolatorGroundUS"}, {"carrier":
+        "purolator", "description": null, "dimensions": [], "human_readable": "Purolator
+        Quick Ship", "max_weight": null, "name": "PurolatorQuickShip"}, {"carrier":
+        "purolator", "description": null, "dimensions": [], "human_readable": "Purolator
+        Quick Ship Envelope", "max_weight": null, "name": "PurolatorQuickShipEnvelope"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Quick Ship Pack", "max_weight": null, "name": "PurolatorQuickShipPack"},
+        {"carrier": "purolator", "description": null, "dimensions": [], "human_readable":
+        "Purolator Quick Ship Box", "max_weight": null, "name": "PurolatorQuickShipBox"}],
+        "shipment_options": [], "supported_features": [{"carrier": "purolator", "description":
+        null, "name": "labels", "supported": true}, {"carrier": "purolator", "description":
+        null, "name": "orders", "supported": true}, {"carrier": "purolator", "description":
+        null, "name": "pickups", "supported": true}, {"carrier": "purolator", "description":
+        "Purolator bills at the end of the day for all labels created that day. You
+        cannot refund a label after the end of the day it was created.", "name": "refunds",
+        "supported": true}, {"carrier": "purolator", "description": null, "name":
+        "returns", "supported": true}, {"carrier": "purolator", "description": null,
+        "name": "scanforms", "supported": true}, {"carrier": "purolator", "description":
+        null, "name": "rating", "supported": true}, {"carrier": "purolator", "description":
+        null, "name": "tracking", "supported": true}, {"carrier": "purolator", "description":
+        null, "name": "bill_on_delivery", "supported": true}, {"carrier": "purolator",
+        "description": null, "name": "commercial_invoices", "supported": true}, {"carrier":
+        "purolator", "description": null, "name": "sort_codes", "supported": false},
+        {"carrier": "purolator", "description": null, "name": "test_environment",
+        "supported": true}]}, {"human_readable": "Royal Mail", "name": "royalmail",
+        "predefined_packages": [{"carrier": "royalmail", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "LARGELETTER"}, {"carrier":
+        "royalmail", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "SMALLPARCEL"}, {"carrier": "royalmail", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "MEDIUMPARCEL"}, {"carrier": "royalmail", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "LETTER"}, {"carrier":
+        "royalmail", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "PRINTEDPAPER"}], "service_levels": [{"carrier":
+        "royalmail", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "InternationalPriority"}, {"carrier": "royalmail",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "InternationalEconomy"}, {"carrier": "royalmail", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InternationalStandard"}, {"carrier": "royalmail", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "InternationalTrackedAndSigned"},
+        {"carrier": "royalmail", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "InternationalTracked"}, {"carrier": "royalmail",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "InternationalSigned"}, {"carrier": "royalmail", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "AccountMail"}, {"carrier": "royalmail", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "RoyalMailUnsigned"},
+        {"carrier": "royalmail", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "RoyalMail"}, {"carrier": "royalmail", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "SpecialDeliveryGuaranteed"}, {"carrier": "royalmail", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "SpecialDeliveryGuaranteed1pm"},
+        {"carrier": "royalmail", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "SpecialDeliveryGuaranteed9am"}, {"carrier":
+        "royalmail", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "StandardLetter"}, {"carrier": "royalmail", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Tracked24"}, {"carrier": "royalmail", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Tracked24HighVolume"},
+        {"carrier": "royalmail", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Tracked24HighVolumeSignature"}, {"carrier":
+        "royalmail", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "Tracked24LBT"}, {"carrier": "royalmail", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Tracked24SignatureLBT"}, {"carrier": "royalmail", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Tracked48LBT"}, {"carrier":
+        "royalmail", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "Tracked48SignatureLBT"}, {"carrier": "royalmail",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Tracked24Signature"}, {"carrier": "royalmail", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Tracked48"}, {"carrier": "royalmail", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Tracked48HighVolume"},
+        {"carrier": "royalmail", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Tracked48HighVolumeSignature"}, {"carrier":
+        "royalmail", "description": null, "dimensions": [], "human_readable": null,
+        "max_weight": null, "name": "Tracked48Signature"}, {"carrier": "royalmail",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "TrackedReturns24"}, {"carrier": "royalmail", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "TrackedReturns48"}], "shipment_options": [{"carrier": "royalmail", "deprecated":
+        false, "description": null, "human_readable": "Carrier Insurance Amount",
+        "name": "carrier_insurance_amount", "type": "float"}, {"carrier": "royalmail",
+        "deprecated": false, "description": null, "human_readable": "Carrier Notification
+        Email", "name": "carrier_notification_email", "type": "boolean"}, {"carrier":
+        "royalmail", "deprecated": false, "description": null, "human_readable": "Carrier
+        Notification Sms", "name": "carrier_notification_sms", "type": "boolean"},
+        {"carrier": "royalmail", "deprecated": true, "description": null, "human_readable":
+        "Date Advance", "name": "date_advance", "type": "integer"}, {"carrier": "royalmail",
+        "deprecated": true, "description": null, "human_readable": "Delivered Duty
+        Paid", "name": "delivered_duty_paid", "type": "boolean"}, {"carrier": "royalmail",
+        "deprecated": false, "description": null, "human_readable": "Delivery Confirmation",
+        "name": "delivery_confirmation", "type": "string"}, {"carrier": "royalmail",
+        "deprecated": false, "description": null, "human_readable": "Handling Instructions",
+        "name": "handling_instructions", "type": "string"}, {"carrier": "royalmail",
+        "deprecated": false, "description": null, "human_readable": "Import Federal
+        Tax Id", "name": "import_federal_tax_id", "type": "string"}, {"carrier": "royalmail",
+        "deprecated": false, "description": null, "human_readable": "Incoterm", "name":
+        "incoterm", "type": "enum"}, {"carrier": "royalmail", "deprecated": false,
+        "description": null, "human_readable": "Invoice Number", "name": "invoice_number",
+        "type": "string"}, {"carrier": "royalmail", "deprecated": false, "description":
+        null, "human_readable": "Label Date", "name": "label_date", "type": "datetime"},
+        {"carrier": "royalmail", "deprecated": false, "description": null, "human_readable":
+        "Label Format", "name": "label_format", "type": "string"}, {"carrier": "royalmail",
+        "deprecated": false, "description": null, "human_readable": "License Number",
+        "name": "license_number", "type": "string"}, {"carrier": "royalmail", "deprecated":
+        true, "description": null, "human_readable": "Print Custom 1", "name": "print_custom_1",
+        "type": "string"}, {"carrier": "royalmail", "deprecated": true, "description":
+        null, "human_readable": "Print Custom 2", "name": "print_custom_2", "type":
+        "string"}, {"carrier": "royalmail", "deprecated": false, "description": null,
+        "human_readable": "Saturday Delivery", "name": "saturday_delivery", "type":
+        "boolean"}], "supported_features": [{"carrier": "royalmail", "description":
+        null, "name": "labels", "supported": true}, {"carrier": "royalmail", "description":
+        null, "name": "orders", "supported": false}, {"carrier": "royalmail", "description":
+        null, "name": "pickups", "supported": false}, {"carrier": "royalmail", "description":
+        null, "name": "refunds", "supported": true}, {"carrier": "royalmail", "description":
+        null, "name": "returns", "supported": true}, {"carrier": "royalmail", "description":
+        null, "name": "scanforms", "supported": true}, {"carrier": "royalmail", "description":
+        null, "name": "rating", "supported": true}, {"carrier": "royalmail", "description":
+        null, "name": "tracking", "supported": true}, {"carrier": "royalmail", "description":
+        null, "name": "bill_on_label_purchase", "supported": false}, {"carrier": "royalmail",
+        "description": null, "name": "bill_on_delivery", "supported": false}, {"carrier":
+        "royalmail", "description": null, "name": "bill_on_scan", "supported": false},
+        {"carrier": "royalmail", "description": null, "name": "bill_on_manifest",
+        "supported": true}, {"carrier": "royalmail", "description": null, "name":
+        "commercial_invoices", "supported": false}, {"carrier": "royalmail", "description":
+        null, "name": "delivers_to_po_box", "supported": true}, {"carrier": "royalmail",
+        "description": null, "name": "sort_codes", "supported": true}, {"carrier":
+        "royalmail", "description": null, "name": "test_environment", "supported":
+        true}]}, {"human_readable": "SEKO OmniParcel", "name": "sekoomniparcel", "predefined_packages":
+        [{"carrier": "sekoomniparcel", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Bag"}, {"carrier": "sekoomniparcel", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Box"}, {"carrier": "sekoomniparcel", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "Carton"}, {"carrier":
+        "sekoomniparcel", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Container"}, {"carrier": "sekoomniparcel",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Crate"}, {"carrier": "sekoomniparcel", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "Envelope"},
+        {"carrier": "sekoomniparcel", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Pail"}, {"carrier": "sekoomniparcel", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Pallet"}, {"carrier": "sekoomniparcel", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Satchel"}, {"carrier":
+        "sekoomniparcel", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Tub"}], "service_levels": [{"carrier":
+        "sekoomniparcel", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Ecommerce Standard Tracked"}, {"carrier":
+        "sekoomniparcel", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Ecommerce Express Tracked"}, {"carrier":
+        "sekoomniparcel", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Domestic Express"}, {"carrier": "sekoomniparcel",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Domestic Standard"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "Sendle", "name": "sendle", "predefined_packages":
+        [], "service_levels": [{"carrier": "sendle", "description": null, "dimensions":
+        [], "human_readable": "Standard", "max_weight": null, "name": "Standard"},
+        {"carrier": "sendle", "description": null, "dimensions": [], "human_readable":
+        "Express", "max_weight": null, "name": "Express"}], "shipment_options": [],
+        "supported_features": []}, {"human_readable": "SF Express", "name": "sfexpress",
+        "predefined_packages": [], "service_levels": [{"carrier": "sfexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InternationalStandardExpressDoc"}, {"carrier": "sfexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InternationalStandardExpressParcel"}, {"carrier": "sfexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InternationalEconomyExpressPilot"}, {"carrier": "sfexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InternationalEconomyExpressDoc"}, {"carrier": "sfexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "InternationalEconomyExpressParcel"}, {"carrier": "sfexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "DomesticExpress"}, {"carrier": "sfexpress", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "DomesticStandard"},
+        {"carrier": "sfexpress", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "DomesticIntraCity"}, {"carrier": "sfexpress",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "StandardExpress"}, {"carrier": "sfexpress", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "EconomyExpress"}], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "SmartKargo", "name": "smartkargo", "predefined_packages": [], "service_levels":
+        [{"carrier": "smartkargo", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "EPR"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "Sonic", "name": "sonic", "predefined_packages": [],
+        "service_levels": [{"carrier": "sonic", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "NEXTDAY"}, {"carrier":
+        "sonic", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "SAMEDAY"}], "shipment_options": [], "supported_features": []},
+        {"human_readable": "Spee-Dee", "name": "speedee", "predefined_packages": [],
+        "service_levels": [{"carrier": "speedee", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "SpeeDeeDelivery"}],
+        "shipment_options": [], "supported_features": []}, {"human_readable": "Swyft",
+        "name": "swyft", "predefined_packages": [], "service_levels": [{"carrier":
+        "swyft", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "NEXTDAY"}, {"carrier": "swyft", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "SAMEDAY"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "TForce Logistics", "name":
+        "tforce", "predefined_packages": [], "service_levels": [{"carrier": "tforce",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "NextDay"}, {"carrier": "tforce", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Return"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "Toll", "name": "toll",
+        "predefined_packages": [], "service_levels": [{"carrier": "toll", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "IPEC Direct"}, {"carrier": "toll", "description": null, "dimensions": [],
+        "human_readable": null, "max_weight": null, "name": "IPEC Fashion"}, {"carrier":
+        "toll", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "IPEC Local"}, {"carrier": "toll", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "IPEC Priority"},
+        {"carrier": "toll", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "IPEC Road Express"}, {"carrier": "toll",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "IPEC Sensitive"}, {"carrier": "toll", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "IPEC
+        VicEXP"}], "shipment_options": [], "supported_features": []}, {"human_readable":
+        "UDS", "name": "uds", "predefined_packages": [], "service_levels": [{"carrier":
+        "uds", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "DeliveryService"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "UPS", "name": "ups", "predefined_packages": [{"carrier":
+        "ups", "description": null, "dimensions": ["12.5in - 15in x 9.5in"], "human_readable":
+        null, "max_weight": 16.0, "name": "UPSLetter"}, {"carrier": "ups", "description":
+        null, "dimensions": ["12.5in x 3.75in x 18in"], "human_readable": null, "max_weight":
+        480.0, "name": "UPSExpressBox"}, {"carrier": "ups", "description": null, "dimensions":
+        ["19.75in x 17.75in x 13.25in"], "human_readable": null, "max_weight": 880.0,
+        "name": "UPS25kgBox"}, {"carrier": "ups", "description": null, "dimensions":
+        ["16.5in x 13.25in x 10.75in"], "human_readable": null, "max_weight": 352.0,
+        "name": "UPS10kgBox"}, {"carrier": "ups", "description": "Triangular tube
+        for rolled papers", "dimensions": ["38in x 6in x 6in"], "human_readable":
+        null, "max_weight": null, "name": "Tube"}, {"carrier": "ups", "description":
+        null, "dimensions": ["16in x 12.75in"], "human_readable": null, "max_weight":
+        null, "name": "Pak"}, {"carrier": "ups", "description": null, "dimensions":
+        ["13in x 11in x 2in"], "human_readable": null, "max_weight": 480.0, "name":
+        "SmallExpressBox"}, {"carrier": "ups", "description": null, "dimensions":
+        ["16in x 11in x 3in"], "human_readable": null, "max_weight": 480.0, "name":
+        "MediumExpressBox"}, {"carrier": "ups", "description": null, "dimensions":
+        ["18in x 13in x 3in"], "human_readable": null, "max_weight": 480.0, "name":
+        "LargeExpressBox"}], "service_levels": [{"carrier": "ups", "description":
+        "1-5 Business Days", "dimensions": null, "human_readable": "UPS Ground", "max_weight":
+        null, "name": "Ground"}, {"carrier": "ups", "description": "1-5 Business Days",
+        "dimensions": null, "human_readable": "UPS Standard", "max_weight": null,
+        "name": "UPSStandard"}, {"carrier": "ups", "description": "Next Day to 4 Business
+        Days", "dimensions": null, "human_readable": "UPS Worldwide Saver", "max_weight":
+        null, "name": "UPSSaver"}, {"carrier": "ups", "description": "Next Day to
+        3 Business Days", "dimensions": null, "human_readable": "UPS Worldwide Express",
+        "max_weight": null, "name": "Express"}, {"carrier": "ups", "description":
+        "Next Day to 2 Business Days", "dimensions": null, "human_readable": "UPS
+        Worldwide Express Plus", "max_weight": null, "name": "ExpressPlus"}, {"carrier":
+        "ups", "description": "3 to 5 Business Days", "dimensions": null, "human_readable":
+        "UPS Worldwide Expedited", "max_weight": null, "name": "Expedited"}, {"carrier":
+        "ups", "description": "Next Business Day by 10:30am", "dimensions": null,
+        "human_readable": "UPS Next Day Air", "max_weight": null, "name": "NextDayAir"},
+        {"carrier": "ups", "description": "Next Business Day by 3:00pm", "dimensions":
+        null, "human_readable": "UPS Next Day Air Saver", "max_weight": null, "name":
+        "NextDayAirSaver"}, {"carrier": "ups", "description": "Next Business Days
+        by 8:00am", "dimensions": null, "human_readable": "UPS Next Day Air A.M.",
+        "max_weight": null, "name": "NextDayAirEarlyAM"}, {"carrier": "ups", "description":
+        "2 Business Days by end of day", "dimensions": null, "human_readable": "UPS
+        2nd Day Air", "max_weight": null, "name": "2ndDayAir"}, {"carrier": "ups",
+        "description": null, "dimensions": null, "human_readable": null, "max_weight":
+        null, "name": "2ndDayAirAM"}, {"carrier": "ups", "description": "3 Business
+        Days by end of day", "dimensions": null, "human_readable": "UPS 3-Day Select",
+        "max_weight": null, "name": "3DaySelect"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "UPS iParcel", "name": "upsiparcel", "predefined_packages":
+        [], "service_levels": [], "shipment_options": [], "supported_features": []},
+        {"human_readable": "UPS Mail Innovations", "name": "upsmailinnovations", "predefined_packages":
+        [], "service_levels": [{"carrier": "upsmailinnovations", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "First"},
+        {"carrier": "upsmailinnovations", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Priority"}, {"carrier": "upsmailinnovations",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "ExpeditedMailInnovations"}, {"carrier": "upsmailinnovations",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "PriorityMailInnovations"}, {"carrier": "upsmailinnovations",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "EconomyMailInnovations"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "USPS", "name": "usps", "predefined_packages": [{"carrier":
+        "usps", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Card"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "Letter"}, {"carrier":
+        "usps", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Flat"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "FlatRateEnvelope"},
+        {"carrier": "usps", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "FlatRateLegalEnvelope"}, {"carrier": "usps",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "FlatRatePaddedEnvelope"}, {"carrier": "usps", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "FlatRateGiftCardEnvelope"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "FlatRateWindowEnvelope"},
+        {"carrier": "usps", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "FlatRateCardboardEnvelope"}, {"carrier":
+        "usps", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "SmallFlatRateEnvelope"}, {"carrier": "usps", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Parcel"}, {"carrier": "usps", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "SoftPack"}, {"carrier": "usps", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "SmallFlatRateBox"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "MediumFlatRateBox"},
+        {"carrier": "usps", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "LargeFlatRateBox"}, {"carrier": "usps",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "LargeFlatRateBoxAPOFPO"}, {"carrier": "usps", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "FlatTubTrayBox"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "EMMTrayBox"}, {"carrier":
+        "usps", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "FullTrayBox"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "HalfTrayBox"}, {"carrier":
+        "usps", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "PMODSack"}], "service_levels": [{"carrier": "usps", "description":
+        "1-3 days", "dimensions": ["22in x 18in x 15in"], "human_readable": null,
+        "max_weight": 15.99, "name": "First"}, {"carrier": "usps", "description":
+        "2-3 days", "dimensions": ["Combined Length and Girth < 108in"], "human_readable":
+        null, "max_weight": 1120.0, "name": "Priority"}, {"carrier": "usps", "description":
+        "1-2 days", "dimensions": ["Combined Length and Girth < 108in"], "human_readable":
+        null, "max_weight": 1120.0, "name": "Express"}, {"carrier": "usps", "description":
+        "2-8 business days", "dimensions": ["Combined Length and Girth < 108in"],
+        "human_readable": null, "max_weight": 1120.0, "name": "ParcelSelect"}, {"carrier":
+        "usps", "description": "2-8 business days", "dimensions": ["Combined Length
+        and Girth < 108in"], "human_readable": null, "max_weight": 1120.0, "name":
+        "LibraryMail"}, {"carrier": "usps", "description": "2-8 business days", "dimensions":
+        ["Combined Length and Girth < 108in"], "human_readable": null, "max_weight":
+        1120.0, "name": "MediaMail"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "FirstClassMailInternational"},
+        {"carrier": "usps", "description": "7-21 days", "dimensions": ["Combined Length
+        and Girth < 108in"], "human_readable": null, "max_weight": 64.0, "name": "FirstClassPackageInternationalService"},
+        {"carrier": "usps", "description": "6-10 business days", "dimensions": ["Combined
+        Length and Girth < 108in"], "human_readable": null, "max_weight": 1120.0,
+        "name": "PriorityMailInternational"}, {"carrier": "usps", "description": "3-5
+        business days", "dimensions": ["Combined Length and Girth < 108in"], "human_readable":
+        null, "max_weight": 1120.0, "name": "ExpressMailInternational"}], "shipment_options":
+        [], "supported_features": []}, {"human_readable": "Veho", "name": "veho",
+        "predefined_packages": [], "service_levels": [{"carrier": "veho", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "nextDay"}, {"carrier": "veho", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "sameDay"}], "shipment_options": [], "supported_features":
+        []}, {"human_readable": "Yanwen", "name": "yanwen", "predefined_packages":
+        [], "service_levels": [], "shipment_options": [], "supported_features": []}]}'
+    headers:
+      cache-control:
+      - private, no-cache, no-store
+      content-length:
+      - '128470'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"4891eb0e7e949236650c8e213bf027c6"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - cb22002c643dcc34e7885d210016aed5
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb1nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq a29e4ad05c
+      - extlb2nuq a29e4ad05c
+      x-runtime:
+      - '0.145759'
+      x-version-label:
+      - easypost-202304172058-4c7088be6d-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_beta_retrieve_carrier_metadata_with_filters.yaml
+++ b/tests/cassettes/test_beta_retrieve_carrier_metadata_with_filters.yaml
@@ -1,0 +1,123 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: GET
+    uri: https://api.easypost.com/beta/metadata?carriers=usps&types=service_levels%2Cpredefined_packages
+  response:
+    body:
+      string: '{"carriers": [{"human_readable": "USPS", "name": "usps", "predefined_packages":
+        [{"carrier": "usps", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Card"}, {"carrier": "usps", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "Letter"}, {"carrier": "usps", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "Flat"}, {"carrier": "usps", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "FlatRateEnvelope"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "FlatRateLegalEnvelope"},
+        {"carrier": "usps", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "FlatRatePaddedEnvelope"}, {"carrier": "usps",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "FlatRateGiftCardEnvelope"}, {"carrier": "usps", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "FlatRateWindowEnvelope"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "FlatRateCardboardEnvelope"},
+        {"carrier": "usps", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "SmallFlatRateEnvelope"}, {"carrier": "usps",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "Parcel"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "SoftPack"}, {"carrier":
+        "usps", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "SmallFlatRateBox"}, {"carrier": "usps", "description": null,
+        "dimensions": [], "human_readable": null, "max_weight": null, "name": "MediumFlatRateBox"},
+        {"carrier": "usps", "description": null, "dimensions": [], "human_readable":
+        null, "max_weight": null, "name": "LargeFlatRateBox"}, {"carrier": "usps",
+        "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "LargeFlatRateBoxAPOFPO"}, {"carrier": "usps", "description":
+        null, "dimensions": [], "human_readable": null, "max_weight": null, "name":
+        "FlatTubTrayBox"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "EMMTrayBox"}, {"carrier":
+        "usps", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "FullTrayBox"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "HalfTrayBox"}, {"carrier":
+        "usps", "description": null, "dimensions": [], "human_readable": null, "max_weight":
+        null, "name": "PMODSack"}], "service_levels": [{"carrier": "usps", "description":
+        "1-3 days", "dimensions": ["22in x 18in x 15in"], "human_readable": null,
+        "max_weight": 15.99, "name": "First"}, {"carrier": "usps", "description":
+        "2-3 days", "dimensions": ["Combined Length and Girth < 108in"], "human_readable":
+        null, "max_weight": 1120.0, "name": "Priority"}, {"carrier": "usps", "description":
+        "1-2 days", "dimensions": ["Combined Length and Girth < 108in"], "human_readable":
+        null, "max_weight": 1120.0, "name": "Express"}, {"carrier": "usps", "description":
+        "2-8 business days", "dimensions": ["Combined Length and Girth < 108in"],
+        "human_readable": null, "max_weight": 1120.0, "name": "ParcelSelect"}, {"carrier":
+        "usps", "description": "2-8 business days", "dimensions": ["Combined Length
+        and Girth < 108in"], "human_readable": null, "max_weight": 1120.0, "name":
+        "LibraryMail"}, {"carrier": "usps", "description": "2-8 business days", "dimensions":
+        ["Combined Length and Girth < 108in"], "human_readable": null, "max_weight":
+        1120.0, "name": "MediaMail"}, {"carrier": "usps", "description": null, "dimensions":
+        [], "human_readable": null, "max_weight": null, "name": "FirstClassMailInternational"},
+        {"carrier": "usps", "description": "7-21 days", "dimensions": ["Combined Length
+        and Girth < 108in"], "human_readable": null, "max_weight": 64.0, "name": "FirstClassPackageInternationalService"},
+        {"carrier": "usps", "description": "6-10 business days", "dimensions": ["Combined
+        Length and Girth < 108in"], "human_readable": null, "max_weight": 1120.0,
+        "name": "PriorityMailInternational"}, {"carrier": "usps", "description": "3-5
+        business days", "dimensions": ["Combined Length and Girth < 108in"], "human_readable":
+        null, "max_weight": 1120.0, "name": "ExpressMailInternational"}]}]}'
+    headers:
+      cache-control:
+      - private, no-cache, no-store
+      content-length:
+      - '4207'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"a842c1378a5f4d5f9ad9956312671ebe"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - eebf4dfe643dcd0fe7885da30016a3dd
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb1nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq a29e4ad05c
+      - extlb1nuq a29e4ad05c
+      x-runtime:
+      - '0.027778'
+      x-version-label:
+      - easypost-202304172058-4c7088be6d-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_beta_carrier_metadata.py
+++ b/tests/test_beta_carrier_metadata.py
@@ -15,9 +15,10 @@ def test_beta_retrieve_carrier_metadata():
 
 @pytest.mark.vcr()
 def test_beta_retrieve_carrier_metadata_with_filters():
-    """Tests that we can retrieve all carriers and all metadata from the API when no params are provided."""
+    """Tests that we can retrieve metadata based on the filters provided."""
     carrier_metadata = easypost.beta.CarrierMetadata.retrieve_carrier_metadata(
-        carriers=["usps"], types=["service_levels", "predefined_packages"]
+        carriers=["usps"],
+        types=["service_levels", "predefined_packages"],
     )
 
     # Assert we get the single carrier we asked for and only the types we asked for

--- a/tests/test_beta_carrier_metadata.py
+++ b/tests/test_beta_carrier_metadata.py
@@ -1,0 +1,28 @@
+import pytest
+
+import easypost
+
+
+@pytest.mark.vcr()
+def test_beta_retrieve_carrier_metadata():
+    """Tests that we can retrieve all carriers and all metadata from the API when no params are provided."""
+    carrier_metadata = easypost.beta.CarrierMetadata.retrieve_carrier_metadata()
+
+    # Assert we get multiple carriers
+    assert any(carrier.name == "usps" for carrier in carrier_metadata)
+    assert any(carrier.name == "fedex" for carrier in carrier_metadata)
+
+
+@pytest.mark.vcr()
+def test_beta_retrieve_carrier_metadata_with_filters():
+    """Tests that we can retrieve all carriers and all metadata from the API when no params are provided."""
+    carrier_metadata = easypost.beta.CarrierMetadata.retrieve_carrier_metadata(
+        carriers=["usps"], types=["service_levels", "predefined_packages"]
+    )
+
+    # Assert we get the single carrier we asked for and only the types we asked for
+    assert all(carrier.name == "usps" for carrier in carrier_metadata)
+    assert len(carrier_metadata) == 1
+    assert carrier_metadata[0]["service_levels"]
+    assert carrier_metadata[0]["predefined_packages"]
+    assert not carrier_metadata[0].get("supported_features")


### PR DESCRIPTION
# Description

Adds the new `/metadata` beta endpoint under `retrieve_carrier_metadata` allowing you to specify either a list of carriers or types or none to get it all.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Adds a test to retrieve all and another to use filters, inspected cassettes
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
