### PR TITLE
chore: cleanup build deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,20 +11,19 @@ REQUIREMENTS = [
 DEV_REQUIREMENTS = [
     "bandit==1.7.5",
     "black==23.*",
-    "build==0.10.*",
+    "build==1.0.*",
     "urllib3==1.*",  # TODO: Pinned because vcrpy did a dumb and didn't pin urllib3
     "flake8==5.*",  # TODO: flake8 v6 requires Python 3.8.1+
     "isort==5.*",
-    "mypy==1.3.*",
-    "pdoc==13.*",
+    "mypy==1.7.*",
+    "pdoc==13.*",  # TODO: pdoc v14 requires Python 3.8+
     "pytest-cov==4.*",
     "pytest-vcr==1.*",
     "pytest==7.*",
     "twine==4.*",
     "types-requests",
     "types-urllib3",
-    "vcrpy==4.*",
-    "wheel==0.40.*",
+    "vcrpy==4.*",  # TODO: vcrpy v5 requires Python 3.8+
 ]
 
 with open("README.md", encoding="utf-8") as f:
@@ -69,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIREMENTS = [
 DEV_REQUIREMENTS = [
     "bandit==1.7.5",
     "black==23.*",
-    "build==1.0.*; python_version >= 3.8",  # TODO: remove python pin when 3.7 is dropped
+    "build==1.0.*;python_version>='3.8'",  # TODO: remove python pin when 3.7 is dropped
     "urllib3==1.*",  # TODO: Pinned because vcrpy did a dumb and didn't pin urllib3
     "flake8==5.*",  # TODO: flake8 v6 requires Python 3.8.1+
     "isort==5.*",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIREMENTS = [
 DEV_REQUIREMENTS = [
     "bandit==1.7.5",
     "black==23.*",
-    "build==1.0.*",
+    "build==1.0.*; python_version >= 3.8",  # TODO: remove python pin when 3.7 is dropped
     "urllib3==1.*",  # TODO: Pinned because vcrpy did a dumb and didn't pin urllib3
     "flake8==5.*",  # TODO: flake8 v6 requires Python 3.8.1+
     "isort==5.*",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DEV_REQUIREMENTS = [
     "urllib3==1.*",  # TODO: Pinned because vcrpy did a dumb and didn't pin urllib3
     "flake8==5.*",  # TODO: flake8 v6 requires Python 3.8.1+
     "isort==5.*",
-    "mypy==1.7.*",
+    "mypy==1.4.*",  # TODO: mypy v1.5 requires Python 3.8+
     "pdoc==13.*",  # TODO: pdoc v14 requires Python 3.8+
     "pytest-cov==4.*",
     "pytest-vcr==1.*",


### PR DESCRIPTION
# Description

When we swapped from building our own packages to using the `build` packages, we forgot to remove `wheel` which is no longer needed. Additionally, `build` just hit v1 so it's a good time to upgrade. No breaking changes affect us
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Ran `make build` and it worked as expected producing the stdist and wheel still
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
