### PR TITLE
fix: payload inherits resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v7.13.1 (2023-05-31)
+
+- Fixes a bug where `Payload` didn't inherit `EasyPostObject` which could throw errors when retrieving event payloads (closes #284)
+
 ## v7.13.0 (2023-05-02)
 
 - Adds `retrieve_estimated_delivery_date` function to the Shipment class

--- a/easypost/payload.py
+++ b/easypost/payload.py
@@ -1,2 +1,5 @@
-class Payload:
+from easypost.resource import Resource
+
+
+class Payload(Resource):
     pass

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="easypost",
-    version="7.13.0",
+    version="7.13.1",
     description="EasyPost Shipping API Client Library for Python",
     author="EasyPost",
     author_email="support@easypost.com",


### PR DESCRIPTION
# Description

- Fixes a bug where `Payload` didn't inherit `EasyPostObject` which could throw errors when retrieving event payloads (closes #284)
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

NA, the error stemmed from this class just not having access to the parent classes due to missing inheritance.
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
