### PR TITLE
Replace extractions/setup-just with EasyPost/ep-actions setup/just action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
@@ -28,7 +28,7 @@ jobs:
         pythonversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## What

Replaces the unverified third-party action `extractions/setup-just` with the internal composite action [`EasyPost/ep-actions/.github/actions/setup/just@main`](https://github.com/EasyPost/ep-actions/tree/main/.github/actions/setup/just).

## Why

`extractions/setup-just` is a third-party action from an unverified publisher and is **not** on the approved list in `EasyPost/ep-actions/ApprovedThirdPartyActions.yaml`. Using the internal composite action keeps CI on a vetted, EasyPost-owned action.

## Notes

- The ep-actions `setup/just` action installs Just on Linux runners; all affected jobs in this repo run on `ubuntu-latest`.
- The `just-version` input is supported by the ep-actions action where it was previously set.