### PR TITLE
Change desired_delivery_date to str instead of key-word args

### DIFF
--- a/easypost/services/shipment_service.py
+++ b/easypost/services/shipment_service.py
@@ -154,12 +154,12 @@ class ShipmentService(BaseService):
 
         return convert_to_easypost_object(response=response.get("rates", []))
 
-    def recommend_ship_date(self, id: str, **params) -> List[Dict[str, Any]]:
+    def recommend_ship_date(self, id: str, desired_delivery_date: str) -> List[Dict[str, Any]]:
         """Retrieve a recommended ship date for an existing Shipment via the Precision Shipping API,
         based on a specific desired delivery date.
         """
         url = f"{self._instance_url(self._model_class, id)}/smartrate/precision_shipping"
-
+        params = {"desired_delivery_date": desired_delivery_date}
         response = Requestor(self._client).request(method=RequestMethod.GET, url=url, params=params)
 
         return convert_to_easypost_object(response=response.get("rates", []))


### PR DESCRIPTION
# Description

Change desired_delivery_date to str instead of key-word args in Shipment.recommend_ship_date function
# Testing

We should expect users to input a string and not a dict for the Shipment.recommend_ship_date function, this matches `retrieve_estimated_delivery_date` function

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
