### PR TITLE
[fix] Remove bad post-request guard clause in pagination functions

### DIFF
--- a/easypost/beta/user.py
+++ b/easypost/beta/user.py
@@ -45,7 +45,7 @@ class User(Resource):
 
         data, api_key = requestor.request(method=RequestMethod.GET, url=url, params=params, beta=True)
         next_children_array: List[Any] = data.get("children", [])
-        if len(next_children_array) == 0 or not data.get("has_more", False):
+        if len(next_children_array) == 0:
             raise Error(message="There are no more pages to retrieve.")
 
         return convert_to_easypost_object(response=data, api_key=api_key)

--- a/easypost/resource.py
+++ b/easypost/resource.py
@@ -93,7 +93,7 @@ class NextPageResource(Resource):
 
         response, api_key = requestor.request(method=RequestMethod.GET, url=url, params=params)
         response_array: List[Any] = response.get(url[1:])  # type: ignore
-        if response is None or len(response_array) == 0 or not response.get("has_more"):
+        if response is None or len(response_array) == 0:
             raise Error(message="There are no more pages to retrieve.")
 
         return convert_to_easypost_object(response=response, api_key=api_key)

--- a/tests/cassettes/test_beta_user_get_next_page_collect_all.yaml
+++ b/tests/cassettes/test_beta_user_get_next_page_collect_all.yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: GET
+    uri: https://api.easypost.com/beta/users/children?page_size=1
+  response:
+    body:
+      string: '{"children": [], "has_more": false}'
+    headers:
+      cache-control:
+      - private, no-cache, no-store
+      content-length:
+      - '32'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"3e2ec6a518ba813e2b978a9e1e34e8f6"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - e7025b87653f1d16f42cf30400b96021
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb35nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq b3de2c47ef
+      - extlb2nuq 003ad9bca0
+      x-runtime:
+      - '0.036347'
+      x-version-label:
+      - easypost-202310271808-bc7d2a481d-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_beta_user.py
+++ b/tests/test_beta_user.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 import easypost
@@ -28,3 +30,73 @@ def test_beta_user_get_next_page(prod_api_key, page_size):
     except easypost.Error as e:
         if e.message != "There are no more pages to retrieve.":
             raise easypost.Error(message="Test failed intentionally.")
+
+
+@pytest.mark.vcr()
+def test_beta_user_get_next_page_collect_all(prod_api_key):
+    page_size = 1  # Doesn't matter what this is, we're mocking the response
+    all_children = []
+
+    first_page_response = {
+        "children": [
+            {
+                "id": "user_123",
+            }
+        ],
+        "has_more": True,
+    }
+
+    # Mock the initial "get all children" call
+    return_value = (first_page_response, prod_api_key)
+    with patch("easypost.requestor.Requestor.request", return_value=return_value):
+        first_page = easypost.beta.User.all_children(page_size=page_size)
+        all_children += first_page["children"]
+        previous_page = first_page
+
+    second_page_response = {
+        "children": [
+            {
+                "id": "user_456",
+            }
+        ],
+        "has_more": True,
+    }
+
+    # Mock the first "get next page" call with more to collect after
+    # (current page "has_more" = True, next page "has_more" = True)
+    return_value = (second_page_response, prod_api_key)
+    with patch("easypost.requestor.Requestor.request", return_value=return_value):
+        next_page = easypost.beta.User.get_next_page_of_children(children=previous_page,  # type: ignore
+                                                                 page_size=page_size)
+        all_children += next_page["children"]
+        previous_page = next_page
+
+    third_page_response = {
+        "children": [
+            {
+                "id": "user_789",
+            }
+        ],
+        "has_more": False,
+    }
+
+    # Mock the second "get next page" call with no more to collect
+    # (current page "has_more" = True, next page "has_more" = False)
+    return_value = (third_page_response, prod_api_key)
+    with patch("easypost.requestor.Requestor.request", return_value=return_value):
+        next_page = easypost.beta.User.get_next_page_of_children(children=previous_page,  # type: ignore
+                                                                 page_size=page_size)
+        all_children += next_page["children"]
+        previous_page = next_page
+
+    # Verify we have all children (from both the "get all children" and "get next page" calls)
+    # Ensures that no guard clauses inside the "get next page" method are preventing us from collecting all children
+    assert len(all_children) == 3
+
+    # Now that the previous page has "has_more" = False, it should throw an error before even making the API call
+    with pytest.raises(easypost.Error) as error:
+        _ = easypost.beta.User.get_next_page_of_children(children=previous_page,  # type: ignore
+                                                         page_size=page_size)
+
+    assert str(error.value) == "There are no more pages to retrieve."
+

--- a/tests/test_beta_user.py
+++ b/tests/test_beta_user.py
@@ -66,8 +66,9 @@ def test_beta_user_get_next_page_collect_all(prod_api_key):
     # (current page "has_more" = True, next page "has_more" = True)
     return_value = (second_page_response, prod_api_key)
     with patch("easypost.requestor.Requestor.request", return_value=return_value):
-        next_page = easypost.beta.User.get_next_page_of_children(children=previous_page,  # type: ignore
-                                                                 page_size=page_size)
+        next_page = easypost.beta.User.get_next_page_of_children(
+            children=previous_page, page_size=page_size  # type: ignore
+        )
         all_children += next_page["children"]
         previous_page = next_page
 
@@ -84,8 +85,9 @@ def test_beta_user_get_next_page_collect_all(prod_api_key):
     # (current page "has_more" = True, next page "has_more" = False)
     return_value = (third_page_response, prod_api_key)
     with patch("easypost.requestor.Requestor.request", return_value=return_value):
-        next_page = easypost.beta.User.get_next_page_of_children(children=previous_page,  # type: ignore
-                                                                 page_size=page_size)
+        next_page = easypost.beta.User.get_next_page_of_children(
+            children=previous_page, page_size=page_size  # type: ignore
+        )
         all_children += next_page["children"]
         previous_page = next_page
 
@@ -95,8 +97,6 @@ def test_beta_user_get_next_page_collect_all(prod_api_key):
 
     # Now that the previous page has "has_more" = False, it should throw an error before even making the API call
     with pytest.raises(easypost.Error) as error:
-        _ = easypost.beta.User.get_next_page_of_children(children=previous_page,  # type: ignore
-                                                         page_size=page_size)
+        _ = easypost.beta.User.get_next_page_of_children(children=previous_page, page_size=page_size)  # type: ignore
 
     assert str(error.value) == "There are no more pages to retrieve."
-

--- a/tests/test_beta_user.py
+++ b/tests/test_beta_user.py
@@ -32,7 +32,7 @@ def test_beta_user_get_next_page(prod_api_key, page_size):
             raise easypost.Error(message="Test failed intentionally.")
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr()  # Cassette not needed due to mocking, but used to avoid making real bogus API calls
 def test_beta_user_get_next_page_collect_all(prod_api_key):
     page_size = 1  # Doesn't matter what this is, we're mocking the response
     all_children = []


### PR DESCRIPTION
# Description

The highlighted code (removed as part of this PR) was an invalid guard clause added at the root of our pagination functionality (and re-implemented for a recent beta child user pagination function in #300 ).

<img width="780" alt="image" src="https://github.com/EasyPost/easypost-python/assets/17054780/d9cf65e5-9aa7-4021-908c-ec7a4c917bc1">


The highlighted code checked AFTER retrieving the "next page" of results if there were still more results to retrieve (the `has_more` boolean). If this was `False`, an error would be thrown alerting the user that there were no more pages to retrieve. However, in doing so, this would discard what we would then know is the last valid page of results, never returning them to the end-user. In effect, the end-user was never able to collect the very last page of results, because the function was always prematurely checking if yet another page exists afterwards. (The array length check also included in this guard clause is largely inconsequential, as it should never be triggered; it more so validates the shape of the response data, catching issues with the current page of results).

This PR removes the invalid guard clause both in the base class and the one-off re-implementation in the beta User service, and adds a unit test for the beta User service that validates the functionality. The unit test confirms that the pagination function no longer prematurely looks ahead and does in fact allow users to collect all available pages.

**This PR is for v7, and will need to be ported to v8 as well.**

# Testing

- Unit test confirms valid functionality (passes; re-add the bad line and it fails as expected)
- Added cassette (not used by test due to mocked responses, but prevents making bogus live API calls)

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
