### PR TITLE
[fix] Fix, re-design implementation of pagination functions

### DIFF
--- a/easypost/constant.py
+++ b/easypost/constant.py
@@ -37,3 +37,4 @@ _CARRIER_ACCOUNT_TYPES_WITH_CUSTOM_WORKFLOWS = [
     "FedexSmartpostAccount",
     "UpsAccount",
 ]
+_FILTERS_KEY = "filters"

--- a/easypost/services/address_service.py
+++ b/easypost/services/address_service.py
@@ -39,7 +39,11 @@ class AddressService(BaseService):
 
     def all(self, **params) -> Dict[str, Any]:
         """Retrieve a list of Addresses."""
-        return self._all_resources(self._model_class, **params)
+        filters = {
+            "key": "addresses",
+        }
+
+        return self._all_resources(self._model_class, filters, **params)
 
     def retrieve(self, id) -> Address:
         """Retrieve an Address."""
@@ -69,4 +73,14 @@ class AddressService(BaseService):
         optional_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Retrieve the next page of the list Addresses response."""
-        return self._get_next_page_resources(self._model_class, addresses, page_size, optional_params)
+        self._check_has_next_page(collection=addresses)
+
+        params = {
+            "before_id": addresses["addresses"][-1].id,
+            "page_size": page_size,
+        }
+
+        if optional_params:
+            params.update(optional_params)
+
+        return self.all(**params)

--- a/easypost/services/base_service.py
+++ b/easypost/services/base_service.py
@@ -6,7 +6,10 @@ from typing import (
     Optional,
 )
 
-from easypost.constant import NO_MORE_PAGES_ERROR
+from easypost.constant import (
+    NO_MORE_PAGES_ERROR,
+    _FILTERS_KEY,
+)
 from easypost.easypost_object import convert_to_easypost_object
 from easypost.errors import EndOfPaginationError
 from easypost.requestor import (
@@ -46,11 +49,14 @@ class BaseService:
 
         return convert_to_easypost_object(response=response)
 
-    def _all_resources(self, class_name: str, **params) -> Any:
+    def _all_resources(self, class_name: str, filters: Dict[str, Any] = None, **params) -> Any:
         """Retrieve a list of EasyPostObjects from the EasyPost API."""
         url = self._class_url(class_name)
-
         response = Requestor(self._client).request(method=RequestMethod.GET, url=url, params=params)
+
+        if filters: # presence of filters indicates we are dealing with a paginated response
+            self._check_has_current_page(response=response, filters=filters)
+            response[_FILTERS_KEY] = filters # Save the filters used to reference in potential get_next_page call
 
         return convert_to_easypost_object(response=response)
 
@@ -79,32 +85,20 @@ class BaseService:
 
         return convert_to_easypost_object(response=response)
 
-    def _get_next_page_resources(
-        self,
-        class_name: str,
-        collection: Dict[str, Any],
-        page_size: int,
-        optional_params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-        """Retrieve next page of EasyPostObjects via the EasyPost API."""
-        url = self._class_url(class_name)
-        collection_array = collection.get(url[1:])
-
-        if collection_array is None or len(collection_array) == 0 or not collection.get("has_more"):
+    def _check_has_next_page(self, collection: Dict[str, Any]) -> None:
+        """Raise exception if there is no next page of a collection."""
+        if not collection.get("has_more", False):
             raise EndOfPaginationError(NO_MORE_PAGES_ERROR)
 
-        params = {
-            "before_id": collection_array[-1].id,
-            "page_size": page_size,
-        }
-
-        if optional_params:
-            params.update(optional_params)
-
-        response = Requestor(self._client).request(method=RequestMethod.GET, url=url, params=params)
-
-        response_array: List[Any] = response.get(url[1:])  # type: ignore
-        if response is None or len(response_array) == 0:
+    def _check_has_current_page(self, response: Dict[str, Any], filters: Dict[str, Any]) -> None:
+        """Raise exception if there is no current page of a collection."""
+        if not response:
             raise EndOfPaginationError(NO_MORE_PAGES_ERROR)
 
-        return convert_to_easypost_object(response=response)
+        entries_key = filters.get("key", None)
+        if not entries_key:
+            raise EndOfPaginationError(NO_MORE_PAGES_ERROR)
+
+        entries = response.get(entries_key, [])
+        if not entries or len(entries) == 0:
+            raise EndOfPaginationError(NO_MORE_PAGES_ERROR)

--- a/easypost/services/batch_service.py
+++ b/easypost/services/batch_service.py
@@ -24,7 +24,11 @@ class BatchService(BaseService):
 
     def all(self, **params) -> Dict[str, Any]:
         """Retrieve a list of Batches."""
-        return self._all_resources(self._model_class, **params)
+        filters = {
+            "key": "batches",
+        }
+
+        return self._all_resources(self._model_class, filters, **params)
 
     def retrieve(self, id: str) -> Batch:
         """Retrieve a Batch."""
@@ -85,5 +89,10 @@ class BatchService(BaseService):
         page_size: int,
         optional_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        """Retrieve the next page of the list Batch response."""
-        return self._get_next_page_resources(self._model_class, batches, page_size, optional_params)
+        """
+        Retrieve the next page of the list Batch response.
+
+        NOTE: This function has known issues and should not be used.
+        """
+        # API doesn't return batches newest to oldest, so these parameters don't work as expected
+        raise NotImplementedError

--- a/easypost/services/event_service.py
+++ b/easypost/services/event_service.py
@@ -27,7 +27,11 @@ class EventService(BaseService):
 
     def all(self, **params) -> Dict[str, Any]:
         """Retrieve a list of Events."""
-        return self._all_resources(self._model_class, **params)
+        filters = {
+            "key": "events",
+        }
+
+        return self._all_resources(self._model_class, filters, **params)
 
     def retrieve(self, id: str) -> Event:
         """Retrieve an Event."""
@@ -56,4 +60,14 @@ class EventService(BaseService):
         optional_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Retrieve the next page of the list Events response."""
-        return self._get_next_page_resources(self._model_class, events, page_size, optional_params)
+        self._check_has_next_page(collection=events)
+
+        params = {
+            "before_id": events["events"][-1].id,
+            "page_size": page_size,
+        }
+
+        if optional_params:
+            params.update(optional_params)
+
+        return self.all(**params)

--- a/easypost/services/insurance_service.py
+++ b/easypost/services/insurance_service.py
@@ -19,7 +19,11 @@ class InsuranceService(BaseService):
 
     def all(self, **params) -> Dict[str, Any]:
         """Retrieve a list of Insurances."""
-        return self._all_resources(self._model_class, **params)
+        filters = {
+            "key": "insurances",
+        }
+
+        return self._all_resources(self._model_class, filters, **params)
 
     def retrieve(self, id: str) -> Insurance:
         """Retrieve an Insurance."""
@@ -32,4 +36,14 @@ class InsuranceService(BaseService):
         optional_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Retrieve the next page of the list Insurance response."""
-        return self._get_next_page_resources(self._model_class, insurances, page_size, optional_params)
+        self._check_has_next_page(collection=insurances)
+
+        params = {
+            "before_id": insurances["insurances"][-1].id,
+            "page_size": page_size,
+        }
+
+        if optional_params:
+            params.update(optional_params)
+
+        return self.all(**params)

--- a/easypost/services/order_service.py
+++ b/easypost/services/order_service.py
@@ -28,12 +28,12 @@ class OrderService(BaseService):
 
     def get_next_page(
         self,
-        insurances: Dict[str, Any],
+        orders: Dict[str, Any],
         page_size: int,
         optional_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Retrieve the next page of the list Order response."""
-        return self._get_next_page_resources(self._model_class, insurances, page_size, optional_params)
+        raise NotImplementedError
 
     def get_rates(self, id: str) -> Order:
         """Get rates for an Order."""

--- a/easypost/services/pickup_service.py
+++ b/easypost/services/pickup_service.py
@@ -24,7 +24,11 @@ class PickupService(BaseService):
 
     def all(self, **params) -> Dict[str, Any]:
         """Retrieve a list of Pickups."""
-        return self._all_resources(self._model_class, **params)
+        filters = {
+            "key": "pickups",
+        }
+
+        return self._all_resources(self._model_class, filters, **params)
 
     def retrieve(self, id: str) -> Pickup:
         """Retrieve a Pickup."""
@@ -37,7 +41,17 @@ class PickupService(BaseService):
         optional_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Retrieve the next page of the list Pickup response."""
-        return self._get_next_page_resources(self._model_class, pickups, page_size, optional_params)
+        self._check_has_next_page(collection=pickups)
+
+        params = {
+            "before_id": pickups["pickups"][-1].id,
+            "page_size": page_size,
+        }
+
+        if optional_params:
+            params.update(optional_params)
+
+        return self.all(**params)
 
     def buy(self, id: str, **params) -> Pickup:
         """Buy a Pickup."""

--- a/easypost/services/referral_customer_service.py
+++ b/easypost/services/referral_customer_service.py
@@ -8,7 +8,7 @@ from typing import (
 import requests
 from easypost.constant import (
     SEND_STRIPE_DETAILS_ERROR,
-    TIMEOUT,
+    TIMEOUT, _FILTERS_KEY,
 )
 from easypost.easypost_object import convert_to_easypost_object
 from easypost.errors import ExternalApiError
@@ -63,13 +63,19 @@ class ReferralCustomerService(BaseService):
 
         This function requires the Partner User's API key.
         """
-        response = Requestor(self._client).request(
-            method=RequestMethod.GET,
-            url="/referral_customers",
-            params=params,
-        )
+        filters = {
+            "key": "referral_customers",
+        }
+
+        url = "/referral_customers"
+
+        response = Requestor(self._client).request(method=RequestMethod.GET, url=url, params=params)
+        self._check_has_current_page(response=response, filters=filters)
+
+        response[_FILTERS_KEY] = filters  # Save the filters used to reference in potential get_next_page call
 
         return convert_to_easypost_object(response=response)
+
 
     def get_next_page(
         self,
@@ -78,7 +84,17 @@ class ReferralCustomerService(BaseService):
         optional_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Retrieve next page of referral customers."""
-        return self._get_next_page_resources("referral_customers", referral_customers, page_size, optional_params)
+        self._check_has_next_page(collection=referral_customers)
+
+        params = {
+            "before_id": referral_customers["referral_customers"][-1].id,
+            "page_size": page_size,
+        }
+
+        if optional_params:
+            params.update(optional_params)
+
+        return self.all(**params)
 
     def add_credit_card(
         self,

--- a/easypost/services/refund_service.py
+++ b/easypost/services/refund_service.py
@@ -18,9 +18,13 @@ class RefundService(BaseService):
         """Create a Shipment Refund."""
         return self._create_resource(self._model_class, **params)
 
-    def all(self, **params) -> List[Refund]:
+    def all(self, **params) -> Dict[str, Any]:
         """Retrieve a list of Shipment Refunds."""
-        return self._all_resources(self._model_class, **params)
+        filters = {
+            "key": "refunds",
+        }
+
+        return self._all_resources(self._model_class, filters, **params)
 
     def retrieve(self, id: str) -> Refund:
         """Retrieve a Shipment Refund."""
@@ -33,4 +37,14 @@ class RefundService(BaseService):
         optional_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Retrieve the next page of the list Refund response."""
-        return self._get_next_page_resources(self._model_class, refunds, page_size, optional_params)
+        self._check_has_next_page(collection=refunds)
+
+        params = {
+            "before_id": refunds["refunds"][-1].id,
+            "page_size": page_size,
+        }
+
+        if optional_params:
+            params.update(optional_params)
+
+        return self.all(**params)

--- a/easypost/services/report_service.py
+++ b/easypost/services/report_service.py
@@ -4,7 +4,10 @@ from typing import (
     Optional,
 )
 
-from easypost.constant import MISSING_PARAMETER_ERROR
+from easypost.constant import (
+    MISSING_PARAMETER_ERROR,
+    _FILTERS_KEY,
+)
 from easypost.easypost_object import convert_to_easypost_object
 from easypost.errors import MissingParameterError
 from easypost.models import Report
@@ -35,15 +38,22 @@ class ReportService(BaseService):
 
     def all(self, **params) -> Dict[str, Any]:
         """Retrieve a list of Reports."""
-        refund_type = params.pop("type")
+        # Capture some of the parameters used for later reference
+        filters = {
+            "key": "reports",
+            "type": params.get("type", None),
+        }
 
-        if refund_type is None:
+        report_type = params.pop("type")
+        if report_type is None:
             raise MissingParameterError(MISSING_PARAMETER_ERROR.format("type"))
 
-        url = f"{self._class_url(self._model_class)}/{refund_type}"
+        url = f"{self._class_url(self._model_class)}/{report_type}"
 
         response = Requestor(self._client).request(method=RequestMethod.GET, url=url, params=params)
-        response["type"] = refund_type  # Needed for retrieving the next page
+        self._check_has_current_page(response=response, filters=filters)
+
+        response[_FILTERS_KEY] = filters  # Save the filters used to reference in potential get_next_page call
 
         return convert_to_easypost_object(response=response)
 
@@ -55,19 +65,18 @@ class ReportService(BaseService):
         self,
         reports: Dict[str, Any],
         page_size: Optional[int] = None,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Retrieve the next page of the list Report response."""
-        refund_type = reports.get("type")
+        self._check_has_next_page(collection=reports)
 
-        if refund_type is None:
-            raise MissingParameterError(MISSING_PARAMETER_ERROR.format("type"))
-
-        url = f"{self._class_url(self._model_class)}/{refund_type}"
         params = {
             "before_id": reports["reports"][-1].id,
             "page_size": page_size,
+            "type": reports.get(_FILTERS_KEY, {}).get("type", None), # Use the same type as the last page
         }
 
-        response = Requestor(self._client).request(method=RequestMethod.GET, url=url, params=params)
+        if optional_params:
+            params.update(optional_params)
 
-        return convert_to_easypost_object(response=response)
+        return self.all(**params)

--- a/easypost/services/scan_form_service.py
+++ b/easypost/services/scan_form_service.py
@@ -19,7 +19,11 @@ class ScanFormService(BaseService):
 
     def all(self, **params) -> Dict[str, Any]:
         """Retrieve a list of ScanForms."""
-        return self._all_resources(self._model_class, **params)
+        filters = {
+            "key": "scan_forms",
+        }
+
+        return self._all_resources(self._model_class, filters, **params)
 
     def retrieve(self, id: str) -> ScanForm:
         """Retrieve a ScanForm."""
@@ -32,4 +36,14 @@ class ScanFormService(BaseService):
         optional_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Retrieve the next page of the list ScanForm response."""
-        return self._get_next_page_resources(self._model_class, scan_forms, page_size, optional_params)
+        self._check_has_next_page(collection=scan_forms)
+
+        params = {
+            "before_id": scan_forms["scan_forms"][-1].id,
+            "page_size": page_size,
+        }
+
+        if optional_params:
+            params.update(optional_params)
+
+        return self.all(**params)

--- a/tests/cassettes/test_referral_get_next_page.yaml
+++ b/tests/cassettes/test_referral_get_next_page.yaml
@@ -56,11 +56,11 @@ interactions:
       cache-control:
       - private, no-cache, no-store
       content-length:
-      - '2858'
+      - '2854'
       content-type:
       - application/json; charset=utf-8
       etag:
-      - W/"57b616a535a9df8008e17cdd2be65c48"
+      - W/"87d4f1c9b4c89d23ec5e4ddf34cfae8e"
       expires:
       - '0'
       pragma:
@@ -78,20 +78,111 @@ interactions:
       x-download-options:
       - noopen
       x-ep-request-uuid:
-      - 23bee7e56463d029e787d9a500340714
+      - e7025b8965417fa6e7798ae402602844
       x-frame-options:
       - SAMEORIGIN
       x-node:
-      - bigweb6nuq
+      - bigweb34nuq
       x-permitted-cross-domain-policies:
       - none
       x-proxied:
-      - intlb1nuq a29e4ad05c
-      - extlb2nuq 5ab12a3ed2
+      - intlb2nuq b3de2c47ef
+      - extlb2nuq 003ad9bca0
       x-runtime:
-      - '0.345269'
+      - '0.308643'
       x-version-label:
-      - easypost-202305161731-3a88337a74-master
+      - easypost-202310312106-bb7125dd9b-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: GET
+    uri: https://api.easypost.com/v2/referral_customers?before_id=user_488e391395f4416196a31965fecac409&page_size=5
+  response:
+    body:
+      string: '{"has_more": false, "referral_customers": [{"id": "user_4a22730cdc844ce1bc2efbed999c869f",
+        "object": "User", "parent_id": null, "name": "test test", "phone_number":
+        "<REDACTED>", "verified": true, "created_at": "2022-04-29T19:35:33Z", "default_carbon_offset":
+        false, "has_elevate_access": false, "balance": "0.00000", "price_per_shipment":
+        "0.00000", "recharge_amount": null, "secondary_recharge_amount": null, "recharge_threshold":
+        null, "has_billing_method": null, "cc_fee_rate": "0.0325", "default_insurance_amount":
+        "50.00", "insurance_fee_rate": "0.005", "insurance_fee_minimum": "0.25", "email":
+        "<REDACTED>", "children": []}, {"id": "user_fa93cc16bcc24c078ee057ce82f38eed",
+        "object": "User", "parent_id": null, "name": "test test", "phone_number":
+        "<REDACTED>", "verified": true, "created_at": "2022-04-28T22:34:38Z", "default_carbon_offset":
+        false, "has_elevate_access": false, "balance": "0.00000", "price_per_shipment":
+        "0.00000", "recharge_amount": null, "secondary_recharge_amount": null, "recharge_threshold":
+        null, "has_billing_method": null, "cc_fee_rate": "0.0325", "default_insurance_amount":
+        "50.00", "insurance_fee_rate": "0.005", "insurance_fee_minimum": "0.25", "email":
+        "<REDACTED>", "children": []}, {"id": "user_35cb81fb8af1454dabf1f6afa7330634",
+        "object": "User", "parent_id": null, "name": "Firstname Lastname", "phone_number":
+        "<REDACTED>", "verified": true, "created_at": "2022-04-27T20:20:52Z", "default_carbon_offset":
+        false, "has_elevate_access": false, "balance": "0.00000", "price_per_shipment":
+        "0.00000", "recharge_amount": "100.00", "secondary_recharge_amount": "100.00",
+        "recharge_threshold": "0.00", "has_billing_method": true, "cc_fee_rate": "0.0325",
+        "default_insurance_amount": "50.00", "insurance_fee_rate": "0.005", "insurance_fee_minimum":
+        "0.25", "email": "<REDACTED>", "children": []}, {"id": "user_634b6daa05744bfaa205058f06864363",
+        "object": "User", "parent_id": null, "name": "Firstname Lastname", "phone_number":
+        "<REDACTED>", "verified": true, "created_at": "2022-04-26T15:50:28Z", "default_carbon_offset":
+        false, "has_elevate_access": false, "balance": "0.00000", "price_per_shipment":
+        "0.00000", "recharge_amount": null, "secondary_recharge_amount": null, "recharge_threshold":
+        null, "has_billing_method": null, "cc_fee_rate": "0.0325", "default_insurance_amount":
+        "50.00", "insurance_fee_rate": "0.005", "insurance_fee_minimum": "0.25", "email":
+        "<REDACTED>", "children": []}]}'
+    headers:
+      cache-control:
+      - private, no-cache, no-store
+      content-length:
+      - '2281'
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"96f6bfd4815c1b4cb441150d0a156828"
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - e7025b8965417fa6e7798ae40260286e
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb39nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb2nuq b3de2c47ef
+      - extlb2nuq 003ad9bca0
+      x-runtime:
+      - '0.169410'
+      x-version-label:
+      - easypost-202310312106-bb7125dd9b-master
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -1,7 +1,7 @@
 import pytest
 from easypost.constant import (
     _TEST_FAILED_INTENTIONALLY_ERROR,
-    NO_MORE_PAGES_ERROR,
+    NO_MORE_PAGES_ERROR, _FILTERS_KEY,
 )
 from easypost.errors import ApiError
 from easypost.models import Address
@@ -18,7 +18,7 @@ def test_address_create(ca_address_1, test_client):
 
 @pytest.mark.vcr()
 def test_address_create_verify(incorrect_address, test_client):
-    """Test creating an address with the verify param.
+    """Test creating an address with the `verify` param.
 
     We purposefully pass in slightly incorrect data to get the corrected address back once verified.
     """
@@ -33,7 +33,7 @@ def test_address_create_verify(incorrect_address, test_client):
 
 @pytest.mark.vcr()
 def test_address_create_verify_strict(ca_address_1, test_client):
-    """Test creating an address with the verify_strict param.
+    """Test creating an address with the `verify_strict` param.
 
     We purposefully pass in slightly incorrect data to get the corrected address back once verified.
     """
@@ -49,7 +49,7 @@ def test_address_create_verify_strict(ca_address_1, test_client):
 
 @pytest.mark.vcr()
 def test_address_create_verify_array(incorrect_address, test_client):
-    """Test creating an address with the verify param as an array.
+    """Test creating an address with the `verify` param as an array.
 
     We purposefully pass in slightly incorrect data to get the corrected address back once verified.
     """
@@ -95,16 +95,19 @@ def test_address_all(page_size, test_client):
 @pytest.mark.vcr()
 def test_address_get_next_page(page_size, test_client):
     try:
-        addresses = test_client.address.all(page_size=page_size)
-        next_page = test_client.address.get_next_page(addresses=addresses, page_size=page_size)
+        first_page = test_client.address.all(page_size=page_size)
+        next_page = test_client.address.get_next_page(addresses=first_page, page_size=page_size)
 
-        first_id_of_first_page = addresses["addresses"][0].id
+        first_id_of_first_page = first_page["addresses"][0].id
         first_id_of_second_page = next_page["addresses"][0].id
 
         assert first_id_of_first_page != first_id_of_second_page
+
+        # Verify that the filters are being passed along for behind-the-scenes reference
+        assert first_page[_FILTERS_KEY] == next_page[_FILTERS_KEY]
     except Exception as e:
         if e.message != NO_MORE_PAGES_ERROR:
-            raise Exception(message=_TEST_FAILED_INTENTIONALLY_ERROR)
+            raise Exception(_TEST_FAILED_INTENTIONALLY_ERROR)
 
 
 @pytest.mark.vcr()

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -5,7 +5,7 @@ import time
 import pytest
 from easypost.constant import (
     _TEST_FAILED_INTENTIONALLY_ERROR,
-    NO_MORE_PAGES_ERROR,
+    NO_MORE_PAGES_ERROR, _FILTERS_KEY,
 )
 from easypost.errors import ApiError
 from easypost.models import (
@@ -29,16 +29,19 @@ def test_event_all(page_size, test_client):
 @pytest.mark.vcr()
 def test_event_get_next_page(page_size, test_client):
     try:
-        events = test_client.event.all(page_size=page_size)
-        next_page = test_client.event.get_next_page(events=events, page_size=page_size)
+        first_page = test_client.event.all(page_size=page_size)
+        next_page = test_client.event.get_next_page(events=first_page, page_size=page_size)
 
-        first_id_of_first_page = events["events"][0].id
+        first_id_of_first_page = first_page["events"][0].id
         first_id_of_second_page = next_page["events"][0].id
 
         assert first_id_of_first_page != first_id_of_second_page
+
+        # Verify that the filters are being passed along for behind-the-scenes reference
+        assert first_page[_FILTERS_KEY] == next_page[_FILTERS_KEY]
     except Exception as e:
         if e.message != NO_MORE_PAGES_ERROR:
-            raise Exception(message=_TEST_FAILED_INTENTIONALLY_ERROR)
+            raise Exception(_TEST_FAILED_INTENTIONALLY_ERROR)
 
 
 @pytest.mark.vcr()

--- a/tests/test_insurance.py
+++ b/tests/test_insurance.py
@@ -1,7 +1,7 @@
 import pytest
 from easypost.constant import (
     _TEST_FAILED_INTENTIONALLY_ERROR,
-    NO_MORE_PAGES_ERROR,
+    NO_MORE_PAGES_ERROR, _FILTERS_KEY,
 )
 from easypost.models import Insurance
 
@@ -50,13 +50,16 @@ def test_insurance_all(page_size, test_client):
 @pytest.mark.vcr()
 def test_insurance_get_next_page(page_size, test_client):
     try:
-        insurances = test_client.insurance.all(page_size=page_size)
-        next_page = test_client.insurance.get_next_page(insurances=insurances, page_size=page_size)
+        first_page = test_client.insurance.all(page_size=page_size)
+        next_page = test_client.insurance.get_next_page(insurances=first_page, page_size=page_size)
 
-        first_id_of_first_page = insurances["insurances"][0].id
+        first_id_of_first_page = first_page["insurances"][0].id
         first_id_of_second_page = next_page["insurances"][0].id
 
         assert first_id_of_first_page != first_id_of_second_page
+
+        # Verify that the filters are being passed along for behind-the-scenes reference
+        assert first_page[_FILTERS_KEY] == next_page[_FILTERS_KEY]
     except Exception as e:
         if e.message != NO_MORE_PAGES_ERROR:
-            raise Exception(message=_TEST_FAILED_INTENTIONALLY_ERROR)
+            raise Exception(_TEST_FAILED_INTENTIONALLY_ERROR)

--- a/tests/test_pickup.py
+++ b/tests/test_pickup.py
@@ -1,7 +1,7 @@
 import pytest
 from easypost.constant import (
     _TEST_FAILED_INTENTIONALLY_ERROR,
-    NO_MORE_PAGES_ERROR,
+    NO_MORE_PAGES_ERROR, _FILTERS_KEY,
 )
 from easypost.errors import FilteringError
 from easypost.models import Pickup
@@ -35,16 +35,19 @@ def test_pickup_all(page_size, test_client):
 @pytest.mark.vcr()
 def test_pickup_get_next_page(page_size, test_client):
     try:
-        pickups = test_client.pickup.all(page_size=page_size)
-        next_page = test_client.pickup.get_next_page(pickups=pickups, page_size=page_size)
+        first_page = test_client.pickup.all(page_size=page_size)
+        next_page = test_client.pickup.get_next_page(pickups=first_page, page_size=page_size)
 
-        first_id_of_first_page = pickups["pickups"][0].id
+        first_id_of_first_page = first_page["pickups"][0].id
         first_id_of_second_page = next_page["pickups"][0].id
 
         assert first_id_of_first_page != first_id_of_second_page
+
+        # Verify that the filters are being passed along for behind-the-scenes reference
+        assert first_page[_FILTERS_KEY] == next_page[_FILTERS_KEY]
     except Exception as e:
         if e.message != NO_MORE_PAGES_ERROR:
-            raise Exception(message=_TEST_FAILED_INTENTIONALLY_ERROR)
+            raise Exception(_TEST_FAILED_INTENTIONALLY_ERROR)
 
 
 @pytest.mark.vcr()

--- a/tests/test_referral_customer.py
+++ b/tests/test_referral_customer.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from easypost.constant import (
     _TEST_FAILED_INTENTIONALLY_ERROR,
-    NO_MORE_PAGES_ERROR,
+    NO_MORE_PAGES_ERROR, _FILTERS_KEY,
 )
 from easypost.models import User
 
@@ -55,18 +55,21 @@ def test_referral_customer_all(partner_user_prod_client, page_size):
 @pytest.mark.vcr()
 def test_referral_get_next_page(partner_user_prod_client, page_size):
     try:
-        referral_customers = partner_user_prod_client.referral_customer.all(page_size=page_size)
+        first_page = partner_user_prod_client.referral_customer.all(page_size=page_size)
         next_page = partner_user_prod_client.referral_customer.get_next_page(
-            referral_customers=referral_customers, page_size=page_size
+            referral_customers=first_page, page_size=page_size
         )
 
-        first_id_of_first_page = referral_customers["referral_customers"][0].id
+        first_id_of_first_page = first_page["referral_customers"][0].id
         first_id_of_second_page = next_page["referral_customers"][0].id
 
         assert first_id_of_first_page != first_id_of_second_page
+
+        # Verify that the filters are being passed along for behind-the-scenes reference
+        assert first_page[_FILTERS_KEY] == next_page[_FILTERS_KEY]
     except Exception as e:
         if e.message != NO_MORE_PAGES_ERROR:
-            raise Exception(message=_TEST_FAILED_INTENTIONALLY_ERROR)
+            raise Exception(_TEST_FAILED_INTENTIONALLY_ERROR)
 
 
 # PyVCR is having troubles matching the body of the form-encoded data here, override the default

--- a/tests/test_refund.py
+++ b/tests/test_refund.py
@@ -1,7 +1,7 @@
 import pytest
 from easypost.constant import (
     _TEST_FAILED_INTENTIONALLY_ERROR,
-    NO_MORE_PAGES_ERROR,
+    NO_MORE_PAGES_ERROR, _FILTERS_KEY,
 )
 from easypost.models import Refund
 
@@ -36,16 +36,19 @@ def test_refund_all(page_size, test_client):
 @pytest.mark.vcr()
 def test_refund_get_next_page(page_size, test_client):
     try:
-        refunds = test_client.refund.all(page_size=page_size)
-        next_page = test_client.refund.get_next_page(refunds=refunds, page_size=page_size)
+        first_page = test_client.refund.all(page_size=page_size)
+        next_page = test_client.refund.get_next_page(refunds=first_page, page_size=page_size)
 
-        first_id_of_first_page = refunds["refunds"][0].id
+        first_id_of_first_page = first_page["refunds"][0].id
         first_id_of_second_page = next_page["refunds"][0].id
 
         assert first_id_of_first_page != first_id_of_second_page
+
+        # Verify that the filters are being passed along for behind-the-scenes reference
+        assert first_page[_FILTERS_KEY] == next_page[_FILTERS_KEY]
     except Exception as e:
         if e.message != NO_MORE_PAGES_ERROR:
-            raise Exception(message=_TEST_FAILED_INTENTIONALLY_ERROR)
+            raise Exception(_TEST_FAILED_INTENTIONALLY_ERROR)
 
 
 @pytest.mark.vcr()

--- a/tests/test_scan_form.py
+++ b/tests/test_scan_form.py
@@ -1,7 +1,7 @@
 import pytest
 from easypost.constant import (
     _TEST_FAILED_INTENTIONALLY_ERROR,
-    NO_MORE_PAGES_ERROR,
+    NO_MORE_PAGES_ERROR, _FILTERS_KEY,
 )
 from easypost.models import ScanForm
 
@@ -42,13 +42,16 @@ def test_scanform_all(page_size, test_client):
 @pytest.mark.vcr()
 def test_scanform_get_next_page(page_size, test_client):
     try:
-        scanforms = test_client.scan_form.all(page_size=page_size)
-        next_page = test_client.scan_form.get_next_page(scan_forms=scanforms, page_size=page_size)
+        first_page = test_client.scan_form.all(page_size=page_size)
+        next_page = test_client.scan_form.get_next_page(scan_forms=first_page, page_size=page_size)
 
-        first_id_of_first_page = scanforms["scan_forms"][0].id
+        first_id_of_first_page = first_page["scan_forms"][0].id
         first_id_of_second_page = next_page["scan_forms"][0].id
 
         assert first_id_of_first_page != first_id_of_second_page
+
+        # Verify that the filters are being passed along for behind-the-scenes reference
+        assert first_page[_FILTERS_KEY] == next_page[_FILTERS_KEY]
     except Exception as e:
         if e.message != NO_MORE_PAGES_ERROR:
-            raise Exception(message=_TEST_FAILED_INTENTIONALLY_ERROR)
+            raise Exception(_TEST_FAILED_INTENTIONALLY_ERROR)

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -1,7 +1,7 @@
 import pytest
 from easypost.constant import (
     _TEST_FAILED_INTENTIONALLY_ERROR,
-    NO_MORE_PAGES_ERROR,
+    NO_MORE_PAGES_ERROR, _FILTERS_KEY,
 )
 from easypost.errors import (
     FilteringError,
@@ -50,16 +50,19 @@ def test_shipment_all(page_size, test_client):
 @pytest.mark.vcr()
 def test_shipment_get_next_page(page_size, test_client):
     try:
-        shipments = test_client.shipment.all(page_size=page_size)
-        next_page = test_client.shipment.get_next_page(shipments=shipments, page_size=page_size)
+        first_page = test_client.shipment.all(page_size=page_size)
+        next_page = test_client.shipment.get_next_page(shipments=first_page, page_size=page_size)
 
-        first_id_of_first_page = shipments["shipments"][0].id
+        first_id_of_first_page = first_page["shipments"][0].id
         first_id_of_second_page = next_page["shipments"][0].id
 
         assert first_id_of_first_page != first_id_of_second_page
+
+        # Verify that the filters are being passed along for behind-the-scenes reference
+        assert first_page[_FILTERS_KEY] == next_page[_FILTERS_KEY]
     except Exception as e:
         if e.message != NO_MORE_PAGES_ERROR:
-            raise Exception(message=_TEST_FAILED_INTENTIONALLY_ERROR)
+            raise Exception(_TEST_FAILED_INTENTIONALLY_ERROR)
 
 
 @pytest.mark.vcr()

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,7 +1,7 @@
 import pytest
 from easypost.constant import (
     _TEST_FAILED_INTENTIONALLY_ERROR,
-    NO_MORE_PAGES_ERROR,
+    NO_MORE_PAGES_ERROR, _FILTERS_KEY,
 )
 from easypost.models import Tracker
 
@@ -40,16 +40,19 @@ def test_tracker_all(page_size, test_client):
 @pytest.mark.vcr()
 def test_tracker_get_next_page(page_size, test_client):
     try:
-        trackers = test_client.tracker.all(page_size=page_size)
-        next_page = test_client.tracker.get_next_page(trackers=trackers, page_size=page_size)
+        first_page = test_client.tracker.all(page_size=page_size)
+        next_page = test_client.tracker.get_next_page(trackers=first_page, page_size=page_size)
 
-        first_id_of_first_page = trackers["trackers"][0].id
+        first_id_of_first_page = first_page["trackers"][0].id
         first_id_of_second_page = next_page["trackers"][0].id
 
         assert first_id_of_first_page != first_id_of_second_page
+
+        # Verify that the filters are being passed along for behind-the-scenes reference
+        assert first_page[_FILTERS_KEY] == next_page[_FILTERS_KEY]
     except Exception as e:
         if e.message != NO_MORE_PAGES_ERROR:
-            raise Exception(message=_TEST_FAILED_INTENTIONALLY_ERROR)
+            raise Exception(_TEST_FAILED_INTENTIONALLY_ERROR)
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
- Redesign pagination for more explicit per-service implementation, support for filters, less fragile

# Description

As we've recently discovered, a bug in the implementation of the "get_next_page" functions in this library meant any specific filters used while getting pages for a given resource were not being preserved and carried forward (e.g. the type of report, a specific tracking code for trackers, "purchased" filter for shipments).

This PR redesigned the underlying implementation of the "get_next_page" functions to be more explicit and account for minor inconsistencies endpoint-to-endpoint by relying on a hidden "_filters" key that will carry necessary metadata about parameters and filters used for each "all" and "get_next_page" call for easy reference behind the scenes when retrieving the next page of a paginated collection. From an end-user perspective, this means they will not need to always pass in, e.g., the "purchased" filter for each page request of shipments, or the type of report for each page request of reports. Whatever filters were used to retrieve the first page of a paginated collection will be reused automatically behind-the-scenes when retrieving each subsequent page. ("page_size" is still on a per-page basis, and filters can be overridden with optional parameters if necessary). This more closely follows the design of pagination as implemented in the Java and .NET library, which were the original models for these functions.

This PR does not change the majority of the end-user experience or public function signatures. As demonstrated by the minor changes to the unit tests and the lack of need to re-record any cassettes, this implementation change does not alter the shape or workflow as it previously was.

The only "breaking changes" include:
- "get_next_page" for the Batch service now throws a `NotImplementedError`, as there is a known bug with batch pagination server-side, and this function should not have been available in the first place.
- "get_next_page" for the Order service now throws a `NotImplementedError`, as order pagination does not exist server-side, and this function should not have been available in the first place. There was not an "all" function for Orders in the first place, so it's unclear how an end-user would have been able to retrieve the first page to use with this function anyhow.

# Testing

- All pagination unit tests have had assertions added to verify the new "filters" are being passed forward as expected, and that the implementation changes do not alter the existing end-user experience
- Only the "referral customer get next page" cassette needed to be re-recorded, as new server-side data allowed for a second page and therefore a second HTTP request/response to be recorded.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
