### PR TITLE
move all_children functions to GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v7.15.0 Next release
+
+- Adds `all_children` function to the User class for retrieving paginated lists of children users, and deprecate the beta function
+- Adds `get_next_page_of_children` function to the User class for retrieving next paginated lists of children users, and deprecate the beta function
+
 ## v7.14.1 (2023-10-30)
 
 - Fixes a bug where `get_next_page` functions threw an error, preventing users from retrieving the final page of results

--- a/easypost/beta/user.py
+++ b/easypost/beta/user.py
@@ -4,6 +4,7 @@ from typing import (
     List,
     Optional,
 )
+from warnings import warn
 
 from easypost.easypost_object import convert_to_easypost_object
 from easypost.error import Error
@@ -17,6 +18,11 @@ from easypost.resource import Resource
 class User(Resource):
     @classmethod
     def all_children(cls, api_key: Optional[str] = None, **params) -> Dict[str, Any]:
+        warn(
+            "This function is deprecated, please use `all_children` function in `user` class for GA accessibility",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         """Retrieve a paginated list of children from the API."""
         requestor = Requestor(local_api_key=api_key)
         url = "/users/children"
@@ -30,6 +36,12 @@ class User(Resource):
         page_size: int,
         api_key: Optional[str] = None,
     ) -> List["User"]:
+        warn(
+            "This function is deprecated, please use `get_next_page_of_children` function in"
+            "`user` class for GA accessibility",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         """Get next page of children."""
         requestor = Requestor(local_api_key=api_key)
         url = "/users/children"

--- a/easypost/requestor.py
+++ b/easypost/requestor.py
@@ -42,7 +42,7 @@ class Requestor:
             return {"id": param.id}
         elif isinstance(param, dict):
             data = {}
-            for (k, v) in param.items():
+            for k, v in param.items():
                 if isinstance(v, list):
                     data[k] = [cls._objects_to_ids(item) for item in v]  # type: ignore
                 else:

--- a/easypost/user.py
+++ b/easypost/user.py
@@ -7,6 +7,7 @@ from typing import (
 
 from easypost.api_key import ApiKey
 from easypost.easypost_object import convert_to_easypost_object
+from easypost.error import Error
 from easypost.requestor import (
     RequestMethod,
     Requestor,
@@ -83,3 +84,38 @@ class User(UpdateResource, DeleteResource):
             method=RequestMethod.PATCH, url=self.instance_url() + "/brand", params=params
         )
         return convert_to_easypost_object(response=response, api_key=api_key)
+
+    @classmethod
+    def all_children(cls, api_key: Optional[str] = None, **params) -> Dict[str, Any]:
+        """Retrieve a paginated list of children from the API."""
+        requestor = Requestor(local_api_key=api_key)
+        url = "/users/children"
+        response, api_key = requestor.request(method=RequestMethod.GET, url=url, params=params)
+        return convert_to_easypost_object(response=response, api_key=api_key)
+
+    @classmethod
+    def get_next_page_of_children(
+        cls,
+        children: Dict[str, Any],
+        page_size: int,
+        api_key: Optional[str] = None,
+    ) -> List["User"]:
+        """Get next page of children."""
+        requestor = Requestor(local_api_key=api_key)
+        url = "/users/children"
+        children_array = children.get("children", [])
+
+        if len(children_array) == 0 or not children.get("has_more", False):
+            raise Error(message="There are no more pages to retrieve.")
+
+        params = {
+            "after_id": children_array[-1].id,
+            "page_size": page_size,
+        }
+
+        data, api_key = requestor.request(method=RequestMethod.GET, url=url, params=params)
+        next_children_array: List[Any] = data.get("children", [])
+        if len(next_children_array) == 0:
+            raise Error(message="There are no more pages to retrieve.")
+
+        return convert_to_easypost_object(response=data, api_key=api_key)

--- a/tests/cassettes/test_user_all_children.yaml
+++ b/tests/cassettes/test_user_all_children.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: GET
+    uri: https://api.easypost.com/v2/users/children?page_size=5
+  response:
+    body:
+      string: '{"children": [{"id": "user_484dd58db70a4f31b4bb862998cf0e04", "object":
+        "User", "parent_id": "user_0f6b83e3530b401cb1e8aeaa6a250d4d", "name": "Test
+        User", "phone_number": "<REDACTED>", "verified": true, "created_at": "2023-05-16T22:01:20Z"},
+        {"id": "user_14e894c0d541459395f4456e7cf4f175", "object": "User", "parent_id":
+        "user_0f6b83e3530b401cb1e8aeaa6a250d4d", "name": "Test User", "phone_number":
+        "<REDACTED>", "verified": true, "created_at": "2023-09-27T22:05:26Z"}, {"id":
+        "user_f04df3dad13848339a7975d295d6629f", "object": "User", "parent_id": "user_0f6b83e3530b401cb1e8aeaa6a250d4d",
+        "name": "Test User", "phone_number": "<REDACTED>", "verified": true, "created_at":
+        "2023-11-30T19:23:22Z"}], "has_more": false}'
+    headers:
+      cache-control:
+      - private, no-cache, no-store
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - ec7851e965970bd2e79a7e400013d8db
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb39nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq 2c48984abf
+      - extlb1nuq 003ad9bca0
+      x-runtime:
+      - '0.039816'
+      x-version-label:
+      - easypost-202401041812-437974c716-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_user_get_next_page.yaml
+++ b/tests/cassettes/test_user_get_next_page.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      authorization:
+      - <REDACTED>
+      user-agent:
+      - <REDACTED>
+    method: GET
+    uri: https://api.easypost.com/v2/users/children?page_size=5
+  response:
+    body:
+      string: '{"children": [{"id": "user_484dd58db70a4f31b4bb862998cf0e04", "object":
+        "User", "parent_id": "user_0f6b83e3530b401cb1e8aeaa6a250d4d", "name": "Test
+        User", "phone_number": "<REDACTED>", "verified": true, "created_at": "2023-05-16T22:01:20Z"},
+        {"id": "user_14e894c0d541459395f4456e7cf4f175", "object": "User", "parent_id":
+        "user_0f6b83e3530b401cb1e8aeaa6a250d4d", "name": "Test User", "phone_number":
+        "<REDACTED>", "verified": true, "created_at": "2023-09-27T22:05:26Z"}, {"id":
+        "user_f04df3dad13848339a7975d295d6629f", "object": "User", "parent_id": "user_0f6b83e3530b401cb1e8aeaa6a250d4d",
+        "name": "Test User", "phone_number": "<REDACTED>", "verified": true, "created_at":
+        "2023-11-30T19:23:22Z"}], "has_more": false}'
+    headers:
+      cache-control:
+      - private, no-cache, no-store
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      expires:
+      - '0'
+      pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-backend:
+      - easypost
+      x-canary:
+      - direct
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-ep-request-uuid:
+      - ec7851e765970bd2e79a7e410013d944
+      x-frame-options:
+      - SAMEORIGIN
+      x-node:
+      - bigweb32nuq
+      x-permitted-cross-domain-policies:
+      - none
+      x-proxied:
+      - intlb1nuq 2c48984abf
+      - extlb1nuq 003ad9bca0
+      x-runtime:
+      - '0.177179'
+      x-version-label:
+      - easypost-202401041812-437974c716-master
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -109,3 +109,30 @@ def test_user_update_brand(prod_api_key):
     assert isinstance(brand, easypost.Brand)
     assert str.startswith(brand.id, "brd_")
     assert brand.color == color
+
+
+@pytest.mark.vcr()
+def test_user_all_children(prod_api_key, page_size):
+    children_data = easypost.User.all_children(page_size=page_size)
+
+    children_array = children_data["children"]
+    assert len(children_array) <= page_size
+    assert all(isinstance(child, easypost.User) for child in children_array)
+
+    has_more = children_data["has_more"]
+    assert isinstance(has_more, bool)
+
+
+@pytest.mark.vcr()
+def test_user_get_next_page(prod_api_key, page_size):
+    try:
+        children = easypost.User.all_children(page_size=page_size)
+        next_page = easypost.User.get_next_page_of_children(children=children, page_size=page_size)
+
+        first_id_of_first_page = children["children"][0].id
+        first_id_of_second_page = next_page["children"][0].id
+
+        assert first_id_of_first_page != first_id_of_second_page
+    except easypost.Error as e:
+        if e.message != "There are no more pages to retrieve.":
+            raise easypost.Error(message="Test failed intentionally.")


### PR DESCRIPTION
# Description

- Adds `all_children` function to the User class for retrieving paginated lists of children users, and deprecate the beta function
- Adds `get_next_page_of_children` function to the User class for retrieving next paginated lists of children users, and deprecate the beta function
# Testing

Add unit tests for GA functions

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
