### PR TITLE
[fix] FedEx SmartPost hits custom register endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix endpoint for creating a FedEx Smartpost carrier account
+
 ## v8.1.0 (2023-07-28)
 
 - Adds new `RequestHook` and `ResponseHook` events. (un)subscribe to them with the new `subscribe_to_request_hook`, `subscribe_to_response_hook`, `unsubscribe_from_request_hook`, or `unsubscribe_from_response_hook` methods of an `EasyPostClient`

--- a/easypost/constant.py
+++ b/easypost/constant.py
@@ -33,5 +33,6 @@ TIMEOUT_ERROR = "Request timed out."
 _TEST_FAILED_INTENTIONALLY_ERROR = "Test failed intentionally."
 _CARRIER_ACCOUNT_TYPES_WITH_CUSTOM_WORKFLOWS = [
     "FedexAccount",
+    "FedexSmartpostAccount",
     "UpsAccount",
 ]


### PR DESCRIPTION
# Description

- FedEx SmartPost carrier account registration should hit `/register` endpoint for creation

# Testing

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
