### PR TITLE
feat: auto release via GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch: ~
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: make install build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: AButler/upload-release-assets@v2.0
+        with:
+          files: 'dist/*'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -151,3 +151,7 @@ To run the test suite with the Google Cloud SDK (`urlfetch` instead of the `requ
    - [Homebrew](https://formulae.brew.sh/cask/google-cloud-sdk)
 1. Point the `PYTHONPATH` environment variable to the path of the newly installed `google-cloud-sdk` directory. For Homebrew, this is `"$(brew --prefix)/share/google-cloud-sdk"`
 1. Run the test suite with the commands listed in this README
+
+### Releasing
+
+To release a new version of this library, bump the version in code and cut a new [GitHub Release](https://github.com/EasyPost/easypost-python/releases/new). This will automatically trigger a workflow via GitHub Actions to release the built binaries to PyPi and upload those assets to the new GitHub release.


### PR DESCRIPTION
# Description

Adds a new GitHub Actions workflow to release when a tag (release) is created. This will build the binaries, push to PyPi, then upload those built assets to the GitHub Release target. This workflow can be manually triggered if necessary on failures.
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Been using this workflow myself for years, shouldn't have any troubles. Will test on our next release
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
