### PR TITLE
Fix CI build

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths=tests


### PR DESCRIPTION
# Description

CI build is currently failing due to a doc generation tool introduced into our examples submodule a few months ago using pytest and has its own conftest.py file to execute, which causes build failing `_pytest.pathlib.ImportPathMismatchError:`

Add `pytest.ini` config file to tell pytest only look in the `tests` directory when running test suite.
# Testing

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
