### PR TITLE
Remove Unused Dependency: typing-extesions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools import (
 
 REQUIREMENTS = [
     "requests >= 2.4.3",
-    "typing-extensions",
 ]
 
 DEV_REQUIREMENTS = [


### PR DESCRIPTION
# Description
## Summary

This pull request removes the unused dependency `typing-extensions` from the `setup.py` configuration file. The removal of this dependency is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.

## Rationale

The `typing-extensions` library was originally introduced to the project  in 35842786, however it  appears to be unused within the source code.
Removing this unused dependency  reduces the overall footprint of the application, mitigating potential security risks, and simplifying the dependency management process.

## Changes

- Removed the `typing-extensions` dependency from `setup.py`.

## Impact

- **Reduced Package Size**: The removal of this unused dependency will lead to a decrease in the overall size of the installed packages.
- **Simplified Dependency Tree**: Fewer dependencies make the project easier to maintain and can speed up installation.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
