### PR TITLE
feat: adds Request and Response Hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Adds new `RequestHook` and `ResponseHook` events. (un)subscribe to them with the new `subscribe_to_request_hook`, `subscribe_to_response_hook`, `unsubscribe_from_request_hook`, or `unsubscribe_from_response_hook` methods of an `EasyPostClient`
+
 ## v8.0.0 (2023-06-06)
 
 See our [Upgrade Guide](UPGRADE_GUIDE.md#upgrading-from-7x-to-80) for more details.

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ black-check:
 build:
 	$(VIRTUAL_BIN)/python -m build
 
-## clean - Remove the virtual environment and clear out .pyc files
+## clean - Clean the project
 clean:
-	rm -rf $(VIRTUAL_ENV) dist/ build/ *.egg-info/ .pytest_cache .mypy_cache
+	rm -rf $(VIRTUAL_ENV) dist/ *.egg-info/ .*cache htmlcov *.lcov .coverage
 	find . -name '*.pyc' -delete
 
 ## coverage - Test the project and generate an HTML coverage report

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ bought_shipment = client.shipment.buy(shipment.id, rate=shipment.lowest_rate())
 print(bought_shipment)
 ```
 
+### HTTP Hooks
+
+Users can subscribe to HTTP requests and responses via the `RequestHook` and `ResponseHook` objects. To do so, pass a function to the `subscribe_to_request_hook` or `subscribe_to_response_hook` methods of an `EasyPostClient` object:
+
+```python
+def custom_function(**kwargs):
+    """Pass your code here, data about the request/response is contained within `kwargs`."""
+    print(f"Received a request with the status code of: {kwargs.get('http_status')}")
+
+client = easypost.EasyPostClient(os.getenv('EASYPOST_API_KEY'))
+
+client.subscribe_to_response_hook(custom_function)
+
+# Make your API calls here, your custom_function will trigger once a response is received
+```
+
+You can also unsubscribe your functions in a similar manner by using the `unsubscribe_from_request_hook` and `unsubscribe_from_response_hook` methods of a client object.
+
 ## Documentation
 
 API documentation can be found at: <https://easypost.com/docs/api>.

--- a/easypost/easypost_client.py
+++ b/easypost/easypost_client.py
@@ -80,8 +80,8 @@ class EasyPostClient:
         self.webhook = WebhookService(self)
 
         # Hooks
-        self._request_event = RequestHook()
-        self._response_event = ResponseHook()
+        self._request_hook = RequestHook()
+        self._response_hook = ResponseHook()
 
         # use urlfetch as request_lib on google app engine, otherwise use requests
         self._request_lib = None
@@ -115,17 +115,17 @@ class EasyPostClient:
                     raise ImportError(INVALID_REQUESTS_VERSION_ERROR.format(SUPPORT_EMAIL))
 
     def subscribe_to_request_hook(self, function):
-        """Subscribe functions to run when a request event occurs."""
-        self._request_event += function
+        """Subscribe functions to run when a request occurs."""
+        self._request_hook += function
 
     def unsubscribe_from_request_hook(self, function):
-        """Unsubscribe functions from running when a request even occurs."""
-        self._request_event -= function
+        """Unsubscribe functions from running when a request occurs."""
+        self._request_hook -= function
 
     def subscribe_to_response_hook(self, function):
-        """Subscribe functions to run when a response event occurs."""
-        self._response_event += function
+        """Subscribe functions to run when a response occurs."""
+        self._response_hook += function
 
     def unsubscribe_from_response_hook(self, function):
-        """Unsubscribe functions from running when a response even occurs."""
-        self._response_event -= function
+        """Unsubscribe functions from running when a response occurs."""
+        self._response_hook -= function

--- a/easypost/easypost_client.py
+++ b/easypost/easypost_client.py
@@ -5,6 +5,10 @@ from easypost.constant import (
     SUPPORT_EMAIL,
     TIMEOUT,
 )
+from easypost.hooks import (
+    RequestHook,
+    ResponseHook,
+)
 from easypost.services import (
     AddressService,
     BatchService,
@@ -75,6 +79,10 @@ class EasyPostClient:
         self.user = UserService(self)
         self.webhook = WebhookService(self)
 
+        # Hooks
+        self._request_event = RequestHook()
+        self._response_event = ResponseHook()
+
         # use urlfetch as request_lib on google app engine, otherwise use requests
         self._request_lib = None
         try:
@@ -105,3 +113,19 @@ class EasyPostClient:
             else:
                 if major_version < 1:
                     raise ImportError(INVALID_REQUESTS_VERSION_ERROR.format(SUPPORT_EMAIL))
+
+    def subscribe_to_request_hook(self, function):
+        """Subscribe functions to run when a request event occurs."""
+        self._request_event += function
+
+    def unsubscribe_from_request_hook(self, function):
+        """Unsubscribe functions from running when a request even occurs."""
+        self._request_event -= function
+
+    def subscribe_to_response_hook(self, function):
+        """Subscribe functions to run when a response event occurs."""
+        self._response_event += function
+
+    def unsubscribe_from_response_hook(self, function):
+        """Unsubscribe functions from running when a response even occurs."""
+        self._response_event -= function

--- a/easypost/hooks/__init__.py
+++ b/easypost/hooks/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa
+from easypost.hooks.event_hook import EventHook
+from easypost.hooks.request_hook import RequestHook
+from easypost.hooks.response_hook import ResponseHook

--- a/easypost/hooks/event_hook.py
+++ b/easypost/hooks/event_hook.py
@@ -1,0 +1,17 @@
+class EventHook:
+    """The parent event that occurs when a hook is triggered."""
+
+    def __init__(self):
+        self._event_handlers = []
+
+    def __iadd__(self, handler):
+        self._event_handlers.append(handler)
+        return self
+
+    def __isub__(self, handler):
+        self._event_handlers.remove(handler)
+        return self
+
+    def __call__(self, *args, **kwargs):
+        for event_handler in self._event_handlers:
+            event_handler(*args, **kwargs)

--- a/easypost/hooks/request_hook.py
+++ b/easypost/hooks/request_hook.py
@@ -1,0 +1,7 @@
+from easypost.hooks import EventHook
+
+
+class RequestHook(EventHook):
+    """An event that gets triggered when an HTTP request begins."""
+
+    pass

--- a/easypost/hooks/response_hook.py
+++ b/easypost/hooks/response_hook.py
@@ -1,0 +1,7 @@
+from easypost.hooks import EventHook
+
+
+class ResponseHook(EventHook):
+    """An event that gets triggered when an HTTP response is returned."""
+
+    pass

--- a/easypost/requestor.py
+++ b/easypost/requestor.py
@@ -201,8 +201,8 @@ class Requestor:
             "User-Agent": user_agent,
         }
 
-        request_timestamp = datetime.datetime.now(datetime.timezone.utc)
         request_uuid = uuid.uuid4()
+        request_timestamp = datetime.datetime.now(datetime.timezone.utc)
         self._client._request_hook(
             method=method,
             path=abs_url,

--- a/easypost/requestor.py
+++ b/easypost/requestor.py
@@ -203,7 +203,7 @@ class Requestor:
 
         request_timestamp = datetime.datetime.now(datetime.timezone.utc)
         request_uuid = uuid.uuid4()
-        self._client._request_event(
+        self._client._request_hook(
             method=method,
             path=abs_url,
             headers=headers,
@@ -224,7 +224,7 @@ class Requestor:
             raise EasyPostError(INVALID_REQUEST_LIB_ERROR.format(self._client._request_lib, SUPPORT_EMAIL))
 
         response_timestamp = datetime.datetime.now(datetime.timezone.utc)
-        self._client._response_event(
+        self._client._response_hook(
             http_status=http_status,
             method=method,
             path=abs_url,

--- a/easypost/requestor.py
+++ b/easypost/requestor.py
@@ -207,7 +207,7 @@ class Requestor:
             method=method,
             path=abs_url,
             headers=headers,
-            data=params,
+            request_body=params,
             request_timestamp=request_timestamp,
             request_uuid=request_uuid,
         )

--- a/tests/cassettes/test_request_hooks.yaml
+++ b/tests/cassettes/test_request_hooks.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{"parcel": {"length": 10, "width": 8, "height": 4, "weight": 15.4}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/parcels
+  response:
+    body:
+      string: '{"id": "prcl_15f34d84a01847799890a35ab7f8a261", "object": "Parcel",
+        "created_at": "2023-06-29T22:36:03Z", "updated_at": "2023-06-29T22:36:03Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}'
+    headers:
+      cache-control:
+      - private, no-cache, no-store
+      content-length:
+      - '229'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"a90098860cd1a677b56d32848a684379"
+      expires:
+      - '0'
+      location:
+      - /api/v2/parcels/prcl_15f34d84a01847799890a35ab7f8a261
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 49bdaf3f649e0753e2b8fb95000a9ec7
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb11nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq d3d339cca1
+      - extlb1nuq 5ab12a3ed2
+      x-runtime:
+      - '0.026615'
+      x-version-label:
+      - easypost-202306292027-2f32ee5ecd-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/cassettes/test_response_hooks.yaml
+++ b/tests/cassettes/test_response_hooks.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: '{"parcel": {"length": 10, "width": 8, "height": 4, "weight": 15.4}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/parcels
+  response:
+    body:
+      string: '{"id": "prcl_d6da00b3a2154818add0e7c9025a63f6", "object": "Parcel",
+        "created_at": "2023-06-29T22:47:00Z", "updated_at": "2023-06-29T22:47:00Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}'
+    headers:
+      cache-control:
+      - private, no-cache, no-store
+      content-length:
+      - '229'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"b3a4057483595cdf3ec2666106f6786a"
+      expires:
+      - '0'
+      location:
+      - /api/v2/parcels/prcl_d6da00b3a2154818add0e7c9025a63f6
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 0598c244649e09e4e2b90015000b6647
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb4nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq d3d339cca1
+      - intlb2wdc d3d339cca1
+      - extlb4wdc 5ab12a3ed2
+      x-runtime:
+      - '0.032784'
+      x-version-label:
+      - easypost-202306292027-2f32ee5ecd-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/cassettes/test_unsubscribe_hooks.yaml
+++ b/tests/cassettes/test_unsubscribe_hooks.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{"parcel": {"length": 10, "width": 8, "height": 4, "weight": 15.4}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: POST
+    uri: https://api.easypost.com/v2/parcels
+  response:
+    body:
+      string: '{"id": "prcl_2535d1e2665641948770e7aa90f70bf3", "object": "Parcel",
+        "created_at": "2023-06-30T17:01:45Z", "updated_at": "2023-06-30T17:01:45Z",
+        "length": 10.0, "width": 8.0, "height": 4.0, "predefined_package": null, "weight":
+        15.4, "mode": "test"}'
+    headers:
+      cache-control:
+      - private, no-cache, no-store
+      content-length:
+      - '229'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"9cb055900bf75d13a2ec90e371e91ee8"
+      expires:
+      - '0'
+      location:
+      - /api/v2/parcels/prcl_2535d1e2665641948770e7aa90f70bf3
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - 9ccf1878649f0a79e786c05b0018405c
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb6nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq d3d339cca1
+      - extlb2nuq 5ab12a3ed2
+      x-runtime:
+      - '0.030761'
+      x-version-label:
+      - easypost-202306301627-c689abe57f-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -8,7 +8,7 @@ def assert_request(**kwargs):
     """Make assertions about a request once the RequestHook fires."""
     assert kwargs.get("method").value == "post"
     assert kwargs.get("path") == "https://api.easypost.com/v2/parcels"
-    assert "parcel" in kwargs.get("data")
+    assert "parcel" in kwargs.get("request_body")
     assert "Authorization" in kwargs.get("headers")
     assert type(kwargs.get("request_timestamp")) == datetime.datetime
     assert uuid.UUID(str(kwargs.get("request_uuid")))

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -4,36 +4,53 @@ import uuid
 import pytest
 
 
-def assert_request(**kwargs):
-    """Make assertions about a request once the RequestHook fires."""
-    assert kwargs.get("method").value == "post"
-    assert kwargs.get("path") == "https://api.easypost.com/v2/parcels"
-    assert "parcel" in kwargs.get("request_body")
-    assert "Authorization" in kwargs.get("headers")
-    assert type(kwargs.get("request_timestamp")) == datetime.datetime
-    assert uuid.UUID(str(kwargs.get("request_uuid")))
-
-
 @pytest.mark.vcr()
 def test_request_hooks(basic_parcel, test_client):
+    def assert_request(**kwargs):
+        """Make assertions about a request once the RequestHook fires."""
+        assert kwargs.get("method").value == "post"
+        assert kwargs.get("path") == "https://api.easypost.com/v2/parcels"
+        assert "parcel" in kwargs.get("request_body")
+        assert "Authorization" in kwargs.get("headers")
+        assert type(kwargs.get("request_timestamp")) == datetime.datetime
+        assert uuid.UUID(str(kwargs.get("request_uuid")))
+
     """Test that we fire a RequestHook prior to making an HTTP request."""
     test_client.subscribe_to_request_hook(assert_request)
     _ = test_client.parcel.create(**basic_parcel)
 
 
-def assert_response(**kwargs):
-    """Make assertions about a response once the ResponseHook fires."""
-    assert kwargs.get("http_status") == 201
-    assert kwargs.get("method").value == "post"
-    assert kwargs.get("path") == "https://api.easypost.com/v2/parcels"
-    assert "object" in kwargs.get("response_body")
-    assert "location" in kwargs.get("headers")
-    assert kwargs.get("response_timestamp") > kwargs.get("request_timestamp")
-    assert uuid.UUID(str(kwargs.get("request_uuid")))
-
-
 @pytest.mark.vcr()
 def test_response_hooks(basic_parcel, test_client):
+    def assert_response(**kwargs):
+        """Make assertions about a response once the ResponseHook fires."""
+        assert kwargs.get("http_status") == 201
+        assert kwargs.get("method").value == "post"
+        assert kwargs.get("path") == "https://api.easypost.com/v2/parcels"
+        assert "object" in kwargs.get("response_body")
+        assert "location" in kwargs.get("headers")
+        assert kwargs.get("response_timestamp") > kwargs.get("request_timestamp")
+        assert uuid.UUID(str(kwargs.get("request_uuid")))
+
     """Test that we fire a ResponseHook after receiving an HTTP response."""
     test_client.subscribe_to_response_hook(assert_response)
     _ = test_client.parcel.create(**basic_parcel)
+
+
+@pytest.mark.vcr()
+def test_unsubscribe_hooks(basic_parcel, test_client):
+    """Test that we do not fire a hook once unsubscribed."""
+
+    def fail_if_subscribed(**kwargs):
+        """This function should never run since we unsubscribe from HTTP hooks."""
+        raise Exception("Unsubscribing from HTTP hooks did not work as intended")
+
+    test_client.subscribe_to_request_hook(fail_if_subscribed)
+    test_client.unsubscribe_from_request_hook(fail_if_subscribed)
+
+    test_client.subscribe_to_response_hook(fail_if_subscribed)
+    test_client.unsubscribe_from_response_hook(fail_if_subscribed)
+
+    _ = test_client.parcel.create(**basic_parcel)
+
+    assert True

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,0 +1,39 @@
+import datetime
+import uuid
+
+import pytest
+
+
+def assert_request(**kwargs):
+    """Make assertions about a request once the RequestHook fires."""
+    assert kwargs.get("method").value == "post"
+    assert kwargs.get("path") == "https://api.easypost.com/v2/parcels"
+    assert "parcel" in kwargs.get("data")
+    assert "Authorization" in kwargs.get("headers")
+    assert type(kwargs.get("request_timestamp")) == datetime.datetime
+    assert uuid.UUID(str(kwargs.get("request_uuid")))
+
+
+@pytest.mark.vcr()
+def test_request_hooks(basic_parcel, test_client):
+    """Test that we fire a RequestHook prior to making an HTTP request."""
+    test_client.subscribe_to_request_hook(assert_request)
+    _ = test_client.parcel.create(**basic_parcel)
+
+
+def assert_response(**kwargs):
+    """Make assertions about a response once the ResponseHook fires."""
+    assert kwargs.get("http_status") == 201
+    assert kwargs.get("method").value == "post"
+    assert kwargs.get("path") == "https://api.easypost.com/v2/parcels"
+    assert "object" in kwargs.get("response_body")
+    assert "location" in kwargs.get("headers")
+    assert kwargs.get("response_timestamp") > kwargs.get("request_timestamp")
+    assert uuid.UUID(str(kwargs.get("request_uuid")))
+
+
+@pytest.mark.vcr()
+def test_response_hooks(basic_parcel, test_client):
+    """Test that we fire a ResponseHook after receiving an HTTP response."""
+    test_client.subscribe_to_response_hook(assert_response)
+    _ = test_client.parcel.create(**basic_parcel)


### PR DESCRIPTION
# Description

- Adds new `RequestHook` and `ResponseHook` events. (un)subscribe to them with the new `subscribe_to_request_hook`, `subscribe_to_response_hook`, `unsubscribe_from_request_hook`, or `unsubscribe_from_response_hook` methods of an `EasyPostClient`
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Adds a new set of tests that subscribe to the hooks and assert details only exposed via the hooks (not the traditional deserialized objects)
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
