### PR TITLE
[POC] New utility script to find and replace version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,12 @@ mypy:
 publish:
 	$(VIRTUAL_BIN)/twine upload dist/*
 
+## prep-release - Updates the CHANGELOG and version files in preparation for a release (Unix only)
+# version = The version to release
+# date = The date to release
+prep-release:
+	sh ./scripts/prep_release.sh ${version} ${date}
+
 ## release - Cuts a release for the project on GitHub (requires GitHub CLI)
 # tag = The associated tag title of the release
 release:

--- a/scripts/prep_release.sh
+++ b/scripts/prep_release.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script is used to prepare a release of the project.
+# This scripts expects to use the GNU version of sed, not the BSD/MacOS version.
+# For MacOS via Homebrew: https://formulae.brew.sh/formula/gnu-sed
+
+NEW_VERSION=$1
+
+# Collect date from second argument if it exists, otherwise use today's date as %Y-%m-%d
+NEW_VERSION_DATE=$2
+if [ -z "$NEW_VERSION_DATE" ]; then
+    NEW_VERSION_DATE=$(date +%Y-%m-%d)
+fi
+
+if [ -z "$NEW_VERSION" ]; then
+    echo "Usage: $0 <new version>"
+    exit 1
+fi
+
+CHANGELOG_TEXT_TO_REPLACE="^## [n,N]ext [r,R]elease"
+NEW_CHANGELOG_TEXT="## v$NEW_VERSION ($NEW_VERSION_DATE)"
+
+# Update version in setup.py
+sed -i -r "s/version=\".*\",/version=\"$NEW_VERSION\",/" setup.py
+
+# Update version in easypost/constant.py
+# Use regex ^ to avoid overriding API_VERSION in the same file
+sed -i -r "s/^VERSION = \".*\"/VERSION = \"$NEW_VERSION\"/" easypost/constant.py
+
+# Update version in CHANGELOG.md
+sed -i -r "s/$CHANGELOG_TEXT_TO_REPLACE/$NEW_CHANGELOG_TEXT/" CHANGELOG.md


### PR DESCRIPTION
# Description

- A new utility script, called via `make prep-release version="x.x.x" date="xxxx-xx-xx"` that will find and update version numbers in:
  - `setup.py`
  - `easypost/constants.py`
  - `CHANGELOG.md`
- `version` required for script/make step, `date` optional (will use today's date if not provided)

# Testing

- Confirmed working via multiple manual tests

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
