### PR TITLE
[bug] Cannot determine payment method when funding/deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Fix payment method funding and deletion failures due to undetermined payment method type
 - Adds `refund` function in Insurance service for requesting a refund for a standalone insurance
 
 ## v9.1.0 (2024-01-08)

--- a/easypost/services/billing_service.py
+++ b/easypost/services/billing_service.py
@@ -67,9 +67,9 @@ class BillingService(BaseService):
         if payment_method_to_use and payment_methods[payment_method_to_use]:
             payment_method_id = payment_methods[payment_method_to_use]["id"]
             payment_method_object_type = payment_methods[payment_method_to_use].get("object", None)
-            if payment_method_id.startswith("card_") or payment_method_object_type == "CreditCard":
+            if payment_method_object_type == "CreditCard":
                 endpoint = "/credit_cards"
-            elif payment_method_id.startswith("bank_") or payment_method_object_type == "BankAccount":
+            elif payment_method_object_type == "BankAccount":
                 endpoint = "/bank_accounts"
             else:
                 raise InvalidObjectError(message=INVALID_PAYMENT_METHOD_ERROR)

--- a/easypost/services/billing_service.py
+++ b/easypost/services/billing_service.py
@@ -66,9 +66,10 @@ class BillingService(BaseService):
 
         if payment_method_to_use and payment_methods[payment_method_to_use]:
             payment_method_id = payment_methods[payment_method_to_use]["id"]
-            if payment_method_id.startswith("card_"):
+            payment_method_object_type = payment_methods[payment_method_to_use].get("object", None)
+            if payment_method_id.startswith("card_") or payment_method_object_type == "CreditCard":
                 endpoint = "/credit_cards"
-            elif payment_method_id.startswith("bank_"):
+            elif payment_method_id.startswith("bank_") or payment_method_object_type == "BankAccount":
                 endpoint = "/bank_accounts"
             else:
                 raise InvalidObjectError(message=INVALID_PAYMENT_METHOD_ERROR)

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,8 +1,7 @@
 from unittest.mock import patch
 
-import pytest
-
 import easypost
+import pytest
 from easypost.errors import InvalidObjectError
 
 
@@ -90,8 +89,10 @@ def test_billing_retrieve_payment_methods_no_billing_setup(mock_request, prod_cl
 
 @patch(
     "easypost.services.billing_service.BillingService.retrieve_payment_methods",
-    return_value={"primary_payment_method": {"id": "pm_123", "object": "CreditCard"},
-                  "secondary_payment_method": {"id": "pm_456", "object": "BankAccount"}},
+    return_value={
+        "primary_payment_method": {"id": "pm_123", "object": "CreditCard"},
+        "secondary_payment_method": {"id": "pm_456", "object": "BankAccount"},
+    },
 )
 def test_billing__get_payment_method_info_by_object_type(mock_request, prod_client):
     """Tests we can determine the payment method type/endpoint by object type."""
@@ -108,8 +109,10 @@ def test_billing__get_payment_method_info_by_object_type(mock_request, prod_clie
 
 @patch(
     "easypost.services.billing_service.BillingService.retrieve_payment_methods",
-    return_value={"primary_payment_method": {"id": "card_123", "object": None},
-                  "secondary_payment_method": {"id": "bank_123", "object": None}},
+    return_value={
+        "primary_payment_method": {"id": "card_123", "object": None},
+        "secondary_payment_method": {"id": "bank_123", "object": None},
+    },
 )
 def test_billing__get_payment_method_info_by_legacy_id_prefix(mock_request, prod_client):
     """Tests we can determine the payment method type/endpoint by legacy ID prefix."""

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,7 +1,8 @@
 from unittest.mock import patch
 
-import easypost
 import pytest
+
+import easypost
 from easypost.errors import InvalidObjectError
 
 
@@ -24,26 +25,26 @@ def test_billing_fund_wallet(mock_request, mock_get_payment_info, prod_client):
 
 @patch(
     "easypost.services.billing_service.BillingService.retrieve_payment_methods",
-    return_value={"primary_payment_method": {"id": "card_123"}},
+    return_value={"primary_payment_method": {"id": "pm_123", "object": "CreditCard"}},
 )
 @patch("easypost.services.billing_service.Requestor.request", return_value={"mock": "response"})
 def test_billing_payment_method_delete_credit_card(mock_request, mock_payment_methods, prod_client):
     """Tests we make a valid call to delete a credit card."""
     prod_client.billing.delete_payment_method(priority="primary")
 
-    mock_request.assert_called_once_with(method=easypost.requestor.RequestMethod.DELETE, url="/credit_cards/card_123")
+    mock_request.assert_called_once_with(method=easypost.requestor.RequestMethod.DELETE, url="/credit_cards/pm_123")
 
 
 @patch(
     "easypost.services.billing_service.BillingService.retrieve_payment_methods",
-    return_value={"primary_payment_method": {"id": "bank_123"}},
+    return_value={"primary_payment_method": {"id": "pm_123", "object": "BankAccount"}},
 )
 @patch("easypost.services.billing_service.Requestor.request", return_value={"mock": "response"})
 def test_billing_payment_method_delete_bank_account(mock_request, mock_payment_methods, prod_client):
     """Tests we make a valid call to delete a bank account."""
     prod_client.billing.delete_payment_method(priority="primary")
 
-    mock_request.assert_called_once_with(method=easypost.requestor.RequestMethod.DELETE, url="/bank_accounts/bank_123")
+    mock_request.assert_called_once_with(method=easypost.requestor.RequestMethod.DELETE, url="/bank_accounts/pm_123")
 
 
 @patch(
@@ -85,3 +86,39 @@ def test_billing_retrieve_payment_methods_no_billing_setup(mock_request, prod_cl
 
     mock_request.assert_called_once()
     assert str(error.value) == "Billing has not been setup for this user. Please add a payment method."
+
+
+@patch(
+    "easypost.services.billing_service.BillingService.retrieve_payment_methods",
+    return_value={"primary_payment_method": {"id": "pm_123", "object": "CreditCard"},
+                  "secondary_payment_method": {"id": "pm_456", "object": "BankAccount"}},
+)
+def test_billing__get_payment_method_info_by_object_type(mock_request, prod_client):
+    """Tests we can determine the payment method type/endpoint by object type."""
+    endpoint, payment_method_id = prod_client.billing._get_payment_method_info(priority="primary")
+
+    assert endpoint == "/credit_cards"
+    assert payment_method_id == "pm_123"
+
+    endpoint, payment_method_id = prod_client.billing._get_payment_method_info(priority="secondary")
+
+    assert endpoint == "/bank_accounts"
+    assert payment_method_id == "pm_456"
+
+
+@patch(
+    "easypost.services.billing_service.BillingService.retrieve_payment_methods",
+    return_value={"primary_payment_method": {"id": "card_123", "object": None},
+                  "secondary_payment_method": {"id": "bank_123", "object": None}},
+)
+def test_billing__get_payment_method_info_by_legacy_id_prefix(mock_request, prod_client):
+    """Tests we can determine the payment method type/endpoint by legacy ID prefix."""
+    endpoint, payment_method_id = prod_client.billing._get_payment_method_info(priority="primary")
+
+    assert endpoint == "/credit_cards"
+    assert payment_method_id == "card_123"
+
+    endpoint, payment_method_id = prod_client.billing._get_payment_method_info(priority="secondary")
+
+    assert endpoint == "/bank_accounts"
+    assert payment_method_id == "bank_123"

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -105,23 +105,3 @@ def test_billing__get_payment_method_info_by_object_type(mock_request, prod_clie
 
     assert endpoint == "/bank_accounts"
     assert payment_method_id == "pm_456"
-
-
-@patch(
-    "easypost.services.billing_service.BillingService.retrieve_payment_methods",
-    return_value={
-        "primary_payment_method": {"id": "card_123", "object": None},
-        "secondary_payment_method": {"id": "bank_123", "object": None},
-    },
-)
-def test_billing__get_payment_method_info_by_legacy_id_prefix(mock_request, prod_client):
-    """Tests we can determine the payment method type/endpoint by legacy ID prefix."""
-    endpoint, payment_method_id = prod_client.billing._get_payment_method_info(priority="primary")
-
-    assert endpoint == "/credit_cards"
-    assert payment_method_id == "card_123"
-
-    endpoint, payment_method_id = prod_client.billing._get_payment_method_info(priority="secondary")
-
-    assert endpoint == "/bank_accounts"
-    assert payment_method_id == "bank_123"


### PR DESCRIPTION
# Description

- Use payment method object type as fallback when determining type for fund, delete functions

# Testing

- Update, add unit test to confirm legacy (by ID prefix) and new (by object type) both work to determine payment method type

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
