### PR TITLE
Pin codecov/codecov-action to v7.0.0 SHA (GHO-261)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 just coverage
       - name: Coverage
         if: github.ref == 'refs/heads/master'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Run security analysis


### PR DESCRIPTION
Pins `codecov/codecov-action` from the floating `@v5` tag to **v7.0.0** at commit `fb8b3582c8e4def4969c97caa2f19720cb33a72f`, per the security review in GHO-261.

The v5 line never received the VULN-1652 template-injection hardening (fixed upstream in v6.0.1); v7.0.0 is the reviewed remediation target, and pinning to a full commit SHA removes the mutable-tag risk. Canary verified green in EasyPost/shentry#23.

Ref: GHO-261