### PR TITLE
feat: add params to requestPin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v10.7.0 (2026-06-25)
+
+- Adds `params` to `request_pin` ensuring users can pass `easypost_details` to the call.
+
 ## v10.6.0 (2026-02-25)
 
 - Adds generic `make_api_call` function

--- a/easypost/constant.py
+++ b/easypost/constant.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 # Library version
-VERSION = "10.6.0"
+VERSION = "10.7.0"
 VERSION_INFO = [str(number) for number in VERSION.split(".")]
 
 # Client defaults

--- a/easypost/services/fedex_registration_service.py
+++ b/easypost/services/fedex_registration_service.py
@@ -19,9 +19,10 @@ class FedExRegistrationService(BaseService):
 
         return convert_to_easypost_object(response=response)
 
-    def request_pin(self, fedex_account_number: str, pin_method_option: str) -> dict[str, Any]:
+    def request_pin(self, fedex_account_number: str, pin_method_option: str, **params) -> dict[str, Any]:
         """Request a PIN for FedEx account verification."""
-        wrapped_params = {"pin_method": {"option": pin_method_option}}
+        wrapped_params = self._wrap_pin_validation(params)
+        wrapped_params["pin_method"] = {"option": pin_method_option}
         url = f"/fedex_registrations/{fedex_account_number}/pin"
 
         response = Requestor(self._client).request(method=RequestMethod.POST, url=url, params=wrapped_params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "easypost"
 description = "EasyPost Shipping API Client Library for Python"
-version = "10.6.0"
+version = "10.7.0"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { file = "LICENSE" }

--- a/tests/test_fedex_registration.py
+++ b/tests/test_fedex_registration.py
@@ -44,6 +44,10 @@ def test_register_address(prod_client, monkeypatch):
 def test_request_pin(prod_client, monkeypatch):
     """Tests requesting a pin."""
     fedex_account_number = "123456789"
+    easypost_details = {"carrier_account_id": "ca_123"}
+    params = {
+        "easypost_details": easypost_details,
+    }
 
     json_response = {"message": "sent secured Pin"}
 
@@ -52,7 +56,7 @@ def test_request_pin(prod_client, monkeypatch):
 
     monkeypatch.setattr("easypost.services.fedex_registration_service.Requestor", mock_requestor)
 
-    response = prod_client.fedex_registration.request_pin(fedex_account_number, "SMS")
+    response = prod_client.fedex_registration.request_pin(fedex_account_number, "SMS", **params)
     assert isinstance(response, EasyPostObject)
     assert response.message == "sent secured Pin"
 

--- a/tests/test_fedex_registration.py
+++ b/tests/test_fedex_registration.py
@@ -44,9 +44,8 @@ def test_register_address(prod_client, monkeypatch):
 def test_request_pin(prod_client, monkeypatch):
     """Tests requesting a pin."""
     fedex_account_number = "123456789"
-    easypost_details = {"carrier_account_id": "ca_123"}
     params = {
-        "easypost_details": easypost_details,
+        "easypost_details": {"carrier_account_id": "ca_123"},
     }
 
     json_response = {"message": "sent secured Pin"}


### PR DESCRIPTION
# Description

Adds `params` to `request_pin` ensuring users can pass `easypost_details` to the call.

# Testing

Updated test to accept new param.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)